### PR TITLE
make  flexible the larky executable path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,7 +131,7 @@ jobs:
     steps:
       - checkout
       - <<: *attach-workspace
-      - run: cp ./larky/target/larky-runner .
+      - run: cp ./larky/target/larky-runner ./pylarky/bin/
       - run:
           name: Python test
           command: |

--- a/pylarky/bin/.gitignore
+++ b/pylarky/bin/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/pylarky/starlarky.py
+++ b/pylarky/starlarky.py
@@ -2,7 +2,10 @@ import os
 import tempfile
 from subprocess import STDOUT, check_output, CalledProcessError
 
-LARKY_RUNNER_EXECUTABLE = os.environ.get('LARKY_RUNNER_EXECUTABLE', 'larky-runner')
+import pkg_resources
+
+LARKY_RUNNER_EXECUTABLE = os.environ.get('LARKY_RUNNER_EXECUTABLE',
+                                         pkg_resources.resource_filename(__name__, "bin/larky-runner"))
 LARKY_INPUT_PARAM = os.environ.get('LARKY_INPUT_PARAM', '-input')
 LARKY_OUTPUT_PARAM = os.environ.get('LARKY_OUTPUT_PARAM', '-output')
 

--- a/pylarky/starlarky.py
+++ b/pylarky/starlarky.py
@@ -1,9 +1,10 @@
+import os
 import tempfile
-from subprocess import PIPE, STDOUT, check_output, CalledProcessError
+from subprocess import STDOUT, check_output, CalledProcessError
 
-RUNNER_EXECUATBLE = 'larky-runner'
-INPUT_PARAM = '-input'
-OUTPUT_PARAM = '-output'
+LARKY_RUNNER_EXECUTABLE = os.environ.get('LARKY_RUNNER_EXECUTABLE', 'larky-runner')
+LARKY_INPUT_PARAM = os.environ.get('LARKY_INPUT_PARAM', '-input')
+LARKY_OUTPUT_PARAM = os.environ.get('LARKY_OUTPUT_PARAM', '-output')
 
 
 def evaluate(script, input_data: str) -> str:
@@ -16,9 +17,9 @@ def evaluate(script, input_data: str) -> str:
 
 def __evaluate(script, input_path, output_path):
     try:
-        check_output([RUNNER_EXECUATBLE,
-                      INPUT_PARAM, input_path,
-                      OUTPUT_PARAM, output_path,
+        check_output([LARKY_RUNNER_EXECUTABLE,
+                      LARKY_INPUT_PARAM, input_path,
+                      LARKY_OUTPUT_PARAM, output_path,
                       script], stderr=STDOUT)
     except CalledProcessError as e:
         raise FailedEvaluation(f'Starlark evaluation failed. \nOutput: {e.output}') from e

--- a/setup.py
+++ b/setup.py
@@ -8,5 +8,5 @@ setup(
     description='Python wrapper for starlarky runner',
     author='Very Good Security',
     license='Apache License v2.0',
-    data_files=[('bin', ['larky-runner'])]
+    package_data={"pylarky": ["bin/larky-runner"]},
 )


### PR DESCRIPTION
- allow optionally to define the larky executable location and arguments, using environmental variables

- change `data_files`  keyword on setup.py for `package_data`, `data_files` is deprecated https://setuptools.readthedocs.io/en/latest/references/keywords.html

- add a bin folder under pylark where the binary should be located before run `setup.py`

- instead of call `larky-runner` directly it now locate the resource using the `pkg_resources` module to make it easy to distribute. based on this discussion: https://stackoverflow.com/questions/39104/finding-a-file-in-a-python-module-distribution
