### PR TITLE
Update Starlark to Bazel Master #543f6e6

### DIFF
--- a/bin/update-starlark.py
+++ b/bin/update-starlark.py
@@ -119,6 +119,9 @@ for _submodule_dir in get_submodules(os.getcwd()):
     add_submodule(bazel_repo, submodule_dir)
     update_submodules(submodule_dir)
 
+    with cd(_submodule_dir) as cwd:
+        subprocess.check_call(["git", "pull"])
+
 
 # if os.path.exists('bazel') and os.path.exists('.tmp/bazel/.git'):
 #     cmds = (

--- a/larky/src/main/java/com/verygood/security/larky/parser/LarkyScript.java
+++ b/larky/src/main/java/com/verygood/security/larky/parser/LarkyScript.java
@@ -179,7 +179,7 @@ public class LarkyScript {
       // This should not happen since we shouldn't have anything interruptable during loading.
       throw new RuntimeException("Internal error", e);
     }
-    return new ParsedStarFile(content.path(), module.getTransitiveBindings(), module);
+    return new ParsedStarFile(content.path(), module.getPredeclaredBindings(), module);
   }
 
   private static class StarFilesSupplier

--- a/larky/src/main/java/com/verygood/security/larky/parser/LarkyScript.java
+++ b/larky/src/main/java/com/verygood/security/larky/parser/LarkyScript.java
@@ -179,7 +179,13 @@ public class LarkyScript {
       // This should not happen since we shouldn't have anything interruptable during loading.
       throw new RuntimeException("Internal error", e);
     }
-    return new ParsedStarFile(content.path(), module.getPredeclaredBindings(), module);
+    return new ParsedStarFile(
+        content.path(),
+        ImmutableMap.<String, Object>builder()
+        .putAll(module.getPredeclaredBindings())
+        .putAll(module.getGlobals())
+        .build(),
+        module);
   }
 
   private static class StarFilesSupplier

--- a/larky/src/main/java/com/verygood/security/larky/parser/ParsedStarFile.java
+++ b/larky/src/main/java/com/verygood/security/larky/parser/ParsedStarFile.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableMap;
 import net.starlark.java.eval.Module;
 
 import java.util.Map;
+import javax.annotation.Nullable;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -59,7 +60,18 @@ public final class ParsedStarFile {
   /**
    * Reads values from the global frame of the skylark environment, i.e. global variables.
    */
+  @Nullable
   public <T> T getGlobalEnvironmentVariable(String name, Class<T> clazz) {
-    return clazz.cast(globals.get(name));
+    if (module.getGlobals().containsKey(name)) {
+      return clazz.cast(module.getGlobal(name));
+    }
+    if(module.getPredeclaredBindings().containsKey(name)) {
+      return clazz.cast(module.getPredeclaredBindings().get(name));
+    }
+    if (globals.containsKey(name)) {
+      return clazz.cast(globals.get(name));
+    }
+    return null;
   }
+
 }

--- a/larky/src/test/java/com/verygood/security/larky/jsr223/LarkyScriptEngineFactoryTest.java
+++ b/larky/src/test/java/com/verygood/security/larky/jsr223/LarkyScriptEngineFactoryTest.java
@@ -43,7 +43,7 @@ public class LarkyScriptEngineFactoryTest {
   public void getNames() {
     Assert.assertEquals(
         factory.getNames(),
-        Arrays.asList("Starlarky", "Larky", "starlarky", "larky", "vgs-larky"));
+        Arrays.asList("Starlarky", "Larky", "starlarky", "larky"));
   }
 
   @Test

--- a/libstarlark/src/main/java/net/starlark/java/annot/processor/StarlarkMethodProcessor.java
+++ b/libstarlark/src/main/java/net/starlark/java/annot/processor/StarlarkMethodProcessor.java
@@ -20,6 +20,7 @@ import com.google.errorprone.annotations.FormatMethod;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import javax.annotation.Nullable;
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.Messager;
 import javax.annotation.processing.ProcessingEnvironment;
@@ -157,6 +158,10 @@ public class StarlarkMethodProcessor extends AbstractProcessor {
                   + " may be specified.");
         }
         hasFlag = true;
+      }
+
+      if (annot.allowReturnNones() != (method.getAnnotation(Nullable.class) != null)) {
+        errorf(method, "Method must be annotated with @Nullable iff allowReturnNones is set.");
       }
 
       checkParameters(method, annot);

--- a/libstarlark/src/main/java/net/starlark/java/eval/Dict.java
+++ b/libstarlark/src/main/java/net/starlark/java/eval/Dict.java
@@ -180,7 +180,6 @@ public final class Dict<K, V>
             named = true,
             doc = "The default value to use (instead of None) if the key is not found.")
       },
-      allowReturnNones = true,
       useStarlarkThread = true)
   // TODO(adonovan): This method is named get2 as a temporary workaround for a bug in
   // StarlarkAnnotations.getStarlarkMethod. The two 'get' methods cause it to get

--- a/libstarlark/src/main/java/net/starlark/java/eval/Eval.java
+++ b/libstarlark/src/main/java/net/starlark/java/eval/Eval.java
@@ -16,12 +16,7 @@ package net.starlark.java.eval;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
-import java.math.BigInteger;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+
 import net.starlark.java.spelling.SpellChecker;
 import net.starlark.java.syntax.Argument;
 import net.starlark.java.syntax.AssignmentStatement;
@@ -51,6 +46,13 @@ import net.starlark.java.syntax.Statement;
 import net.starlark.java.syntax.StringLiteral;
 import net.starlark.java.syntax.TokenKind;
 import net.starlark.java.syntax.UnaryOperatorExpression;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 final class Eval {
 
@@ -90,9 +92,8 @@ final class Eval {
         if (stmt instanceof AssignmentStatement) {
           AssignmentStatement assign = (AssignmentStatement) stmt;
           for (Identifier id : Identifier.boundIdentifiers(assign.getLHS())) {
-            String name = id.getName();
-            Object value = fn(fr).getModule().getGlobal(name);
-            fr.thread.postAssignHook.assign(name, value);
+            Object value = fn(fr).getGlobal(id.getBinding().getIndex());
+            fr.thread.postAssignHook.assign(id.getName(), value);
           }
         }
       }
@@ -176,10 +177,13 @@ final class Eval {
       defaults = EMPTY;
     }
 
+    // Nested functions use the same globalIndex as their enclosing function,
+    // since both were compiled from the same Program.
+    StarlarkFunction fn = fn(fr);
     assignIdentifier(
         fr,
         node.getIdentifier(),
-        new StarlarkFunction(rfn, Tuple.wrap(defaults), fn(fr).getModule()));
+        new StarlarkFunction(rfn, Tuple.wrap(defaults), fn.getModule(), fn.globalIndex));
   }
 
   private static TokenKind execIf(StarlarkThread.Frame fr, IfStatement node)
@@ -231,7 +235,7 @@ final class Eval {
       // simply assign(binding.getLocalName(), value).
       // Currently, we update the module but not module.exportedGlobals;
       // changing it to fr.locals.put breaks a test. TODO(adonovan): find out why.
-      fn(fr).getModule().setGlobal(binding.getLocalName().getName(), value);
+      fn(fr).setGlobal(binding.getLocalName().getBinding().getIndex(), value);
     }
   }
 
@@ -330,11 +334,8 @@ final class Eval {
         // Updates a module binding and sets its 'exported' flag.
         // (Only load bindings are not exported.
         // But exportedGlobals does at run time what should be done in the resolver.)
-        // TODO(adonovan): use a flat array for Module.globals too.
-        Module module = fn(fr).getModule();
-        String name = id.getName();
-        module.setGlobal(name, value);
-        module.exportedGlobals.add(name);
+        fn(fr).setGlobal(bind.getIndex(), value);
+        fn(fr).getModule().exportedGlobals.add(id.getName());
         break;
       default:
         throw new IllegalStateException(bind.getScope().toString());
@@ -639,20 +640,13 @@ final class Eval {
         result = fr.locals[bind.getIndex()];
         break;
       case GLOBAL:
-        result = fn(fr).getModule().getGlobal(id.getName());
+        result = fn(fr).getGlobal(bind.getIndex());
         break;
       case PREDECLARED:
-        // TODO(adonovan): don't call getGlobal. This requires the Resolver to distinguish
-        // "predeclared" vars from "already defined module globals" instead of lumping them
-        // together via getNames. The latter odd category exists in the REPL, and
-        // in EvaluationTestCase, which calls Starlark.execFile repeatedly on the same Module.
-        // The REPL could just create a new module for each chunk, whose predeclared vars
-        // are the previous module's globals, but things may be trickier in EvaluationTestCase.
-        Module module = fn(fr).getModule();
-        result = module.getGlobal(id.getName());
-        if (result == null) {
-          result = module.getPredeclared(id.getName());
-        }
+        result = fn(fr).getModule().getPredeclared(id.getName());
+        break;
+      case UNIVERSAL:
+        result = Starlark.UNIVERSE.get(id.getName());
         break;
       default:
         throw new IllegalStateException(bind.toString());

--- a/libstarlark/src/main/java/net/starlark/java/eval/Eval.java
+++ b/libstarlark/src/main/java/net/starlark/java/eval/Eval.java
@@ -16,7 +16,12 @@ package net.starlark.java.eval;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
-
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import net.starlark.java.spelling.SpellChecker;
 import net.starlark.java.syntax.Argument;
 import net.starlark.java.syntax.AssignmentStatement;
@@ -46,13 +51,6 @@ import net.starlark.java.syntax.Statement;
 import net.starlark.java.syntax.StringLiteral;
 import net.starlark.java.syntax.TokenKind;
 import net.starlark.java.syntax.UnaryOperatorExpression;
-
-import java.math.BigInteger;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
 
 final class Eval {
 

--- a/libstarlark/src/main/java/net/starlark/java/eval/Eval.java
+++ b/libstarlark/src/main/java/net/starlark/java/eval/Eval.java
@@ -322,38 +322,22 @@ final class Eval {
   private static void assignIdentifier(StarlarkThread.Frame fr, Identifier id, Object value)
       throws EvalException {
     Resolver.Binding bind = id.getBinding();
-    // Legacy hack for incomplete identifier resolution.
-    // In a <toplevel> function, assignments to unresolved identifiers
-    // update the module, except for load statements and comprehensions,
-    // which should both be file-local.
-    // Load statements don't yet use assignIdentifier,
-    // so we need consider only comprehensions.
-    // In effect, we do the missing resolution using fr.compcount.
-    Resolver.Scope scope;
-    if (bind == null) {
-      scope =
-          fn(fr).isToplevel() && fr.compcount == 0
-              ? Resolver.Scope.GLOBAL //
-              : Resolver.Scope.LOCAL;
-    } else {
-      scope = bind.getScope();
-    }
-
-    String name = id.getName();
-    switch (scope) {
+    switch (bind.getScope()) {
       case LOCAL:
-        fr.locals.put(name, value);
+        fr.locals[bind.getIndex()] = value;
         break;
       case GLOBAL:
         // Updates a module binding and sets its 'exported' flag.
         // (Only load bindings are not exported.
         // But exportedGlobals does at run time what should be done in the resolver.)
+        // TODO(adonovan): use a flat array for Module.globals too.
         Module module = fn(fr).getModule();
+        String name = id.getName();
         module.setGlobal(name, value);
         module.exportedGlobals.add(name);
         break;
       default:
-        throw new IllegalStateException(scope.toString());
+        throw new IllegalStateException(bind.getScope().toString());
     }
   }
 
@@ -648,52 +632,35 @@ final class Eval {
 
   private static Object evalIdentifier(StarlarkThread.Frame fr, Identifier id)
       throws EvalException, InterruptedException {
-    String name = id.getName();
     Resolver.Binding bind = id.getBinding();
-    if (bind == null) {
-      // Legacy behavior, to be removed.
-      Object result = fr.locals.get(name);
-      if (result != null) {
-        return result;
-      }
-      result = fn(fr).getModule().get(name);
-      if (result != null) {
-        return result;
-      }
-
-      // Assuming resolution was successfully applied before execution
-      // (which is not yet true for copybara, but will be soon),
-      // then the identifier must have been resolved but the
-      // resolution was not annotated onto the syntax tree---because
-      // it's a BUILD file that may share trees with the prelude.
-      // So this error does not mean "undefined variable" (morally a
-      // static error), but "variable was (dynamically) referenced
-      // before being bound", as in 'print(x); x=1'.
-      fr.setErrorLocation(id.getStartLocation());
-      throw Starlark.errorf("variable '%s' is referenced before assignment", name);
-    }
-
     Object result;
     switch (bind.getScope()) {
       case LOCAL:
-        result = fr.locals.get(name);
+        result = fr.locals[bind.getIndex()];
         break;
       case GLOBAL:
-        result = fn(fr).getModule().getGlobal(name);
+        result = fn(fr).getModule().getGlobal(id.getName());
         break;
       case PREDECLARED:
-        // TODO(adonovan): call getPredeclared
-        result = fn(fr).getModule().get(name);
+        // TODO(adonovan): don't call getGlobal. This requires the Resolver to distinguish
+        // "predeclared" vars from "already defined module globals" instead of lumping them
+        // together via getNames. The latter odd category exists in the REPL, and
+        // in EvaluationTestCase, which calls Starlark.execFile repeatedly on the same Module.
+        // The REPL could just create a new module for each chunk, whose predeclared vars
+        // are the previous module's globals, but things may be trickier in EvaluationTestCase.
+        Module module = fn(fr).getModule();
+        result = module.getGlobal(id.getName());
+        if (result == null) {
+          result = module.getPredeclared(id.getName());
+        }
         break;
       default:
         throw new IllegalStateException(bind.toString());
     }
     if (result == null) {
-      // Since Scope was set, we know that the local/global variable is defined,
-      // but its assignment was not yet executed.
       fr.setErrorLocation(id.getStartLocation());
       throw Starlark.errorf(
-          "%s variable '%s' is referenced before assignment.", bind.getScope(), name);
+          "%s variable '%s' is referenced before assignment.", bind.getScope(), id.getName());
     }
     return result;
   }
@@ -751,23 +718,6 @@ final class Eval {
     final StarlarkList<Object> list =
         comp.isDict() ? null : StarlarkList.of(fr.thread.mutability());
 
-    // Save previous value (if any) of local variables bound in a 'for' clause
-    // so we can restore them later.
-    // TODO(adonovan): throw all this away when we implement flat environments.
-    List<Object> saved = new ArrayList<>(); // alternating keys and values
-    for (Comprehension.Clause clause : comp.getClauses()) {
-      if (clause instanceof Comprehension.For) {
-        for (Identifier ident :
-            Identifier.boundIdentifiers(((Comprehension.For) clause).getVars())) {
-          String name = ident.getName();
-          Object value = fr.locals.get(ident.getName()); // may be null
-          saved.add(name);
-          saved.add(value);
-        }
-      }
-    }
-    fr.compcount++;
-
     // The Lambda class serves as a recursive lambda closure.
     class Lambda {
       // execClauses(index) recursively executes the clauses starting at index,
@@ -823,19 +773,6 @@ final class Eval {
       }
     }
     new Lambda().execClauses(0);
-    fr.compcount--;
-
-    // Restore outer scope variables.
-    // This loop implicitly undefines comprehension variables.
-    for (int i = 0; i != saved.size(); ) {
-      String name = (String) saved.get(i++);
-      Object value = saved.get(i++);
-      if (value != null) {
-        fr.locals.put(name, value);
-      } else {
-        fr.locals.remove(name);
-      }
-    }
 
     return comp.isDict() ? dict : list;
   }

--- a/libstarlark/src/main/java/net/starlark/java/eval/EvalUtils.java
+++ b/libstarlark/src/main/java/net/starlark/java/eval/EvalUtils.java
@@ -443,7 +443,7 @@ final class EvalUtils {
       String string = (String) object;
       int index = Starlark.toInt(key, "string index");
       index = getSequenceIndex(index, string.length());
-      return string.substring(index, index + 1);
+      return StringModule.memoizedCharToString(string.charAt(index));
     } else {
       throw Starlark.errorf(
           "type '%s' has no operator [](%s)", Starlark.type(object), Starlark.type(key));

--- a/libstarlark/src/main/java/net/starlark/java/eval/Module.java
+++ b/libstarlark/src/main/java/net/starlark/java/eval/Module.java
@@ -16,9 +16,10 @@ package net.starlark.java.eval;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -51,11 +52,13 @@ public final class Module implements Resolver.Module {
   // The module's predeclared environment. Excludes UNIVERSE bindings.
   private ImmutableMap<String, Object> predeclared;
 
-  // The module's global bindings, in order of creation.
-  private final LinkedHashMap<String, Object> globals = new LinkedHashMap<>();
+  // The module's global variables, in order of creation.
+  private final LinkedHashMap<String, Integer> globalIndex = new LinkedHashMap<>();
+  private Object[] globals = new Object[8];
 
   // Names of globals that are exported and can be loaded from other modules.
-  // TODO(adonovan): eliminate this field when the resolver does its job properly.
+  // TODO(adonovan): eliminate this field when the resolver treats loads as local bindings.
+  // Then all globals are exported.
   final HashSet<String> exportedGlobals = new HashSet<>();
 
   // An optional piece of metadata associated with the module/file.
@@ -138,13 +141,9 @@ public final class Module implements Resolver.Module {
     return clientData;
   }
 
-  /** Returns the value of a predeclared (or universal) binding in this module. */
+  /** Returns the value of a predeclared (not universal) binding in this module. */
   Object getPredeclared(String name) {
-    Object v = predeclared.get(name);
-    if (v != null) {
-      return v;
-    }
-    return Starlark.UNIVERSE.get(name);
+    return predeclared.get(name);
   }
 
   /**
@@ -158,13 +157,21 @@ public final class Module implements Resolver.Module {
   }
 
   /**
-   * Returns a read-only view of this module's global bindings.
+   * Returns an immutable mapping containing the global variables of this module.
    *
    * <p>The bindings are returned in a deterministic order (for a given sequence of initial values
    * and updates).
    */
-  public Map<String, Object> getGlobals() {
-    return Collections.unmodifiableMap(globals);
+  public ImmutableMap<String, Object> getGlobals() {
+    int n = globalIndex.size();
+    ImmutableMap.Builder<String, Object> m = ImmutableMap.builderWithExpectedSize(n);
+    for (Map.Entry<String, Integer> e : globalIndex.entrySet()) {
+      Object v = getGlobalByIndex(e.getValue());
+      if (v != null) {
+        m.put(e.getKey(), v);
+      }
+    }
+    return m.build();
   }
 
   /**
@@ -176,7 +183,7 @@ public final class Module implements Resolver.Module {
   //  once loads bind locally (then all globals will be exported).
   public ImmutableMap<String, Object> getExportedGlobals() {
     ImmutableMap.Builder<String, Object> result = new ImmutableMap.Builder<>();
-    for (Map.Entry<String, Object> entry : globals.entrySet()) {
+    for (Map.Entry<String, Object> entry : getGlobals().entrySet()) {
       if (exportedGlobals.contains(entry.getKey())) {
         result.put(entry);
       }
@@ -186,30 +193,33 @@ public final class Module implements Resolver.Module {
 
   /** Implements the resolver's module interface. */
   @Override
-  public Set<String> getNames() {
-    // TODO(adonovan): for now, the resolver treats all predeclared/universe
-    //  and global names as one bucket (Scope.PREDECLARED). Fix that.
-    // TODO(adonovan): opt: change the resolver to request names on
-    //  demand to avoid all this set copying.
-    HashSet<String> names = new HashSet<>();
-    names.addAll(Starlark.UNIVERSE.keySet());
-    for (Map.Entry<String, Object> bind : getPredeclaredBindings().entrySet()) {
-      if (bind.getValue() instanceof FlagGuardedValue) {
-        continue; // disabled
-      }
-      names.add(bind.getKey());
+  public Resolver.Scope resolve(String name) throws Undefined {
+    // global?
+    if (globalIndex.containsKey(name)) {
+      return Resolver.Scope.GLOBAL;
     }
-    names.addAll(globals.keySet());
-    return names;
-  }
 
-  @Override
-  @Nullable
-  public String getUndeclaredNameError(String name) {
-    Object v = getPredeclared(name);
-    return v instanceof FlagGuardedValue
-        ? ((FlagGuardedValue) v).getErrorFromAttemptingAccess(name)
-        : null;
+    // predeclared?
+    Object v = predeclared.get(name);
+    if (v != null) {
+      if (v instanceof FlagGuardedValue) {
+        // Name is correctly spelled, but access is disabled by a flag.
+        throw new Undefined(((FlagGuardedValue) v).getErrorFromAttemptingAccess(name), null);
+      }
+      return Resolver.Scope.PREDECLARED;
+    }
+
+    // universal?
+    if (Starlark.UNIVERSE.containsKey(name)) {
+      return Resolver.Scope.UNIVERSAL;
+    }
+
+    // undefined
+    Set<String> candidates = new HashSet<>();
+    candidates.addAll(globalIndex.keySet());
+    candidates.addAll(predeclared.keySet());
+    candidates.addAll(Starlark.UNIVERSE.keySet());
+    throw new Undefined(String.format("name '%s' is not defined", name), candidates);
   }
 
   /**
@@ -217,13 +227,61 @@ public final class Module implements Resolver.Module {
    * predeclared environment.
    */
   public Object getGlobal(String name) {
-    return globals.get(name);
+    Integer i = globalIndex.get(name);
+    return i != null ? globals[i] : null;
+  }
+
+  /**
+   * Sets the value of a global variable based on its index in this module ({@see
+   * getIndexOfGlobal}).
+   */
+  void setGlobalByIndex(int i, Object v) {
+    Preconditions.checkArgument(i < globalIndex.size());
+    this.globals[i] = v;
+  }
+
+  /**
+   * Returns the value of a global variable based on its index in this module ({@see
+   * getIndexOfGlobal}.) Returns null if the variable has not been assigned a value.
+   */
+  @Nullable
+  Object getGlobalByIndex(int i) {
+    Preconditions.checkArgument(i < globalIndex.size());
+    return this.globals[i];
+  }
+
+  /**
+   * Returns the index within this Module of a global variable, given its name, creating a new slot
+   * for it if needed. The numbering of globals used by these functions is not the same as the
+   * numbering within any compiled Program. Thus each StarlarkFunction must contain a secondary
+   * index mapping Program indices (from Binding.index) to Module indices.
+   */
+  int getIndexOfGlobal(String name) {
+    int i = globalIndex.size();
+    Integer prev = globalIndex.putIfAbsent(name, i);
+    if (prev != null) {
+      return prev;
+    }
+    if (i == globals.length) {
+      globals = Arrays.copyOf(globals, globals.length << 1); // grow by doubling
+    }
+    return i;
+  }
+
+  /** Returns a list of indices of a list of globals; {@see getIndexOfGlobal}. */
+  int[] getIndicesOfGlobals(List<String> globals) {
+    int n = globals.size();
+    int[] array = new int[n];
+    for (int i = 0; i < n; i++) {
+      array[i] = getIndexOfGlobal(globals.get(i));
+    }
+    return array;
   }
 
   /** Updates a global binding in the module environment. */
   public void setGlobal(String name, Object value) {
     Preconditions.checkNotNull(value, "Module.setGlobal(%s, null)", name);
-    globals.put(name, value);
+    setGlobalByIndex(getIndexOfGlobal(name), value);
   }
 
   @Override

--- a/libstarlark/src/main/java/net/starlark/java/eval/Starlark.java
+++ b/libstarlark/src/main/java/net/starlark/java/eval/Starlark.java
@@ -39,6 +39,7 @@ import net.starlark.java.syntax.Expression;
 import net.starlark.java.syntax.FileOptions;
 import net.starlark.java.syntax.ParserInput;
 import net.starlark.java.syntax.Program;
+import net.starlark.java.syntax.Resolver;
 import net.starlark.java.syntax.StarlarkFile;
 import net.starlark.java.syntax.SyntaxError;
 
@@ -858,8 +859,22 @@ public final class Starlark {
   public static Object execFileProgram(Program prog, Module module, StarlarkThread thread)
       throws EvalException, InterruptedException {
     Tuple defaultValues = Tuple.empty();
-    StarlarkFunction toplevel =
-        new StarlarkFunction(prog.getResolvedFunction(), defaultValues, module);
+
+    Resolver.Function rfn = prog.getResolvedFunction();
+
+    // A given Module may be passed to execFileProgram multiple times in sequence,
+    // for different compiled Programs. (This happens in the REPL, and in
+    // EvaluationTestCase scenarios. It is not true of the go.starlark.net
+    // implementation, and it complicates things significantly.
+    // It would be nice to stop doing that.)
+    //
+    // Therefore StarlarkFunctions from different Programs (files) but initializing
+    // the same Module need different mappings from the Program's numbering of
+    // globals to the Module's numbering of globals, and to access a global requires
+    // two array lookups.
+    int[] globalIndex = module.getIndicesOfGlobals(rfn.getGlobals());
+
+    StarlarkFunction toplevel = new StarlarkFunction(rfn, defaultValues, module, globalIndex);
     return Starlark.fastcall(thread, toplevel, NOARGS, NOARGS);
   }
 
@@ -904,7 +919,9 @@ public final class Starlark {
     Expression expr = Expression.parse(input, options);
     Program prog = Program.compileExpr(expr, module, options);
     Tuple defaultValues = Tuple.empty();
-    return new StarlarkFunction(prog.getResolvedFunction(), defaultValues, module);
+    Resolver.Function rfn = prog.getResolvedFunction();
+    int[] globalIndex = module.getIndicesOfGlobals(rfn.getGlobals()); // see execFileProgram
+    return new StarlarkFunction(rfn, defaultValues, module, globalIndex);
   }
 
   /**

--- a/libstarlark/src/main/java/net/starlark/java/eval/Starlark.java
+++ b/libstarlark/src/main/java/net/starlark/java/eval/Starlark.java
@@ -244,7 +244,7 @@ public final class Starlark {
   public static Object[] toArray(Object x) throws EvalException {
     // Specialize Sequence and Dict to avoid allocation and/or indirection.
     if (x instanceof Sequence) {
-      return ((Sequence<?>) x).toArray();
+      return ((Sequence<?>) x).toArray(new Object[((Sequence) x).size()]);
     } else if (x instanceof Dict) {
       return ((Dict<?, ?>) x).keySet().toArray();
     } else {

--- a/libstarlark/src/main/java/net/starlark/java/eval/StarlarkFunction.java
+++ b/libstarlark/src/main/java/net/starlark/java/eval/StarlarkFunction.java
@@ -36,13 +36,26 @@ import net.starlark.java.syntax.StringLiteral;
 public final class StarlarkFunction implements StarlarkCallable {
 
   final Resolver.Function rfn;
+  final int[] globalIndex; // index in Module.globals of ith Program global (binding index)
   private final Module module; // a function closes over its defining module
   private final Tuple defaultValues;
 
-  StarlarkFunction(Resolver.Function rfn, Tuple defaultValues, Module module) {
+  StarlarkFunction(Resolver.Function rfn, Tuple defaultValues, Module module, int[] globalIndex) {
     this.rfn = rfn;
+    this.globalIndex = globalIndex;
     this.module = module;
     this.defaultValues = defaultValues;
+  }
+
+  // Sets a global variable, given its index in this function's compiled Program.
+  void setGlobal(int progIndex, Object value) {
+    module.setGlobalByIndex(globalIndex[progIndex], value);
+  }
+
+  // Gets the value of a global variable, given its index in this function's compiled Program.
+  @Nullable
+  Object getGlobal(int progIndex) {
+    return module.getGlobalByIndex(globalIndex[progIndex]);
   }
 
   boolean isToplevel() {

--- a/libstarlark/src/main/java/net/starlark/java/eval/StarlarkFunction.java
+++ b/libstarlark/src/main/java/net/starlark/java/eval/StarlarkFunction.java
@@ -35,7 +35,7 @@ import net.starlark.java.syntax.StringLiteral;
     doc = "The type of functions declared in Starlark.")
 public final class StarlarkFunction implements StarlarkCallable {
 
-  private final Resolver.Function rfn;
+  final Resolver.Function rfn;
   private final Module module; // a function closes over its defining module
   private final Tuple defaultValues;
 
@@ -152,11 +152,8 @@ public final class StarlarkFunction implements StarlarkCallable {
     Object[] arguments = processArgs(thread.mutability(), positional, named);
 
     StarlarkThread.Frame fr = thread.frame(0);
-    ImmutableList<String> names = rfn.getParameterNames();
-    for (int i = 0; i < names.size(); ++i) {
-      fr.locals.put(names.get(i), arguments[i]);
-    }
-
+    fr.locals = new Object[rfn.getLocals().size()];
+    System.arraycopy(arguments, 0, fr.locals, 0, rfn.getParameterNames().size());
     return Eval.execFunctionBody(fr, rfn.getBody());
   }
 

--- a/libstarlark/src/main/java/net/starlark/java/eval/StarlarkInt.java
+++ b/libstarlark/src/main/java/net/starlark/java/eval/StarlarkInt.java
@@ -40,6 +40,9 @@ public abstract class StarlarkInt implements StarlarkValue, Comparable<StarlarkI
 
   static final StarlarkInt ZERO = StarlarkInt.of(0);
 
+  /** Only nested classes of {@code StarlarkInt} are allowed to inherit it. */
+  private StarlarkInt() {}
+
   /** Returns the Starlark int value that represents x. */
   public static StarlarkInt of(int x) {
     int index = x - LEAST_SMALLINT; // (may overflow)
@@ -181,6 +184,11 @@ public abstract class StarlarkInt implements StarlarkValue, Comparable<StarlarkI
     }
 
     @Override
+    protected long toLongFast() {
+      return (long) v;
+    }
+
+    @Override
     public BigInteger toBigInteger() {
       return BigInteger.valueOf(v);
     }
@@ -217,6 +225,11 @@ public abstract class StarlarkInt implements StarlarkValue, Comparable<StarlarkI
 
     @Override
     public long toLong(String what) {
+      return v;
+    }
+
+    @Override
+    protected long toLongFast() {
       return v;
     }
 
@@ -315,6 +328,19 @@ public abstract class StarlarkInt implements StarlarkValue, Comparable<StarlarkI
     throw Starlark.errorf("got %s for %s, want value in the signed 64-bit range", this, what);
   }
 
+  // A preallocated exception used to indicate overflow errors without the cost of allocation.
+  private static final Overflow OVERFLOW = new Overflow();
+
+  private static final class Overflow extends Exception {}
+
+  /**
+   * Similar to {@link #toLong(String)}, but faster: exception is not allocated and stack trace is
+   * not collected.
+   */
+  protected long toLongFast() throws Overflow {
+    throw OVERFLOW;
+  }
+
   /** Returns the nearest IEEE-754 double-precision value closest to this int, which may be ±Inf. */
   public double toDouble() {
     if (this instanceof Int32) {
@@ -400,6 +426,13 @@ public abstract class StarlarkInt implements StarlarkValue, Comparable<StarlarkI
     if (x instanceof Int32 && y instanceof Int32) {
       return Integer.compare(((Int32) x).v, ((Int32) y).v);
     }
+
+    try {
+      return Long.compare(x.toLongFast(), y.toLongFast());
+    } catch (Overflow unused) {
+      /* fall through */
+    }
+
     return x.toBigInteger().compareTo(y.toBigInteger());
   }
 
@@ -409,6 +442,19 @@ public abstract class StarlarkInt implements StarlarkValue, Comparable<StarlarkI
       long xl = ((Int32) x).v;
       long yl = ((Int32) y).v;
       return StarlarkInt.of(xl + yl);
+    }
+
+    // We avoid Math.addExact and its overheads of exception allocation.
+    try {
+      long xl = x.toLongFast();
+      long yl = y.toLongFast();
+      long zl = xl + yl;
+      boolean overflow = ((xl ^ zl) & (yl ^ zl)) < 0; // see Hacker's Delight, chapter 2
+      if (!overflow) {
+        return StarlarkInt.of(zl);
+      }
+    } catch (Overflow unused) {
+      /* fall through */
     }
 
     BigInteger xbig = x.toBigInteger();
@@ -423,6 +469,19 @@ public abstract class StarlarkInt implements StarlarkValue, Comparable<StarlarkI
       long xl = ((Int32) x).v;
       long yl = ((Int32) y).v;
       return StarlarkInt.of(xl - yl);
+    }
+
+    // We avoid Math.subtractExact and its overhead of exception allocation.
+    try {
+      long xl = x.toLongFast();
+      long yl = y.toLongFast();
+      long zl = xl - yl;
+      boolean overflow = ((xl ^ yl) & (xl ^ zl)) < 0; // see Hacker's Delight, chapter 2
+      if (!overflow) {
+        return StarlarkInt.of(zl);
+      }
+    } catch (Overflow unused) {
+      /* fall through */
     }
 
     BigInteger xbig = x.toBigInteger();
@@ -442,23 +501,6 @@ public abstract class StarlarkInt implements StarlarkValue, Comparable<StarlarkI
     BigInteger xbig = x.toBigInteger();
     BigInteger ybig = y.toBigInteger();
     BigInteger zbig = xbig.multiply(ybig);
-    return StarlarkInt.of(zbig);
-  }
-
-  /** Returns x / y (real division). */
-  public static StarlarkInt divide(StarlarkInt x, StarlarkInt y) throws EvalException {
-    if (y == ZERO) {
-      throw Starlark.errorf("real division by zero");
-    }
-    if (x instanceof Int32 && y instanceof Int32) {
-      long xl = ((Int32) x).v;
-      long yl = ((Int32) y).v;
-      return StarlarkInt.of(xl / yl);
-    }
-
-    BigInteger xbig = x.toBigInteger();
-    BigInteger ybig = y.toBigInteger();
-    BigInteger zbig = xbig.divide(ybig);
     return StarlarkInt.of(zbig);
   }
 
@@ -613,6 +655,13 @@ public abstract class StarlarkInt implements StarlarkValue, Comparable<StarlarkI
     if (x instanceof Int32) {
       long xl = ((Int32) x).v;
       return StarlarkInt.of(-xl);
+    }
+
+    if (x instanceof Int64) {
+      long xl = ((Int64) x).v;
+      if (xl != Long.MIN_VALUE) {
+        return StarlarkInt.of(-xl);
+      }
     }
 
     BigInteger xbig = x.toBigInteger();

--- a/libstarlark/src/main/java/net/starlark/java/eval/StarlarkList.java
+++ b/libstarlark/src/main/java/net/starlark/java/eval/StarlarkList.java
@@ -78,6 +78,7 @@ public final class StarlarkList<E> extends AbstractList<E>
   // but without the extra indirection of using ArrayList.
 
   // elems[0:size] holds the logical elements, and elems[size:] are not used.
+  // elems.getClass() == Object[].class. This is necessary to avoid ArrayStoreException.
   private int size;
   private int iteratorCount; // number of active iterators (unused once frozen)
   private Object[] elems = EMPTY_ARRAY; // elems[i] == null  iff  i >= size
@@ -88,15 +89,16 @@ public final class StarlarkList<E> extends AbstractList<E>
   private static final Object[] EMPTY_ARRAY = {};
 
   private StarlarkList(@Nullable Mutability mutability, Object[] elems, int size) {
+    Preconditions.checkArgument(elems.getClass() == Object[].class);
     this.elems = elems;
     this.size = size;
     this.mutability = mutability == null ? Mutability.IMMUTABLE : mutability;
   }
 
   /**
-   * Takes ownership of the supplied array and returns a new StarlarkList instance that initially
-   * wraps the array. The caller must not subsequently modify the array, but the StarlarkList
-   * instance may do so.
+   * Takes ownership of the supplied array of class Object[].class, and returns a new StarlarkList
+   * instance that initially wraps the array. The caller must not subsequently modify the array, but
+   * the StarlarkList instance may do so.
    */
   static <T> StarlarkList<T> wrap(@Nullable Mutability mutability, Object[] elems) {
     return new StarlarkList<>(mutability, elems, elems.length);
@@ -184,13 +186,13 @@ public final class StarlarkList<E> extends AbstractList<E>
    */
   public static <T> StarlarkList<T> of(@Nullable Mutability mutability, T... elems) {
     checkElemsValid(elems);
-    return wrap(mutability, Arrays.copyOf(elems, elems.length));
+    return wrap(mutability, Arrays.copyOf(elems, elems.length, Object[].class));
   }
 
   /** Returns an immutable {@code StarlarkList} with the given items. */
   public static <T> StarlarkList<T> immutableOf(T... elems) {
     checkElemsValid(elems);
-    return wrap(null, Arrays.copyOf(elems, elems.length));
+    return wrap(null, Arrays.copyOf(elems, elems.length, Object[].class));
   }
 
   @Override

--- a/libstarlark/src/main/java/net/starlark/java/eval/StarlarkThread.java
+++ b/libstarlark/src/main/java/net/starlark/java/eval/StarlarkThread.java
@@ -17,7 +17,6 @@ package net.starlark.java.eval;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Maps;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
@@ -126,8 +125,6 @@ public final class StarlarkThread {
     @Nullable
     final Debug.Debugger dbg = Debug.debugger.get(); // the debugger, if active for this frame
 
-    int compcount = 0; // number of enclosing comprehensions
-
     Object result = Starlark.NONE; // the operand of a Starlark return statement
 
     // Current PC location. Initially fn.getLocation(); for Starlark functions,
@@ -138,8 +135,9 @@ public final class StarlarkThread {
     // location (loc) should not be overrwritten.
     private boolean errorLocationSet;
 
-    // The locals of this frame, if fn is a StarlarkFunction, otherwise empty.
-    Map<String, Object> locals;
+    // The locals of this frame, if fn is a StarlarkFunction, otherwise null.
+    // Set by StarlarkFunction.fastcall.
+    @Nullable Object[] locals;
 
     @Nullable private Object profileSpan; // current span of walltime call profiler
 
@@ -179,7 +177,16 @@ public final class StarlarkThread {
 
     @Override
     public ImmutableMap<String, Object> getLocals() {
-      return ImmutableMap.copyOf(this.locals);
+      // TODO(adonovan): provide a more efficient API.
+      ImmutableMap.Builder<String, Object> env = ImmutableMap.builder();
+      if (fn instanceof StarlarkFunction) {
+        for (int i = 0; i < locals.length; i++) {
+          if (locals[i] != null) {
+            env.put(((StarlarkFunction) fn).rfn.getLocals().get(i).getName(), locals[i]);
+          }
+        }
+      }
+      return env.build();
     }
 
     @Override
@@ -214,14 +221,6 @@ public final class StarlarkThread {
     // Notify debug tools of the thread's first push.
     if (callstack.size() == 1 && Debug.threadHook != null) {
       Debug.threadHook.onPushFirst(this);
-    }
-
-    if (fn instanceof StarlarkFunction) {
-      StarlarkFunction sfn = (StarlarkFunction) fn;
-      fr.locals = Maps.newLinkedHashMapWithExpectedSize(sfn.getParameterNames().size());
-    } else {
-      // built-in function
-      fr.locals = ImmutableMap.of();
     }
 
     fr.loc = fn.getLocation();

--- a/libstarlark/src/main/java/net/starlark/java/lib/json/Json.java
+++ b/libstarlark/src/main/java/net/starlark/java/lib/json/Json.java
@@ -1,0 +1,763 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package net.starlark.java.lib.json;
+
+import java.util.Arrays;
+import java.util.Map;
+import net.starlark.java.annot.Param;
+import net.starlark.java.annot.StarlarkBuiltin;
+import net.starlark.java.annot.StarlarkMethod;
+import net.starlark.java.eval.Dict;
+import net.starlark.java.eval.EvalException;
+import net.starlark.java.eval.Mutability;
+import net.starlark.java.eval.Starlark;
+import net.starlark.java.eval.StarlarkFloat;
+import net.starlark.java.eval.StarlarkInt;
+import net.starlark.java.eval.StarlarkIterable;
+import net.starlark.java.eval.StarlarkList;
+import net.starlark.java.eval.StarlarkThread;
+import net.starlark.java.eval.StarlarkValue;
+import net.starlark.java.eval.Structure;
+
+// Tests at //src/test/java/net/starlark/java/eval:testdata/json.sky
+
+/**
+ * Json defines the Starlark {@code json} module, which provides functions for encoding/decoding
+ * Starlark values as JSON (https://tools.ietf.org/html/rfc8259).
+ */
+@StarlarkBuiltin(
+    name = "json",
+    category = "core.lib",
+    doc = "Module json is a Starlark module of JSON-related functions.")
+public final class Json implements StarlarkValue {
+
+  private Json() {}
+
+  /**
+   * The module instance. You may wish to add this to your predeclared environment under the name
+   * "json".
+   */
+  public static final Json INSTANCE = new Json();
+
+  /** An interface for StarlarkValue subclasses to define their own JSON encoding. */
+  public interface Encodable {
+    String encodeJSON();
+  }
+
+  /**
+   * Encodes a Starlark value as JSON.
+   *
+   * <p>An application-defined subclass of StarlarkValue may define its own JSON encoding by
+   * implementing the {@link Encodable} interface. Otherwise, the encoder tests for the {@link Map},
+   * {@link StarlarkIterable}, and {@link Structure} interfaces, in that order, resulting in
+   * dict-like, list-like, and struct-like encoding, respectively. See the Starlark documentation
+   * annotation for more detail.
+   *
+   * <p>Encoding any other value yields an error.
+   */
+  @StarlarkMethod(
+      name = "encode",
+      doc =
+          "<p>The encode function accepts one required positional argument, which it converts to"
+              + " JSON by cases:\n"
+              + "<ul>\n"
+              + "<li>None, True, and False are converted to 'null', 'true', and 'false',"
+              + " respectively.\n"
+              + "<li>An int, no matter how large, is encoded as a decimal integer. Some decoders"
+              + " may not be able to decode very large integers.\n"
+              + "<li>A float is encoded using a decimal point or an exponent or both, even if its"
+              + " numeric value is an integer. It is an error to encode a non-finite "
+              + " floating-point value.\n"
+              + "<li>A string value is encoded as a JSON string literal that denotes the value. "
+              + " Each unpaired surrogate is replaced by U+FFFD.\n"
+              + "<li>A dict is encoded as a JSON object, in key order.  It is an error if any key"
+              + " is not a string.\n"
+              + "<li>A list or tuple is encoded as a JSON array.\n"
+              + "<li>A struct-like value is encoded as a JSON object, in field name order.\n"
+              + "</ul>\n"
+              + "An application-defined type may define its own JSON encoding.\n"
+              + "Encoding any other value yields an error.\n",
+      parameters = {@Param(name = "x")})
+  public String encode(Object x) throws EvalException {
+    Encoder enc = new Encoder();
+    try {
+      enc.encode(x);
+    } catch (StackOverflowError unused) {
+      throw Starlark.errorf("nesting depth limit exceeded");
+    }
+    return enc.out.toString();
+  }
+
+  private static final class Encoder {
+
+    private final StringBuilder out = new StringBuilder();
+
+    private void encode(Object x) throws EvalException {
+      if (x == Starlark.NONE) {
+        out.append("null");
+        return;
+      }
+
+      if (x instanceof String) {
+        appendQuoted((String) x);
+        return;
+      }
+
+      if (x instanceof Boolean || x instanceof StarlarkInt) {
+        out.append(x);
+        return;
+      }
+
+      if (x instanceof StarlarkFloat) {
+        if (!Double.isFinite(((StarlarkFloat) x).toDouble())) {
+          throw Starlark.errorf("cannot encode non-finite float %s", x);
+        }
+        out.append(x.toString()); // always contains a decimal point or exponent
+        return;
+      }
+
+      if (x instanceof Encodable) {
+        // Application-defined Starlark value types
+        // may define their own JSON encoding.
+        out.append(((Encodable) x).encodeJSON());
+        return;
+      }
+
+      // e.g. dict (must have string keys)
+      if (x instanceof Map) {
+        Map<?, ?> m = (Map) x;
+
+        // Sort keys for determinism.
+        Object[] keys = m.keySet().toArray();
+        for (Object key : keys) {
+          if (!(key instanceof String)) {
+            throw Starlark.errorf(
+                "%s has %s key, want string", Starlark.type(x), Starlark.type(key));
+          }
+        }
+        Arrays.sort(keys);
+
+        // emit object
+        out.append('{');
+        String sep = "";
+        for (Object key : keys) {
+          out.append(sep);
+          sep = ",";
+          appendQuoted((String) key);
+          out.append(':');
+          try {
+            encode(m.get(key));
+          } catch (EvalException ex) {
+            throw Starlark.errorf(
+                "in %s key %s: %s", Starlark.type(x), Starlark.repr(key), ex.getMessage());
+          }
+        }
+        out.append('}');
+        return;
+      }
+
+      // e.g. tuple, list
+      if (x instanceof StarlarkIterable) {
+        out.append('[');
+        String sep = "";
+        int i = 0;
+        for (Object elem : (StarlarkIterable) x) {
+          out.append(sep);
+          sep = ",";
+          try {
+            encode(elem);
+          } catch (EvalException ex) {
+            throw Starlark.errorf("at %s index %d: %s", Starlark.type(x), i, ex.getMessage());
+          }
+          i++;
+        }
+        out.append(']');
+        return;
+      }
+
+      // e.g. struct
+      if (x instanceof Structure) {
+        Structure obj = (Structure) x;
+
+        // Sort keys for determinism.
+        String[] fields = obj.getFieldNames().toArray(new String[0]);
+        Arrays.sort(fields);
+
+        out.append('{');
+        String sep = "";
+        for (String field : fields) {
+          out.append(sep);
+          sep = ",";
+          appendQuoted(field);
+          out.append(":");
+          try {
+            Object v = obj.getValue(field); // may fail (field not defined)
+            encode(v); // may fail (unexpected type)
+          } catch (EvalException ex) {
+            throw Starlark.errorf("in %s field .%s: %s", Starlark.type(x), field, ex.getMessage());
+          }
+        }
+        out.append('}');
+        return;
+      }
+
+      throw Starlark.errorf("cannot encode %s as JSON", Starlark.type(x));
+    }
+
+    private void appendQuoted(String s) {
+      // We use String's code point iterator so that we can map
+      // unpaired surrogates to U+FFFD in the output.
+      // TODO(adonovan): if we ever get an isPrintable(codepoint)
+      // function, use uXXXX escapes for non-printables.
+      out.append('"');
+      for (int i = 0, n = s.length(); i < n; ) {
+        int cp = s.codePointAt(i);
+
+        // ASCII control code?
+        if (cp < 0x20) {
+          switch (cp) {
+            case '\b':
+              out.append("\\b");
+              break;
+            case '\f':
+              out.append("\\f");
+              break;
+            case '\n':
+              out.append("\\n");
+              break;
+            case '\r':
+              out.append("\\r");
+              break;
+            case '\t':
+              out.append("\\t");
+              break;
+            default:
+              out.append("\\u00");
+              out.append(HEX[(cp >> 4) & 0xf]);
+              out.append(HEX[cp & 0xf]);
+          }
+          i++;
+          continue;
+        }
+
+        // printable ASCII (or DEL 0x7f)? (common case)
+        if (cp < 0x80) {
+          if (cp == '"' || cp == '\\') {
+            out.append('\\');
+          }
+          out.append((char) cp);
+          i++;
+          continue;
+        }
+
+        // non-ASCII
+        if (Character.MIN_SURROGATE <= cp && cp <= Character.MAX_SURROGATE) {
+          cp = 0xFFFD; // unpaired surrogate
+        }
+        out.appendCodePoint(cp);
+        i += Character.charCount(cp);
+      }
+      out.append('"');
+    }
+  }
+
+  private static final char[] HEX = "0123456789abcdef".toCharArray();
+
+  /** Parses a JSON string as a Starlark value. */
+  @StarlarkMethod(
+      name = "decode",
+      doc =
+          "The decode function accepts one positional parameter, a JSON string.\n"
+              + "It returns the Starlark value that the string denotes.\n"
+              + "<ul>"
+              + "<li>'null', 'true', and 'false' are parsed as None, True, and False.\n"
+              + "<li>Numbers are parsed as int, or as a float if they contain"
+              + " a decimal point or an exponent. Although JSON has no syntax "
+              + " for non-finite values, very large values may be decoded as infinity.\n"
+              + "<li>a JSON object is parsed as a new unfrozen Starlark dict."
+              + " Keys must be unique strings.\n"
+              + "<li>a JSON array is parsed as new unfrozen Starlark list.\n"
+              + "</ul>\n"
+              + "Decoding fails if x is not a valid JSON encoding.\n",
+      parameters = {@Param(name = "x")},
+      useStarlarkThread = true)
+  public Object decode(String x, StarlarkThread thread) throws EvalException {
+    return new Decoder(thread.mutability(), x).decode();
+  }
+
+  private static final class Decoder {
+
+    // The decoder necessarily makes certain representation choices
+    // such as list vs tuple, struct vs dict, int vs float.
+    // In principle, we could parameterize it to allow the caller to
+    // control the returned types, but there's no compelling need yet.
+
+    private final Mutability mu;
+    private final String s; // the input string
+    private int i = 0; // current index in s
+
+    private Decoder(Mutability mu, String s) {
+      this.mu = mu;
+      this.s = s;
+    }
+
+    // decode is the entry point into the decoder.
+    private Object decode() throws EvalException {
+      try {
+        Object x = parse();
+        if (skipSpace()) {
+          throw Starlark.errorf("unexpected character %s after value", quoteChar(s.charAt(i)));
+        }
+        return x;
+      } catch (StackOverflowError unused) {
+        throw Starlark.errorf("nesting depth limit exceeded");
+      } catch (EvalException ex) {
+        throw Starlark.errorf("at offset %d, %s", i, ex.getMessage());
+      }
+    }
+
+    // parse returns the next JSON value from the input.
+    // It consumes leading but not trailing whitespace.
+    private Object parse() throws EvalException {
+      char c = next();
+      switch (c) {
+        case '"':
+          return parseString();
+
+        case 'n':
+          if (s.startsWith("null", i)) {
+            i += "null".length();
+            return Starlark.NONE;
+          }
+          break;
+
+        case 't':
+          if (s.startsWith("true", i)) {
+            i += "true".length();
+            return true;
+          }
+          break;
+
+        case 'f':
+          if (s.startsWith("false", i)) {
+            i += "false".length();
+            return false;
+          }
+          break;
+
+        case '[':
+          // array
+          StarlarkList<Object> list = StarlarkList.newList(mu);
+
+          i++; // '['
+          c = next();
+          if (c != ']') {
+            while (true) {
+              Object elem = parse();
+              list.addElement(elem); // can't fail
+              c = next();
+              if (c != ',') {
+                if (c != ']') {
+                  throw Starlark.errorf("got %s, want ',' or ']'", quoteChar(c));
+                }
+                break;
+              }
+              i++; // ','
+            }
+          }
+          i++; // ']'
+          return list;
+
+        case '{':
+          // object
+          Dict<String, Object> dict = Dict.of(mu);
+
+          i++; // '{'
+          c = next();
+          if (c != '}') {
+            while (true) {
+              Object key = parse();
+              if (!(key instanceof String)) {
+                throw Starlark.errorf("got %s for object key, want string", Starlark.type(key));
+              }
+              c = next();
+              if (c != ':') {
+                throw Starlark.errorf("after object key, got %s, want ':' ", quoteChar(c));
+              }
+              i++; // ':'
+              Object value = parse();
+              int sz = dict.size();
+              dict.putEntry((String) key, value); // can't fail
+              if (dict.size() == sz) {
+                throw Starlark.errorf("object has duplicate key: %s", Starlark.repr(key));
+              }
+              c = next();
+              if (c != ',') {
+                if (c != '}') {
+                  throw Starlark.errorf("in object, got %s, want ',' or '}'", quoteChar(c));
+                }
+                break;
+              }
+              i++; // ','
+            }
+          }
+          i++; // '}'
+          return dict;
+
+        default:
+          // number?
+          if (isdigit(c) || c == '-') {
+            return parseNumber(c);
+          }
+          break;
+      }
+      throw Starlark.errorf("unexpected character %s", quoteChar(c));
+    }
+
+    private String parseString() throws EvalException {
+      i++; // '"'
+      StringBuilder str = new StringBuilder();
+      while (i < s.length()) {
+        char c = s.charAt(i);
+
+        // end quote?
+        if (c == '"') {
+          i++; // skip '"'
+          return str.toString();
+        }
+
+        // literal char?
+        if (c != '\\') {
+          // reject unescaped control codes
+          if (c <= 0x1F) {
+            throw Starlark.errorf("invalid character '\\x%02x' in string literal", (int) c);
+          }
+          i++; // consume
+          str.append(c);
+          continue;
+        }
+
+        // escape: uXXXX or [\/bfnrt"]
+        i++; // '\\'
+        if (i == s.length()) {
+          throw Starlark.errorf("incomplete escape");
+        }
+        c = s.charAt(i);
+        i++; // consume c
+        switch (c) {
+          case '\\':
+          case '/':
+          case '"':
+            str.append(c);
+            break;
+          case 'b':
+            str.append('\b');
+            break;
+          case 'f':
+            str.append('\f');
+            break;
+          case 'n':
+            str.append('\n');
+            break;
+          case 'r':
+            str.append('\r');
+            break;
+          case 't':
+            str.append('\t');
+            break;
+          case 'u': // \ uXXXX
+            if (i + 4 >= s.length()) {
+              throw Starlark.errorf("incomplete \\uXXXX escape");
+            }
+            int hex = 0;
+            for (int j = 0; j < 4; j++) {
+              c = s.charAt(i + j);
+              int nybble = 0;
+              if (isdigit(c)) {
+                nybble = c - '0';
+              } else if ('a' <= c && c <= 'f') {
+                nybble = 10 + c - 'a';
+              } else if ('A' <= c && c <= 'F') {
+                nybble = 10 + c - 'A';
+              } else {
+                throw Starlark.errorf("invalid hex char %s in \\uXXXX escape", quoteChar(c));
+              }
+              hex = (hex << 4) | nybble;
+            }
+            str.append((char) hex);
+            i += 4;
+            break;
+          default:
+            throw Starlark.errorf("invalid escape '\\%s'", c);
+        }
+      }
+      throw Starlark.errorf("unclosed string literal");
+    }
+
+    private Object parseNumber(char c) throws EvalException {
+      // For now, allow any sequence of [0-9.eE+-]*.
+      boolean isfloat = false; // whether digit string contains [.Ee+-] (other than leading minus)
+      int j = i;
+      for (j = i + 1; j < s.length(); j++) {
+        c = s.charAt(j);
+        if (isdigit(c)) {
+          // ok
+        } else if (c == '.' || c == 'e' || c == 'E' || c == '+' || c == '-') {
+          isfloat = true;
+        } else {
+          break;
+        }
+      }
+
+      String num = s.substring(i, j);
+
+      int digits = i; // s[digits:j] is the digit string
+      if (s.charAt(i) == '-') {
+        digits++;
+      }
+
+      // Structural checks not performed by parse routines below.
+      // Unlike most C-like languages,
+      // JSON disallows a leading zero before a digit.
+      if (digits == j // "-"
+          || s.charAt(digits) == '.' // ".5"
+          || s.charAt(j - 1) == '.' // "0."
+          || num.contains(".e") // "5.e1"
+          || (s.charAt(digits) == '0' && j - digits > 1 && isdigit(s.charAt(digits + 1)))) { // "01"
+        throw Starlark.errorf("invalid number: %s", num);
+      }
+
+      i = j;
+
+      // parse number literal
+      try {
+        if (isfloat) {
+          double x = Double.parseDouble(num);
+          return StarlarkFloat.of(x);
+        } else {
+          return StarlarkInt.parse(num, 10);
+        }
+      } catch (NumberFormatException unused) {
+        throw Starlark.errorf("invalid number: %s", num);
+      }
+    }
+
+    // skipSpace consumes leading spaces, and reports whether there is more input.
+    private boolean skipSpace() {
+      for (; i < s.length(); i++) {
+        char c = s.charAt(i);
+        if (c != ' ' && c != '\t' && c != '\n' && c != '\r') {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    // next consumes leading spaces and returns the first non-space.
+    private char next() throws EvalException {
+      if (skipSpace()) {
+        return s.charAt(i);
+      }
+      throw Starlark.errorf("unexpected end of file");
+    }
+  }
+
+  @StarlarkMethod(
+      name = "indent",
+      doc =
+          "The indent function returns the indented form of a valid JSON-encoded string.\n"
+              + "Each array element or object field appears on a new line, beginning with"
+              + " the prefix string followed by one or more copies of the indent string, according"
+              + " to its nesting depth.\n"
+              + "The function accepts one required positional parameter, the JSON string,\n"
+              + "and two optional keyword-only string parameters, prefix and indent,\n"
+              + "that specify a prefix of each new line, and the unit of indentation.\n"
+              + "If the input is not valid, the funtion may fail or return invalid output.\n",
+      parameters = {
+        @Param(name = "s"),
+        @Param(name = "prefix", positional = false, named = true, defaultValue = "''"),
+        @Param(name = "indent", positional = false, named = true, defaultValue = "'\\t'")
+      })
+  public String indent(String s, String prefix, String indent) throws EvalException {
+    // Indentation can be efficiently implemented in a single pass, independent of encoding,
+    // with no state other than a depth counter. This separation enables efficient indentation
+    // of values obtained from, say, reading a file, without the need for decoding.
+
+    Indenter in = new Indenter(prefix, indent, s);
+    try {
+      in.indent();
+    } catch (StringIndexOutOfBoundsException unused) {
+      throw Starlark.errorf("input is not valid JSON");
+    }
+    return in.out.toString();
+  }
+
+  @StarlarkMethod(
+      name = "encode_indent",
+      doc =
+          "The encode_indent function is equivalent to <code>json.indent(json.encode(x),"
+              + " ...)</code>. See <code>indent</code> for description of formatting parameters.",
+      parameters = {
+        @Param(name = "x"),
+        @Param(name = "prefix", positional = false, named = true, defaultValue = "''"),
+        @Param(name = "indent", positional = false, named = true, defaultValue = "'\\t'"),
+      })
+  public String encodeIndent(Object x, String prefix, String indent) throws EvalException {
+    return indent(encode(x), prefix, indent);
+  }
+
+  private static final class Indenter {
+
+    private final StringBuilder out = new StringBuilder();
+    private final String prefix;
+    private final String indent;
+    private final String s; // input string
+    private int i; // current index in s, possibly out of bounds
+
+    Indenter(String prefix, String indent, String s) {
+      this.prefix = prefix;
+      this.indent = indent;
+      this.s = s;
+    }
+
+    // Appends a single JSON value to str.
+    // May throw StringIndexOutOfBoundsException.
+    //
+    // The current implementation is a rudimentary placeholder:
+    // given invalid JSON, it produces garbage output.
+    // TODO(adonovan): factor Decoder and Indenter using a
+    // validating state machine, without loss of efficiency.
+    // This requires different states after [, {, :, etc,
+    // and a stack of open tokens.
+    private void indent() throws EvalException {
+      int depth = 0;
+
+      // token loop
+      do { // while (depth > 0)
+        char c = next();
+        int start = i;
+        switch (c) {
+          case '"': // string
+            for (c = s.charAt(++i); c != '"'; c = s.charAt(++i)) {
+              if (c == '\\') {
+                c = s.charAt(++i);
+                if (c == 'u') {
+                  i += 4;
+                }
+              }
+            }
+            i++; // '"'
+            out.append(s, start, i);
+            break;
+
+          case 'n':
+            i += "null".length();
+            out.append(s, start, i);
+            break;
+
+          case 't':
+            i += "true".length();
+            out.append(s, start, i);
+            break;
+
+          case 'f':
+            i += "false".length();
+            out.append(s, start, i);
+            break;
+
+          case ',':
+            i++;
+            out.append(',');
+            newline(depth);
+            break;
+
+          case '[':
+          case '{':
+            i++;
+            out.append(c);
+            c = next();
+            if (c == ']' || c == '}') {
+              i++;
+              out.append(c);
+            } else {
+              newline(++depth);
+            }
+            break;
+
+          case ']':
+          case '}':
+            i++;
+            newline(--depth);
+            out.append(c);
+            break;
+
+          case ':':
+            i++;
+            out.append(": ");
+            break;
+
+          default:
+            // number
+            if (!(isdigit(c) || c == '-')) {
+              throw Starlark.errorf("unexpected character %s", quoteChar(c));
+            }
+            while (i < s.length()) {
+              c = s.charAt(++i);
+              if (!(isdigit(c) || c == '.' || c == 'e' || c == 'E' || c == '+' || c == '-')) {
+                break;
+              }
+            }
+            out.append(s, start, i);
+            break;
+        }
+      } while (depth > 0);
+    }
+
+    private void newline(int depth) {
+      out.append('\n').append(prefix);
+      for (int i = 0; i < depth; i++) {
+        out.append(indent);
+      }
+    }
+
+    // skipSpace consumes leading spaces, and reports whether there is more input.
+    private boolean skipSpace() {
+      for (; i < s.length(); i++) {
+        char c = s.charAt(i);
+        if (c != ' ' && c != '\t' && c != '\n' && c != '\r') {
+          return true;
+        }
+      }
+      return false;
+    }
+
+    // next consumes leading spaces and returns the first non-space.
+    private char next() throws EvalException {
+      if (skipSpace()) {
+        return s.charAt(i);
+      }
+      throw Starlark.errorf("unexpected end of file");
+    }
+  }
+
+  private static boolean isdigit(char c) {
+    return c >= '0' && c <= '9';
+  }
+
+  // Returns a Starlark string literal that denotes c.
+  private static String quoteChar(char c) {
+    return Starlark.repr("" + c);
+  }
+}

--- a/libstarlark/src/main/java/net/starlark/java/syntax/FileOptions.java
+++ b/libstarlark/src/main/java/net/starlark/java/syntax/FileOptions.java
@@ -76,12 +76,6 @@ public abstract class FileOptions {
    */
   public abstract boolean requireLoadStatementsFirst();
 
-  /**
-   * Record the results of name resolution in the syntax tree by setting {@code Identifer.scope}.
-   * (Disabled for Bazel BUILD files, as its prelude's syntax trees are shared.)
-   */
-  public abstract boolean recordScope();
-
   public static Builder builder() {
     // These are the DEFAULT values.
     return new AutoValue_FileOptions.Builder()
@@ -89,8 +83,7 @@ public abstract class FileOptions {
         .allowLoadPrivateSymbols(false)
         .allowToplevelRebinding(false)
         // .loadBindsGlobally(false)
-        .requireLoadStatementsFirst(true)
-        .recordScope(true);
+        .requireLoadStatementsFirst(true);
   }
 
   public abstract Builder toBuilder();
@@ -108,8 +101,6 @@ public abstract class FileOptions {
     // public abstract Builder loadBindsGlobally(boolean value);
 
     public abstract Builder requireLoadStatementsFirst(boolean value);
-
-    public abstract Builder recordScope(boolean value);
 
     public abstract FileOptions build();
   }

--- a/libstarlark/src/main/java/net/starlark/java/syntax/Identifier.java
+++ b/libstarlark/src/main/java/net/starlark/java/syntax/Identifier.java
@@ -107,7 +107,7 @@ public final class Identifier extends Expression {
   //   When it works in a single pass, it is more efficient to process bindings in order,
   //   deferring (rare) forward references until the end of the block.
   // - Eval calls boundIdentifiers for comprehensions. This can be eliminated when
-  //   recordScope is always enabled and variables are assigned frame slot indices.
+  //   variables are assigned frame slot indices.
   // - Eval calls boundIdentifiers for the 'export' hack. This can be eliminated
   //   when we switch to compilation by emitting EXPORT instructions for the necessary
   //   bindings. (Ideally we would eliminate Bazel's export hack entirely.)

--- a/libstarlark/src/main/java/net/starlark/java/syntax/Resolver.java
+++ b/libstarlark/src/main/java/net/starlark/java/syntax/Resolver.java
@@ -44,19 +44,30 @@ import net.starlark.java.spelling.SpellChecker;
  */
 public final class Resolver extends NodeVisitor {
 
-  // TODO(adonovan): use "keyword" (not "named") and "required" (not "mandatory") terminology
-  // everywhere, including the spec.
+  // TODO(adonovan):
+  // - use "keyword" (not "named") and "required" (not "mandatory") terminology everywhere,
+  //   including the spec.
+  // - move the "no if statements at top level" check to bazel's check{Build,*}Syntax
+  //   (that's a spec change), or put it behind a FileOptions flag (no spec change).
+  // - remove restriction on nested def:
+  //   1. use FREE for scope of references to outer LOCALs, which become CELLs.
+  //   2. implement closures in eval/.
+  // - make loads bind locals by default.
 
   /** Scope discriminates the scope of a binding: global, local, etc. */
   public enum Scope {
-    // TODO(adonovan): Add UNIVERSAL, FREE, CELL.
-    // (PREDECLARED vs UNIVERSAL allows us to represent the app-dependent and fixed parts of the
-    // predeclared environment separately, reducing the amount of copying.)
+    // TODO(adonovan): Add UNIVERSAL. Separating PREDECLARED from UNIVERSAL allows
+    // us to represent the app-dependent and fixed parts of the predeclared
+    // environment separately, reducing the amount of copying.
 
     /** Binding is local to a function, comprehension, or file (e.g. load). */
     LOCAL,
     /** Binding occurs outside any function or comprehension. */
     GLOBAL,
+    /** Binding is local to a function, comprehension, or file, plus its nested functions. */
+    CELL, // TODO(adonovan): implement nested def
+    /** Binding is a CELL of some enclosing function. */
+    FREE, // TODO(adonovan): implement nested def
     /** Binding is predeclared by the core or application. */
     PREDECLARED;
 
@@ -74,7 +85,7 @@ public final class Resolver extends NodeVisitor {
 
     private final Scope scope;
     @Nullable private final Identifier first; // first binding use, if syntactic
-    private final int index; // within its block (currently unused)
+    final int index; // index within function (LOCAL) or module (GLOBAL)
 
     private Binding(Scope scope, @Nullable Identifier first, int index) {
       this.scope = scope;
@@ -82,9 +93,20 @@ public final class Resolver extends NodeVisitor {
       this.index = index;
     }
 
+    /** Returns the name of this binding's identifier. */
+    @Nullable
+    public String getName() {
+      return first != null ? first.getName() : null;
+    }
+
     /** Returns the scope of the binding. */
     public Scope getScope() {
       return scope;
+    }
+
+    /** Returns the index of a binding within its function (LOCAL) or module (GLOBAL). */
+    public int getIndex() {
+      return index;
     }
 
     @Override
@@ -108,6 +130,7 @@ public final class Resolver extends NodeVisitor {
     private final int numKeywordOnlyParams;
     private final ImmutableList<String> parameterNames;
     private final boolean isToplevel;
+    private final ImmutableList<Binding> locals;
 
     private Function(
         String name,
@@ -116,7 +139,8 @@ public final class Resolver extends NodeVisitor {
         ImmutableList<Statement> body,
         boolean hasVarargs,
         boolean hasKwargs,
-        int numKeywordOnlyParams) {
+        int numKeywordOnlyParams,
+        List<Binding> locals) {
       this.name = name;
       this.location = loc;
       this.params = params;
@@ -132,6 +156,7 @@ public final class Resolver extends NodeVisitor {
       this.parameterNames = names.build();
 
       this.isToplevel = name.equals("<toplevel>");
+      this.locals = ImmutableList.copyOf(locals);
     }
 
     /**
@@ -141,6 +166,11 @@ public final class Resolver extends NodeVisitor {
      */
     public String getName() {
       return name;
+    }
+
+    /** Returns the function's local bindings, parameters first. */
+    public ImmutableList<Binding> getLocals() {
+      return locals;
     }
 
     /** Returns the location of the function's identifier. */
@@ -191,10 +221,10 @@ public final class Resolver extends NodeVisitor {
 
     /**
      * isToplevel indicates that this is the <toplevel> function containing top-level statements of
-     * a file. It causes assignments to unresolved identifiers to update the module, not the lexical
-     * frame.
+     * a file.
      */
-    // TODO(adonovan): remove this hack when identifier resolution is accurate.
+    // TODO(adonovan): remove this when we remove Bazel's "export" hack,
+    // or switch to a compiled representation of function bodies.
     public boolean isToplevel() {
       return isToplevel;
     }
@@ -230,12 +260,14 @@ public final class Resolver extends NodeVisitor {
 
   private static class Block {
     private final Map<String, Binding> bindings = new HashMap<>();
+    private final ArrayList<Binding> locals; // of enclosing function
     private final Scope scope;
     @Nullable private final Block parent;
 
-    Block(Scope scope, @Nullable Block parent) {
+    Block(Scope scope, @Nullable Block parent, ArrayList<Binding> locals) {
       this.scope = scope;
       this.parent = parent;
+      this.locals = locals;
     }
   }
 
@@ -253,7 +285,7 @@ public final class Resolver extends NodeVisitor {
     this.module = module;
     this.options = options;
 
-    this.block = new Block(Scope.PREDECLARED, null);
+    this.block = new Block(Scope.PREDECLARED, /*parent=*/ null, /*locals=*/ null);
     for (String name : module.getNames()) {
       block.bindings.put(name, PREDECLARED);
     }
@@ -277,7 +309,7 @@ public final class Resolver extends NodeVisitor {
    * in order).
    */
   // TODO(adonovan): eliminate this first pass by using go.starlark.net one-pass approach.
-  private void createBindings(Iterable<Statement> stmts) {
+  private void createBindingsForBlock(Iterable<Statement> stmts) {
     for (Statement stmt : stmts) {
       createBindings(stmt);
     }
@@ -286,19 +318,19 @@ public final class Resolver extends NodeVisitor {
   private void createBindings(Statement stmt) {
     switch (stmt.kind()) {
       case ASSIGNMENT:
-        createBindings(((AssignmentStatement) stmt).getLHS());
+        createBindingsForLHS(((AssignmentStatement) stmt).getLHS());
         break;
       case IF:
         IfStatement ifStmt = (IfStatement) stmt;
-        createBindings(ifStmt.getThenBlock());
+        createBindingsForBlock(ifStmt.getThenBlock());
         if (ifStmt.getElseBlock() != null) {
-          createBindings(ifStmt.getElseBlock());
+          createBindingsForBlock(ifStmt.getElseBlock());
         }
         break;
       case FOR:
         ForStatement forStmt = (ForStatement) stmt;
-        createBindings(forStmt.getVars());
-        createBindings(forStmt.getBody());
+        createBindingsForLHS(forStmt.getVars());
+        createBindingsForBlock(forStmt.getBody());
         break;
       case DEF:
         DefStatement def = (DefStatement) stmt;
@@ -341,7 +373,7 @@ public final class Resolver extends NodeVisitor {
     }
   }
 
-  private void createBindings(Expression lhs) {
+  private void createBindingsForLHS(Expression lhs) {
     for (Identifier id : Identifier.boundIdentifiers(lhs)) {
       bind(id);
     }
@@ -371,9 +403,7 @@ public final class Resolver extends NodeVisitor {
     for (Block b = block; b != null; b = b.parent) {
       Binding bind = b.bindings.get(id.getName());
       if (bind != null) {
-        if (options.recordScope()) {
-          id.setBinding(bind);
-        }
+        id.setBinding(bind);
         return;
       }
     }
@@ -504,11 +534,13 @@ public final class Resolver extends NodeVisitor {
     Comprehension.For for0 = (Comprehension.For) clauses.get(0);
     visit(for0.getIterable());
 
-    openBlock(Scope.LOCAL);
+    // A comprehension defines a distinct lexical block in the same function.
+    openBlock(Scope.LOCAL, this.block.locals);
+
     for (Comprehension.Clause clause : clauses) {
       if (clause instanceof Comprehension.For) {
         Comprehension.For forClause = (Comprehension.For) clause;
-        createBindings(forClause.getVars());
+        createBindingsForLHS(forClause.getVars());
       }
     }
     for (int i = 0; i < clauses.size(); i++) {
@@ -555,7 +587,8 @@ public final class Resolver extends NodeVisitor {
     }
 
     // Enter function block.
-    openBlock(Scope.LOCAL);
+    ArrayList<Binding> locals = new ArrayList<>();
+    openBlock(Scope.LOCAL, locals);
 
     // Check parameter order and convert to run-time order:
     // positionals, keyword-only, *args, **kwargs.
@@ -629,7 +662,7 @@ public final class Resolver extends NodeVisitor {
       bindParam(params, starStar);
     }
 
-    createBindings(body);
+    createBindingsForBlock(body);
     visitAll(body);
     closeBlock();
 
@@ -640,7 +673,8 @@ public final class Resolver extends NodeVisitor {
         body,
         star != null && star.getIdentifier() != null,
         starStar != null,
-        numKeywordOnlyParams);
+        numKeywordOnlyParams,
+        locals);
   }
 
   private void bindParam(ImmutableList.Builder<Parameter> params, Parameter param) {
@@ -697,19 +731,20 @@ public final class Resolver extends NodeVisitor {
         }
       }
 
-      if (options.recordScope()) {
-        id.setBinding(bind);
-      }
+      id.setBinding(bind);
       return true;
     }
 
     // new binding
-    // TODO(adonovan): accumulate locals in the enclosing function/file block.
-    bind = new Binding(block.scope, id, block.bindings.size());
-    block.bindings.put(id.getName(), bind);
-    if (options.recordScope()) {
-      id.setBinding(bind);
+    if (block.scope == Scope.LOCAL) {
+      // Accumulate local bindings in the enclosing function.
+      bind = new Binding(block.scope, id, block.locals.size());
+      block.locals.add(bind);
+    } else { // GLOBAL
+      bind = new Binding(block.scope, id, block.bindings.size());
     }
+    block.bindings.put(id.getName(), bind);
+    id.setBinding(bind);
     return false;
   }
 
@@ -747,35 +782,30 @@ public final class Resolver extends NodeVisitor {
     }
   }
 
-  private void resolveToplevelStatements(List<Statement> statements) {
-    // Check that load() statements are on top.
-    if (options.requireLoadStatementsFirst()) {
-      checkLoadAfterStatement(statements);
-    }
-
-    openBlock(Scope.GLOBAL);
-
-    // Add a binding for each variable defined by statements, not including definitions that appear
-    // in sub-scopes of the given statements (function bodies and comprehensions).
-    createBindings(statements);
-
-    // Second pass: ensure that all symbols have been defined.
-    visitAll(statements);
-    closeBlock();
-  }
-
   /**
    * Performs static checks, including resolution of identifiers in {@code file} in the environment
    * defined by {@code module}. The StarlarkFile is mutated. Errors are appended to {@link
    * StarlarkFile#errors}.
    */
   public static void resolveFile(StarlarkFile file, Module module) {
+    Resolver r = new Resolver(file.errors, module, file.getOptions());
+
+    ArrayList<Binding> locals = new ArrayList<>();
+    r.openBlock(Scope.GLOBAL, locals);
+
     ImmutableList<Statement> stmts = file.getStatements();
 
-    Resolver r = new Resolver(file.errors, module, file.getOptions());
-    r.resolveToplevelStatements(stmts);
-    // Check that no closeBlock was forgotten.
-    Preconditions.checkState(r.block.parent == null);
+    // Check that load() statements are on top.
+    if (r.options.requireLoadStatementsFirst()) {
+      r.checkLoadAfterStatement(stmts);
+    }
+
+    // First pass: creating bindings for statements in this block.
+    r.createBindingsForBlock(stmts);
+
+    // Second pass: visit all references.
+    r.visitAll(stmts);
+    r.closeBlock();
 
     // If the final statement is an expression, synthesize a return statement.
     int n = stmts.size();
@@ -797,7 +827,8 @@ public final class Resolver extends NodeVisitor {
             /*body=*/ stmts,
             /*hasVarargs=*/ false,
             /*hasKwargs=*/ false,
-            /*numKeywordOnlyParams=*/ 0));
+            /*numKeywordOnlyParams=*/ 0,
+            locals));
   }
 
   /**
@@ -810,7 +841,10 @@ public final class Resolver extends NodeVisitor {
     List<SyntaxError> errors = new ArrayList<>();
     Resolver r = new Resolver(errors, module, options);
 
+    ArrayList<Binding> locals = new ArrayList<>();
+    r.openBlock(Scope.LOCAL, locals); // for bindings in list comprehensions
     r.visit(expr);
+    r.closeBlock();
 
     if (!errors.isEmpty()) {
       throw new SyntaxError.Exception(errors);
@@ -824,12 +858,13 @@ public final class Resolver extends NodeVisitor {
         ImmutableList.of(ReturnStatement.make(expr)),
         /*hasVarargs=*/ false,
         /*hasKwargs=*/ false,
-        /*numKeywordOnlyParams=*/ 0);
+        /*numKeywordOnlyParams=*/ 0,
+        locals);
   }
 
-  /** Open a new lexical block that will contain the future declarations. */
-  private void openBlock(Scope scope) {
-    block = new Block(scope, block);
+  /** Open a new lexical block for future bindings. Local bindings will be added to locals. */
+  private void openBlock(Scope scope, ArrayList<Binding> locals) {
+    block = new Block(scope, block, locals);
   }
 
   /** Close a lexical block (and lose all declarations it contained). */

--- a/libstarlark/src/test/java/net/starlark/java/eval/Benchmarks.java
+++ b/libstarlark/src/test/java/net/starlark/java/eval/Benchmarks.java
@@ -1,0 +1,360 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package net.starlark.java.eval;
+
+import com.google.common.collect.ImmutableMap;
+import com.sun.management.ThreadMXBean;
+import java.io.File;
+import java.lang.management.ManagementFactory;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+import net.starlark.java.annot.StarlarkBuiltin;
+import net.starlark.java.annot.StarlarkMethod;
+import net.starlark.java.lib.json.Json;
+import net.starlark.java.syntax.FileOptions;
+import net.starlark.java.syntax.ParserInput;
+import net.starlark.java.syntax.SyntaxError;
+
+// TODO(adonovan): document how to obtain a Java CPU profile.
+
+// TODO(adonovan): mitigate the effects of JVM warmup.
+// (See Oracle's JMH; we can't use it directly because it
+// seems to be entirely driven by Java annotations,
+// which is no good for a dynamic suite.)
+
+/**
+ * Script-based benchmarks of the Starlark evaluator.
+ *
+ * <p>Scripts in testdata/bench_*.star are executed, and then each function named {@code bench_*} is
+ * repeatedly called and measured. The function has one parameter, b, a Benchmark, that provides
+ * b.n, the number of iterations to execute. The function must have resource costs linear in b.n.
+ * Typically, the function body is a loop of the form {@code for _ in range(b.n): ...}. Using b.n
+ * for other purposes leads to meaningless results. For example, it would be a mistake to use it as
+ * the length of a random list to be sorted, because sorting does not run in linear time.
+ *
+ * <p>A benchmark with significant set-up costs may reset the timer ({@code b.restart()}) before
+ * entering its loop. Example:
+ *
+ * <pre>
+ * def bench_my_func(b):
+ *     """Description goes here."""
+ *     my_setup()
+ *     b.restart()
+ *     for _ in range(b.n):
+ *         my_func()
+ * </pre>
+ */
+public final class Benchmarks {
+
+  private static final String HELP =
+      "Usage: Benchmarks [--help] [--filter regex] [--seconds float]\n"
+          + "Runs Starlark benchmarks matching the filter for the specified (approximate) time,\n"
+          + "and reports various performance measures.\n"
+          + "The optional filter is a regular expression applied to the string FILE:FUNC,\n"
+          + "where FILE is the base name of the file and FUNC is the name of the function,\n"
+          + "for example 'bench_int.star:bench_add32'.\n";
+
+  private static boolean ok = true;
+
+  public static void main(String[] args) throws Exception {
+    Pattern filter = null; // default: all
+    long budgetNanos = 1_000_000_000;
+
+    // parse flags
+    int i;
+    for (i = 0; i < args.length; i++) {
+      if (args[i].equals("--")) {
+        i++;
+        break;
+
+      } else if (args[i].equals("--help")) {
+        System.out.println(HELP);
+        System.exit(0);
+
+      } else if (args[i].equals("--filter")) {
+        if (++i == args.length) {
+          fail("--filter needs an argument");
+        }
+        try {
+          filter = Pattern.compile(args[i]);
+        } catch (PatternSyntaxException ex) {
+          fail("for --filter, invalid regexp: %s", ex.getMessage());
+        }
+
+      } else if (args[i].equals("--seconds")) {
+        if (++i == args.length) {
+          fail("--seconds needs an argument");
+        }
+        try {
+          budgetNanos = (long) (1e9 * Double.parseDouble(args[i]));
+        } catch (NumberFormatException unused) {
+          fail("for --seconds, got '%s', want floating-point number of seconds", args[i]);
+        }
+        if (!(0 <= budgetNanos && budgetNanos <= 1e13)) {
+          fail("--seconds out of range");
+        }
+
+      } else {
+        fail("unknown flag: %s", args[i]);
+      }
+    }
+    if (i < args.length) {
+      fail("unexpected arguments");
+    }
+
+    // Read testdata/bench_* files.
+    File src = new File("third_party/bazel/src"); // blaze
+    if (!src.exists()) {
+      src = new File("src"); // bazel
+    }
+    File testdata = new File(src, "test/java/net/starlark/java/eval/testdata");
+    for (File file : testdata.listFiles()) {
+      String basename = file.getName();
+      if (!(basename.startsWith("bench_") && basename.endsWith(".star"))) {
+        continue;
+      }
+
+      // parse & execute
+      ParserInput input = ParserInput.readFile(file.toString());
+      ImmutableMap.Builder<String, Object> predeclared = ImmutableMap.builder();
+      predeclared.put("json", Json.INSTANCE);
+
+      Module module = Module.withPredeclared(semantics, predeclared.build());
+      try (Mutability mu = Mutability.create("test")) {
+        StarlarkThread thread = new StarlarkThread(mu, semantics);
+        Starlark.execFile(input, FileOptions.DEFAULT, module, thread);
+
+      } catch (SyntaxError.Exception ex) {
+        for (SyntaxError err : ex.errors()) {
+          System.err.println(err); // includes location
+          ok = false;
+          continue;
+        }
+      } catch (EvalException ex) {
+        System.err.println(ex.getMessageWithStack());
+        ok = false;
+        continue;
+
+      } catch (
+          @SuppressWarnings("InterruptedExceptionSwallowed")
+          Throwable ex) {
+        // unhandled exception (incl. InterruptedException)
+        System.err.printf("in %s: %s\n", file, ex.getMessage());
+        ex.printStackTrace();
+        ok = false;
+        continue;
+      }
+
+      // Sort bench_* functions by name.
+      TreeMap<String, StarlarkFunction> benchmarks = new TreeMap<>();
+      for (Map.Entry<String, Object> e : module.getExportedGlobals().entrySet()) {
+        if (e.getKey().startsWith("bench_") && e.getValue() instanceof StarlarkFunction) {
+          String name = e.getKey();
+          if (filter == null || filter.matcher(basename + ":" + name).find()) {
+            benchmarks.put(name, (StarlarkFunction) e.getValue());
+          }
+        }
+      }
+      if (benchmarks.isEmpty()) {
+        if (filter == null) {
+          System.err.printf("File %s: no bench_* functions\n", file);
+          ok = false;
+        }
+        continue;
+      }
+
+      // Run benchmarks.
+      System.out.printf("File %s:\n", file);
+      System.out.printf(
+          "%-20s %10s %10s %10s %10s %10s\n", //
+          "benchmark", "ops", "cpu/op", "wall/op", "steps/op", "alloc/op");
+      for (Map.Entry<String, StarlarkFunction> e : benchmarks.entrySet()) {
+        String name = e.getKey();
+        System.out.flush(); // help user identify a slow benchmark
+        Benchmark b = run(name, e.getValue(), budgetNanos);
+        if (b == null) {
+          ok = false;
+          continue;
+        }
+        System.out.printf(
+            "%-20s %10d %10s %10s %10d %10s\n",
+            name,
+            b.count,
+            formatDuration(((double) b.time) / b.count),
+            formatDuration(((double) b.cpu) / b.count),
+            b.steps / b.count,
+            formatBytes(b.alloc / b.count));
+      }
+      System.out.println();
+    }
+    if (!ok) {
+      System.exit(1);
+    }
+  }
+
+  private static void fail(String format, Object... args) {
+    System.err.printf(format, args);
+    System.err.println();
+    System.exit(1);
+  }
+
+  // Runs benchmark function f for the specified time budget
+  // (which we may exceed by a factor of two).
+  private static Benchmark run(String name, StarlarkFunction f, long budgetNanos) {
+    Mutability mu = Mutability.create("test");
+    StarlarkThread thread = new StarlarkThread(mu, semantics);
+
+    Benchmark b = new Benchmark();
+
+    // Keep doubling the number of iterations until we exceed the deadline.
+    // TODO(adonovan): opt: extrapolate and predict the number of iterations
+    // in the remaining time budget, being wary of extrapolation error.
+    for (b.n = 1; b.time < budgetNanos; b.n <<= 1) {
+      if (b.n <= 0) {
+        System.err.printf(
+            "In %s: function is too fast; likely a loop over `range(b.n)` is missing\n", name);
+        return null;
+      }
+
+      try {
+        b.start(thread);
+        Starlark.fastcall(thread, f, new Object[] {b}, new Object[0]);
+        b.stop(thread);
+
+      } catch (EvalException ex) {
+        System.err.println(ex.getMessageWithStack());
+        return null;
+
+      } catch (
+          @SuppressWarnings("InterruptedExceptionSwallowed")
+          Throwable ex) {
+        // unhandled exception (incl. InterruptedException)
+        System.err.printf("In %s: %s\n", name, ex.getMessage());
+        ex.printStackTrace();
+        return null;
+      }
+    }
+
+    return b;
+  }
+
+  // The type of the parameter to each bench(b) function.
+  // Provides n, the number of iterations.
+  @StarlarkBuiltin(name = "Benchmark")
+  private static class Benchmark implements StarlarkValue {
+
+    // The cast assumes we use the "Sun" JVM, which measures per-thread allocation and CPU.
+    private final ThreadMXBean threadMX = (ThreadMXBean) ManagementFactory.getThreadMXBean();
+
+    // Starlark attributes
+    private int n; // requested number of iterations
+
+    // current span  (time0 != 0 => started)
+    private long cpu0;
+    private long alloc0;
+    private long time0;
+    private long steps0;
+
+    // accumulators
+    private int count; // iterations
+    private long cpu; // CPU time (ns) in this thread
+    private long alloc; // bytes allocated by this thread
+    private long time; // wall time (ns)
+    private long steps; // Starlark computation steps
+
+    @StarlarkMethod(name = "n", doc = "Requested number of iterations.", structField = true)
+    public int n() {
+      return n;
+    }
+
+    @StarlarkMethod(name = "start", doc = "Starts the timer.", useStarlarkThread = true)
+    public void start(StarlarkThread thread) throws EvalException {
+      if (time0 != 0) {
+        throw Starlark.errorf("timer already started");
+      }
+
+      this.cpu0 = threadMX.getCurrentThreadCpuTime();
+      this.alloc0 = threadMX.getThreadAllocatedBytes(Thread.currentThread().getId());
+      this.steps0 = thread.getExecutedSteps();
+      this.time0 = System.nanoTime();
+    }
+
+    @StarlarkMethod(name = "stop", doc = "Starts the timer.", useStarlarkThread = true)
+    public void stop(StarlarkThread thread) throws EvalException {
+      if (time0 == 0) {
+        throw Starlark.errorf("timer already stopped");
+      }
+      long time1 = System.nanoTime();
+      long steps1 = thread.getExecutedSteps();
+      long alloc1 = threadMX.getThreadAllocatedBytes(Thread.currentThread().getId());
+      long cpu1 = threadMX.getCurrentThreadCpuTime();
+
+      this.time += time1 - this.time0;
+      this.steps += steps1 - this.steps0;
+      this.alloc += alloc1 - this.alloc0;
+      this.cpu += cpu1 - this.cpu0;
+
+      this.count += this.n;
+
+      time0 = 0; // stopped
+    }
+
+    @StarlarkMethod(name = "restart", doc = "Restarts the timer.", useStarlarkThread = true)
+    public void restart(StarlarkThread thread) throws EvalException {
+      time0 = 0; // stop, and discard current span
+      start(thread);
+    }
+
+    @Override
+    public void repr(Printer p) {
+      p.append("<Benchmark>");
+    }
+  }
+
+  private static String formatDuration(double ns) {
+    // (Similar format to Go's time.Duration.)
+    if (ns == 0) {
+      return "0s";
+    } else if (ns < 1e3) {
+      return String.format("%dns", (long) ns);
+    } else if (ns < 1e6) {
+      return String.format("%.3gµs", ns / 1e3);
+    } else if (ns < 1e9) {
+      return String.format("%.6gms", ns / 1e6);
+    } else {
+      return String.format("%.3gs", ns / 1e9);
+    }
+  }
+
+  private static String formatBytes(long bytes) {
+    if (bytes == 0) {
+      return "0B";
+    } else if (bytes < 1e3) {
+      return String.format("%dB", bytes);
+    } else if (bytes < 1e6) {
+      return String.format("%.3gKB", bytes / 1e3);
+    } else if (bytes < 1e9) {
+      return String.format("%.6gMB", bytes / 1e6);
+    } else {
+      return String.format("%.3gGB", bytes / 1e9);
+    }
+  }
+
+  private static final StarlarkSemantics semantics = StarlarkSemantics.DEFAULT;
+
+  private Benchmarks() {}
+}

--- a/libstarlark/src/test/java/net/starlark/java/eval/EvaluationTest.java
+++ b/libstarlark/src/test/java/net/starlark/java/eval/EvaluationTest.java
@@ -396,29 +396,10 @@ public final class EvaluationTest {
 
   @Test
   public void testListComprehensionDefinitionOrder() throws Exception {
-    // This exercises the .bzl file behavior. This is a dynamic error.
-    // (The error message for BUILD files is slightly different (no "local")
-    // because it doesn't record the scope in the syntax tree.)
     ev.new Scenario()
         .testIfErrorContains(
-            "local variable 'y' is referenced before assignment", //
+            "local variable 'y' is referenced before assignment",
             "[x for x in (1, 2) if y for y in (3, 4)]");
-
-    // This is the corresponding test for BUILD files.
-    EvalException ex =
-        assertThrows(
-            EvalException.class, () -> execBUILD("[x for x in (1, 2) if y for y in (3, 4)]"));
-    assertThat(ex).hasMessageThat().isEqualTo("variable 'y' is referenced before assignment");
-  }
-
-  private static void execBUILD(String... lines)
-      throws SyntaxError.Exception, EvalException, InterruptedException {
-    ParserInput input = ParserInput.fromLines(lines);
-    FileOptions options = FileOptions.builder().recordScope(false).build();
-    try (Mutability mu = Mutability.create("test")) {
-      StarlarkThread thread = new StarlarkThread(mu, StarlarkSemantics.DEFAULT);
-      Starlark.execFile(input, options, Module.create(), thread);
-    }
   }
 
   @Test

--- a/libstarlark/src/test/java/net/starlark/java/eval/Examples.java
+++ b/libstarlark/src/test/java/net/starlark/java/eval/Examples.java
@@ -14,7 +14,7 @@
 package net.starlark.java.eval;
 
 import com.google.common.collect.ImmutableMap;
-
+import java.io.IOException;
 import net.starlark.java.annot.Param;
 import net.starlark.java.annot.StarlarkMethod;
 import net.starlark.java.syntax.FileOptions;
@@ -23,8 +23,6 @@ import net.starlark.java.syntax.Program;
 import net.starlark.java.syntax.Resolver;
 import net.starlark.java.syntax.StarlarkFile;
 import net.starlark.java.syntax.SyntaxError;
-
-import java.io.IOException;
 
 /**
  * Examples of typical API usage of the Starlark interpreter.<br>

--- a/libstarlark/src/test/java/net/starlark/java/eval/Examples.java
+++ b/libstarlark/src/test/java/net/starlark/java/eval/Examples.java
@@ -14,15 +14,17 @@
 package net.starlark.java.eval;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-import java.io.IOException;
+
 import net.starlark.java.annot.Param;
 import net.starlark.java.annot.StarlarkMethod;
 import net.starlark.java.syntax.FileOptions;
 import net.starlark.java.syntax.ParserInput;
 import net.starlark.java.syntax.Program;
+import net.starlark.java.syntax.Resolver;
 import net.starlark.java.syntax.StarlarkFile;
 import net.starlark.java.syntax.SyntaxError;
+
+import java.io.IOException;
 
 /**
  * Examples of typical API usage of the Starlark interpreter.<br>
@@ -89,7 +91,8 @@ final class Examples {
     StarlarkFile file = StarlarkFile.parse(input);
 
     // Compile the program, with additional predeclared environment bindings.
-    Program prog = Program.compileFile(file, () -> ImmutableSet.of("zero", "square"));
+    // TODO(adonovan): supply Starlark.UNIVERSE somehow.
+    Program prog = Program.compileFile(file, Resolver.moduleWithPredeclared("zero", "square"));
 
     // . . .
 

--- a/libstarlark/src/test/java/net/starlark/java/eval/ScriptTest.java
+++ b/libstarlark/src/test/java/net/starlark/java/eval/ScriptTest.java
@@ -1,0 +1,318 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package net.starlark.java.eval;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.Files;
+import java.io.File;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+import net.starlark.java.annot.Param;
+import net.starlark.java.annot.StarlarkBuiltin;
+import net.starlark.java.annot.StarlarkMethod;
+import net.starlark.java.lib.json.Json;
+import net.starlark.java.syntax.FileOptions;
+import net.starlark.java.syntax.ParserInput;
+import net.starlark.java.syntax.SyntaxError;
+
+/** Script-based tests of Starlark evaluator. */
+public final class ScriptTest {
+
+  // Tests for Starlark.
+  //
+  // In each test file, chunks are separated by "\n---\n".
+  // Each chunk is evaluated separately.
+  // A comment containing
+  //     ### regular expression
+  // specifies an expected error on that line.
+  // The part after '###', with leading/trailing spaces removed,
+  // must be a valid regular expression matching the error.
+  // If there is no "###", the test will succeed iff there is no error.
+  //
+  // Within the file, the assert_ and assert_eq functions may be used to
+  // report errors without stopping the program. (They are not evaluation
+  // errors that can be caught with a '###' expectation.)
+
+  // TODO(adonovan): improve this test driver (following go.starlark.net):
+  //
+  // - extract support for "chunked files" into a library
+  //   and reuse it for tests of lexer, parser, resolver.
+  // - require that some frame of each EvalException match the file/line of the expectation.
+
+  interface Reporter {
+    void reportError(StarlarkThread thread, String message);
+  }
+
+  @StarlarkMethod(
+      name = "assert_",
+      documented = false,
+      parameters = {
+        @Param(name = "cond"),
+        @Param(name = "msg", defaultValue = "'assertion failed'"),
+      },
+      useStarlarkThread = true)
+  public Object assertStarlark(Object cond, String msg, StarlarkThread thread)
+      throws EvalException {
+    if (!Starlark.truth(cond)) {
+      thread.getThreadLocal(Reporter.class).reportError(thread, "assert_: " + msg);
+    }
+    return Starlark.NONE;
+  }
+
+  @StarlarkMethod(
+      name = "assert_eq",
+      documented = false,
+      parameters = {
+        @Param(name = "x"),
+        @Param(name = "y"),
+      },
+      useStarlarkThread = true)
+  public Object assertEq(Object x, Object y, StarlarkThread thread) throws EvalException {
+    if (!x.equals(y)) {
+      String msg = String.format("assert_eq: %s != %s", Starlark.repr(x), Starlark.repr(y));
+      thread.getThreadLocal(Reporter.class).reportError(thread, msg);
+    }
+    return Starlark.NONE;
+  }
+
+  // Constructor for simple structs, for testing.
+  @StarlarkMethod(name = "struct", documented = false, extraKeywords = @Param(name = "kwargs"))
+  public Struct struct(Dict<String, Object> kwargs) throws EvalException {
+    return new ImmutableStruct(ImmutableMap.copyOf(kwargs));
+  }
+
+  @StarlarkMethod(
+      name = "mutablestruct",
+      documented = false,
+      extraKeywords = @Param(name = "kwargs"))
+  public Struct mutablestruct(Dict<String, Object> kwargs) throws EvalException {
+    return new MutableStruct(kwargs);
+  }
+
+  private static boolean ok = true;
+
+  public static void main(String[] args) throws Exception {
+    File root = new File("third_party/bazel"); // blaze
+    if (!root.exists()) {
+      root = new File("."); // bazel
+    }
+    File testdata = new File(root, "src/test/java/net/starlark/java/eval/testdata");
+    for (String name : testdata.list()) {
+      File file = new File(testdata, name);
+      String content = Files.asCharSource(file, UTF_8).read();
+      int linenum = 1;
+      for (String chunk : Splitter.on("\n---\n").split(content)) {
+        // prepare chunk
+        StringBuilder buf = new StringBuilder();
+        for (int i = 1; i < linenum; i++) {
+          buf.append('\n');
+        }
+        buf.append(chunk);
+        if (false) {
+          System.err.printf("%s:%d: <<%s>>\n", file, linenum, buf);
+        }
+
+        // extract expectations: ### "regular expression"
+        Map<Pattern, Integer> expectations = new HashMap<>();
+        for (int i = chunk.indexOf("###"); i >= 0; i = chunk.indexOf("###", i)) {
+          int j = chunk.indexOf("\n", i);
+          if (j < 0) {
+            j = chunk.length();
+          }
+
+          int line = linenum + newlines(chunk.substring(0, i));
+          String comment = chunk.substring(i + 3, j);
+          i = j;
+
+          // Compile regular expression in comment.
+          Pattern pattern;
+          try {
+            pattern = Pattern.compile(comment.trim());
+          } catch (PatternSyntaxException ex) {
+            System.err.printf("%s:%d: invalid regexp: %s\n", file, line, ex.getMessage());
+            ok = false;
+            continue;
+          }
+
+          if (false) {
+            System.err.printf("%s:%d: expectation '%s'\n", file, line, pattern);
+          }
+          expectations.put(pattern, line);
+        }
+
+        // parse & execute
+        ParserInput input = ParserInput.fromString(buf.toString(), file.toString());
+        ImmutableMap.Builder<String, Object> predeclared = ImmutableMap.builder();
+        Starlark.addMethods(predeclared, new ScriptTest()); // e.g. assert_eq
+        predeclared.put("json", Json.INSTANCE);
+
+        StarlarkSemantics semantics = StarlarkSemantics.DEFAULT;
+        Module module = Module.withPredeclared(semantics, predeclared.build());
+        try (Mutability mu = Mutability.create("test")) {
+          StarlarkThread thread = new StarlarkThread(mu, semantics);
+          thread.setThreadLocal(Reporter.class, ScriptTest::reportError);
+          Starlark.execFile(input, FileOptions.DEFAULT, module, thread);
+
+        } catch (SyntaxError.Exception ex) {
+          // parser/resolver errors
+          //
+          // Static errors cannot be suppressed by expectations:
+          // it would be dangerous because the presence of a static
+          // error prevents execution of any dynamic assertions in
+          // a chunk. Tests of static errors belong in syntax/.
+          for (SyntaxError err : ex.errors()) {
+            System.err.println(err); // includes location
+            ok = false;
+          }
+
+        } catch (EvalException ex) {
+          // evaluation error
+          //
+          // TODO(adonovan): the old logic checks only that each error is matched
+          // by at least one expectation. Instead, ensure that errors
+          // and expections match exactly. Furthermore, look only at errors
+          // whose stack has a frame with a file/line that matches the expectation.
+          // This requires inspecting EvalException stack.
+          // (There can be at most one dynamic error per chunk.
+          // Do we even need to allow multiple expectations?)
+          if (!expected(expectations, ex.getMessage())) {
+            System.err.println(ex.getMessageWithStack());
+            ok = false;
+          }
+
+        } catch (Throwable ex) {
+          // unhandled exception (incl. InterruptedException)
+          System.err.printf(
+              "%s:%d: unhandled %s in this chunk: %s\n",
+              file, linenum, ex.getClass().getSimpleName(), ex.getMessage());
+          ex.printStackTrace();
+          ok = false;
+        }
+
+        // unmatched expectations
+        for (Map.Entry<Pattern, Integer> e : expectations.entrySet()) {
+          System.err.printf("%s:%d: unmatched expectation: %s\n", file, e.getValue(), e.getKey());
+          ok = false;
+        }
+
+        // advance line number
+        linenum += newlines(chunk) + 2; // for "\n---\n"
+      }
+    }
+    if (!ok) {
+      System.exit(1);
+    }
+  }
+
+  // Called by assert_ and assert_eq when the test encounters an error.
+  // Does not stop the program; multiple failures may be reported in a single run.
+  private static void reportError(StarlarkThread thread, String message) {
+    System.err.printf("Traceback (most recent call last):\n");
+    List<StarlarkThread.CallStackEntry> stack = thread.getCallStack();
+    stack = stack.subList(0, stack.size() - 1); // pop the built-in function
+    for (StarlarkThread.CallStackEntry fr : stack) {
+      System.err.printf("%s: called from %s\n", fr.location, fr.name);
+    }
+    System.err.println("Error: " + message);
+    ok = false;
+  }
+
+  private static boolean expected(Map<Pattern, Integer> expectations, String message) {
+    for (Pattern pattern : expectations.keySet()) {
+      if (pattern.matcher(message).find()) {
+        expectations.remove(pattern);
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static int newlines(String s) {
+    int n = 0;
+    for (int i = 0; i < s.length(); i++) {
+      if (s.charAt(i) == '\n') {
+        n++;
+      }
+    }
+    return n;
+  }
+
+  // A trivial struct-like class with Starlark fields defined by a map.
+  private static class Struct implements StarlarkValue, Structure {
+    final Map<String, Object> fields;
+
+    Struct(Map<String, Object> fields) {
+      this.fields = fields;
+    }
+
+    @Override
+    public ImmutableList<String> getFieldNames() {
+      return ImmutableList.copyOf(fields.keySet());
+    }
+
+    @Override
+    public Object getValue(String name) {
+      return fields.get(name);
+    }
+
+    @Override
+    public String getErrorMessageForUnknownField(String name) {
+      return null;
+    }
+
+    @Override
+    public void repr(Printer p) {
+      // This repr function prints only the fields.
+      // Any methods are still accessible through dir/getattr/hasattr.
+      p.append(Starlark.type(this));
+      p.append("(");
+      String sep = "";
+      for (Map.Entry<String, Object> e : fields.entrySet()) {
+        p.append(sep).append(e.getKey()).append(" = ").repr(e.getValue());
+        sep = ", ";
+      }
+      p.append(")");
+    }
+  }
+
+  @StarlarkBuiltin(name = "struct")
+  private static class ImmutableStruct extends Struct {
+    ImmutableStruct(ImmutableMap<String, Object> fields) {
+      super(fields);
+    }
+  }
+
+  @StarlarkBuiltin(name = "mutablestruct")
+  private static class MutableStruct extends Struct {
+    MutableStruct(Dict<String, Object> fields) {
+      super(fields);
+    }
+
+    @Override
+    public void setField(String field, Object value) throws EvalException {
+      if (value.equals("bad")) {
+        throw Starlark.errorf("bad field value");
+      }
+      ((Dict<String, Object>) fields).putEntry(field, value);
+    }
+  }
+}

--- a/libstarlark/src/test/java/net/starlark/java/eval/StarlarkEvaluationTest.java
+++ b/libstarlark/src/test/java/net/starlark/java/eval/StarlarkEvaluationTest.java
@@ -24,6 +24,7 @@ import com.google.errorprone.annotations.DoNotCall;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import net.starlark.java.annot.Param;
 import net.starlark.java.annot.ParamType;
 import net.starlark.java.annot.StarlarkBuiltin;
@@ -195,6 +196,7 @@ public final class StarlarkEvaluationTest {
     }
 
     @StarlarkMethod(name = "nullfunc_working", documented = false, allowReturnNones = true)
+    @Nullable
     public StarlarkValue nullfuncWorking() {
       return null;
     }
@@ -343,7 +345,6 @@ public final class StarlarkEvaluationTest {
     @StarlarkMethod(
         name = "proxy_methods_object",
         doc = "Returns a struct containing all callable method objects of this mock",
-        allowReturnNones = true,
         useStarlarkThread = true)
     public Structure proxyMethodsObject(StarlarkThread thread)
         throws EvalException, InterruptedException {

--- a/libstarlark/src/test/java/net/starlark/java/eval/StarlarkListTest.java
+++ b/libstarlark/src/test/java/net/starlark/java/eval/StarlarkListTest.java
@@ -321,12 +321,20 @@ public final class StarlarkListTest {
 
   @Test
   public void testWrapTakesOwnershipOfArray() throws EvalException {
-    String[] wrapped = {"hello"};
+    Object[] wrapped = {"hello"};
     Mutability mutability = Mutability.create("test");
-    StarlarkList<String> mutableList = StarlarkList.wrap(mutability, wrapped);
+    StarlarkList<Object> mutableList = StarlarkList.wrap(mutability, wrapped);
 
     // Big no-no, but we're proving a point.
     wrapped[0] = "goodbye";
-    assertThat((List<String>) mutableList).containsExactly("goodbye");
+    assertThat((List<?>) mutableList).containsExactly("goodbye");
+  }
+
+  @Test
+  public void testOfReturnsListWhoseArrayElementTypeIsObject() throws EvalException {
+    Mutability mu = Mutability.create("test");
+    StarlarkList<Object> list = StarlarkList.of(mu, "a", "b");
+    list.addElement(StarlarkInt.of(1)); // no ArrayStoreException
+    assertThat(list.toString()).isEqualTo("[\"a\", \"b\", 1]");
   }
 }

--- a/libstarlark/src/test/java/net/starlark/java/eval/testdata/assign.star
+++ b/libstarlark/src/test/java/net/starlark/java/eval/testdata/assign.star
@@ -1,0 +1,6 @@
+# tests of assignment
+
+# computation in a[...]=x expression.
+a = [0, 1, 2, 3, 4, 5]
+a[[i for i in range(6) if i == 2][0]] = "z"
+assert_eq(a, [0, 1, "z", 3, 4, 5])

--- a/libstarlark/src/test/java/net/starlark/java/eval/testdata/bench_int.star
+++ b/libstarlark/src/test/java/net/starlark/java/eval/testdata/bench_int.star
@@ -1,0 +1,56 @@
+_11 = 1 << 11  # 32-bit integer
+_33 = 1 << 33  # 64-bit integer
+_maxlong = (1 << 63) - 1
+_66 = 1 << 66  # BigInteger
+
+def bench_add32(b):
+    for _ in range(b.n):
+        _11 + _11
+        _11 + _11
+        _11 + _11
+        _11 + _11
+        _11 + _11
+        _11 + _11
+        _11 + _11
+        _11 + _11
+        _11 + _11
+        _11 + _11
+
+def bench_add64(b):
+    for _ in range(b.n):
+        _33 + _33
+        _33 + _33
+        _33 + _33
+        _33 + _33
+        _33 + _33
+        _33 + _33
+        _33 + _33
+        _33 + _33
+        _33 + _33
+        _33 + _33
+
+def bench_add64_overflow(b):
+    for _ in range(b.n):
+        _maxlong + _maxlong
+        _maxlong + _maxlong
+        _maxlong + _maxlong
+        _maxlong + _maxlong
+        _maxlong + _maxlong
+        _maxlong + _maxlong
+        _maxlong + _maxlong
+        _maxlong + _maxlong
+        _maxlong + _maxlong
+        _maxlong + _maxlong
+
+def bench_addbig(b):
+    for _ in range(b.n):
+        _66 + _66
+        _66 + _66
+        _66 + _66
+        _66 + _66
+        _66 + _66
+        _66 + _66
+        _66 + _66
+        _66 + _66
+        _66 + _66
+        _66 + _66

--- a/libstarlark/src/test/java/net/starlark/java/eval/testdata/bench_list.star
+++ b/libstarlark/src/test/java/net/starlark/java/eval/testdata/bench_list.star
@@ -1,0 +1,14 @@
+_list1000 = list(range(1000))
+
+def bench_extend(b):
+    "Extends an empty list by 1000 items."
+    for _ in range(b.n):
+        x = []
+        x.extend(_list1000)
+
+def bench_append(b):
+    "Appends 1000 items to an empty list."
+    for _ in range(b.n):
+        x = []
+        for y in _list1000:
+            x.append(y)

--- a/libstarlark/src/test/java/net/starlark/java/eval/testdata/bench_sorted.star
+++ b/libstarlark/src/test/java/net/starlark/java/eval/testdata/bench_sorted.star
@@ -1,0 +1,21 @@
+def random(seed):
+    "Updates seed[0] and returns the next pseudorandom number."
+    x = seed[0]
+    seed[0] = x + 9319 * 125 % 6011
+    return x
+
+def _bench_sort(b, size):
+    seed = [0]
+    orig = [random(seed) for x in range(size)]
+    b.restart()
+    for _ in range(b.n):
+        copy = orig[:]  # TODO(adonovan): move allocation outside loop
+        sorted(copy)
+
+def bench_large(b):
+    "Sort an array of a million ints."
+    _bench_sort(b, 1000000)
+
+def bench_small(b):
+    "Sort an array of ten ints."
+    _bench_sort(b, 10)

--- a/libstarlark/src/test/java/net/starlark/java/eval/testdata/function.star
+++ b/libstarlark/src/test/java/net/starlark/java/eval/testdata/function.star
@@ -42,7 +42,23 @@ assert_eq(str(len), "<built-in function len>")
 x = {}.pop
 x() ###  missing 1 required positional argument: key
 ---
+# Arguments are evaluated in left-to-right order.
+# See https://github.com/bazelbuild/starlark/issues/13.
+order = []
 
+def id(x):
+  order.append(x)
+  return x
+
+def f(*args, **kwargs):
+  return args, kwargs
+
+assert_eq(
+  f(id(1), id(2), x=id(3), *[id(4)], **dict(z=id(5))),
+  ((1, 2, 4), {"x": 3, "z": 5}))
+assert_eq(order, [1, 2, 3, 4, 5])
+
+---
 # getattr
 
 assert_eq(getattr("abc", "upper")(), "ABC")

--- a/libstarlark/src/test/java/net/starlark/java/eval/testdata/int.star
+++ b/libstarlark/src/test/java/net/starlark/java/eval/testdata/int.star
@@ -83,7 +83,7 @@ assert_eq(111111111 * 111111111, 12345678987654321)
 assert_eq(-(111111111 * 111111111), -12345678987654321)
 assert_eq((111111111 * 111111111) // 111111111, 111111111)
 
-# division
+# floored division
 assert_eq(100 // 7, 14)
 assert_eq(100 // -7, -15)
 assert_eq(-100 // 7, -15) # NB: different from Go / Java
@@ -92,12 +92,30 @@ assert_eq(98 // 7, 14)
 assert_eq(98 // -7, -14)
 assert_eq(-98 // 7, -14)
 assert_eq(-98 // -7, 14)
-quot = 1169282 * 1000000 + 890553 # simplify when we have big literals
-assert_eq(product // 1234567, quot)
-assert_eq(product // -1234567, -quot-1)
-assert_eq(-product // 1234567, -quot-1)
-assert_eq(-product // -1234567, quot)
-assert_eq(((-1) << 31) // -1, 2147483647+1) # sole case of int // int that causes int overflow
+assert_eq( product //  1234567,  1169282890553)
+assert_eq( product // -1234567, -1169282890553-1)
+assert_eq(-product //  1234567, -1169282890553-1)
+assert_eq(-product // -1234567,  1169282890553)
+assert_eq(((-1) << 31) // -1, 1 << 31) # sole case of int // int that causes int overflow
+assert_eq(((-1) << 63) // -1, 1 << 63) # ditto, long overflow
+
+# floating-point division of int operands
+assert_eq(str(100 / 7), "14.285714285714286")
+assert_eq(str(100 / -7), "-14.285714285714286")
+assert_eq(str(-100 / 7), "-14.285714285714286")
+assert_eq(str(-100 / -7), "14.285714285714286")
+assert_eq(type(98 / 7), "float")
+assert_eq(98 / 7, 14.0)
+assert_eq(98 / -7, -14.0)
+assert_eq(-98 / 7, -14.0)
+assert_eq(-98 / -7, 14.0)
+assert_eq(type(product /  1234567), "float")
+assert_eq(int( product /  1234567),  1169282890553)
+assert_eq(int( product / -1234567), -1169282890553)
+assert_eq(int(-product /  1234567), -1169282890553)
+assert_eq(int(-product / -1234567),  1169282890553)
+assert_eq(((-1) << 31) / -1, 1 << 31) # sole case of int / int that causes int overflow
+assert_eq(((-1) << 63) / -1, 1 << 63) # ditto, long overflow
 
 # remainder
 assert_eq(100 % 7, 2)
@@ -139,10 +157,20 @@ compound()
 
 # unary operators
 
+assert_eq(+0, 0)
 assert_eq(+4, 4)
-assert_eq(-4, -4)
-assert_eq(++4, 4)
 assert_eq(+-4, -4)
+
+assert_eq(-0, 0)
+assert_eq(-4, 0 - 4)
+assert_eq(-(0 - 4), 4)
+assert_eq(-minint, 0 - minint)
+assert_eq(-maxint, 0 - maxint)
+assert_eq(-minlong, 0 - minlong)
+assert_eq(-maxlong, 0 - maxlong)
+
+assert_eq(++4, 4)
+assert_eq(+-4, 0 - 4)
 assert_eq(-+-4, 4)
 
 ---

--- a/libstarlark/src/test/java/net/starlark/java/syntax/ResolverTest.java
+++ b/libstarlark/src/test/java/net/starlark/java/syntax/ResolverTest.java
@@ -17,12 +17,10 @@ import static com.google.common.truth.Truth.assertThat;
 import static net.starlark.java.syntax.LexerTest.assertContainsError;
 
 import com.google.common.base.Joiner;
-
+import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-
-import java.util.List;
 
 /** Tests of the Starlark resolver. */
 @RunWith(JUnit4.class)

--- a/libstarlark/src/test/java/net/starlark/java/syntax/ResolverTest.java
+++ b/libstarlark/src/test/java/net/starlark/java/syntax/ResolverTest.java
@@ -17,11 +17,12 @@ import static com.google.common.truth.Truth.assertThat;
 import static net.starlark.java.syntax.LexerTest.assertContainsError;
 
 import com.google.common.base.Joiner;
-import com.google.common.collect.ImmutableSet;
-import java.util.List;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+
+import java.util.List;
 
 /** Tests of the Starlark resolver. */
 @RunWith(JUnit4.class)
@@ -35,7 +36,7 @@ public class ResolverTest {
   private StarlarkFile resolveFile(String... lines) throws SyntaxError.Exception {
     ParserInput input = ParserInput.fromLines(lines);
     StarlarkFile file = StarlarkFile.parse(input, options.build());
-    Resolver.resolveFile(file, () -> ImmutableSet.of("pre"));
+    Resolver.resolveFile(file, Resolver.moduleWithPredeclared("pre"));
     return file;
   }
 
@@ -185,6 +186,11 @@ public class ResolverTest {
     List<SyntaxError> errors = getResolutionErrors("a = 1", "a = 2");
     assertContainsError(errors, ":2:1: cannot reassign global 'a'");
     assertContainsError(errors, ":1:1: 'a' previously declared here");
+
+    // global 'pre' shadows predeclared of same name.
+    errors = getResolutionErrors("pre; pre = 1; pre = 2");
+    assertContainsError(errors, ":1:15: cannot reassign global 'pre'");
+    assertContainsError(errors, ":1:6: 'pre' previously declared here");
   }
 
   @Test
@@ -403,6 +409,11 @@ public class ResolverTest {
     // Note: loads bind globally, for now.
     checkBindings("load('module', aᴳ₀='a', bᴳ₁='b')");
 
+    // If a name is bound globally, all toplevel references
+    // resolve to it, even those that precede it.
+    checkBindings("preᴾ₀");
+    checkBindings("preᴳ₀; preᴳ₀=1; preᴳ₀");
+
     checkBindings(
         "aᴳ₀, bᴳ₁ = 0, 0", //
         "def fᴳ₂(aᴸ₀=bᴳ₁):",
@@ -419,7 +430,7 @@ public class ResolverTest {
   // the spaces. The resulting string must match the input.
   private void checkBindings(String... lines) throws Exception {
     String src = Joiner.on("\n").join(lines);
-    StarlarkFile file = resolveFile(src.replaceAll("[₀₁₂₃₄₅₆₇₈₉ᴳᴸᴾᶠᶜ]", " "));
+    StarlarkFile file = resolveFile(src.replaceAll("[₀₁₂₃₄₅₆₇₈₉ᴸᴳᶜᶠᴾᵁ]", " "));
     if (!file.ok()) {
       throw new AssertionError("resolution failed: " + file.errors());
     }
@@ -430,8 +441,8 @@ public class ResolverTest {
         // Replace ...x__... with ...xᴸ₀...
         out[0] =
             out[0].substring(0, id.getEndOffset())
-                + "ᴸᴳᶜᶠᴾ".charAt(id.getBinding().getScope().ordinal()) // follow order of enum
-                + "₀₁₂₃₄₅₆₇₈₉".charAt(id.getBinding().index) // 10 is plenty
+                + "ᴸᴳᶜᶠᴾᵁ".charAt(id.getBinding().getScope().ordinal()) // follow order of enum
+                + "₀₁₂₃₄₅₆₇₈₉".charAt(id.getBinding().getIndex()) // 10 is plenty
                 + out[0].substring(id.getEndOffset() + 2);
       }
     }.visit(file);


### PR DESCRIPTION
- starlark: delete Module.getTransitiveBindings and get Make
clients spell out what they mean instead of just looking for key/value pairs in
random places. Starlark is a statically scoped language, after all.
- starlark: implement "flat frames" optimization. The resolver now statically maps each local variable to a small integer, and the set of local bindings (including from comprehensions) is accumulated into each Resolver.Function. The evaluator uses an array instead of a LinkedHashMap to represent the environment, and no longer needs a hack to save/restore the values of comprehensions. Also, added a test of the resolver.
- starlark: always record resolver information in syntax tree. FileOptions.recordScope(false) is no longer needed.
- Starlark: more 64-bit integer operations without round-trip to BigInteger. Implement faster integer operations for integers within signed 64-bit range:
  * comparison
  * addition
  * subtraction Note JDK has `Math.addExact` function; it cannot cannot be used directly, because thrown exception on overflow results in high performance slowdown (about 3x on my laptop) because stack trace is collected on overflow.
64-bit integer benchmark is significantly faster.
- starlark: fix ArrayStoreException crash in list.append by establishing the invariant that StarlarkList.elems.getClass() == Object[].class. + Test
- starlark: add tests of int / int  …  Also, remove StarklarkInt.divide, which is unused and untested. (int / int is implemented by first converting operands to float.)
- Starlark: microoptimize str[index]  …  Preallocate single-char ASCII strings. ``` def test():  for i in range(1000000):  s = "abcdefghijklmnopqrstuvwxyz"  for j in range(len(s)):  s[j] test() ``` ``` A: N=48, r=3.896+-0.475 B: N=48, r=3.516+-0.571 B/A: 0.902 ``` 
- Starlark: optimize 64-bit integer negation  …  Perform negation of 64-bit integer without roundtrip to `BigInteger`. Not a big deal, but it may be a performance issue in certain cases.
- Starlark: StarlarkCallable.allowReturnNones as Nullable. Functional change is in StarlarkMethodProcessor. Other changes are adding missing Nullable annotations (or removing unnecessary allowReturnNones, for example when returning None or primitive types). At this point @nullable annotation does almost nothing, but if we decide to use nullness checker, the checker would guarantee that a method may return null iff annotated.
- Starlark: only nested classes of StarlarkInt are allowed to inherit it. Minor code cleanup