### PR TITLE
Fix Failing CI setup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
             <groupId>org.conscrypt</groupId>
             <artifactId>conscrypt-openjdk</artifactId>
             <version>${org.conscrypt.version}</version>
-            <classifier>${os.detected.classifier}</classifier>
+            <classifier>${os.detected.name}-${os.detected.arch}</classifier>
         </dependency>
 
         <dependency>
@@ -161,6 +161,14 @@
     </dependencies>
 
     <build>
+        <extensions>
+            <extension>
+              <groupId>kr.motd.maven</groupId>
+              <artifactId>os-maven-plugin</artifactId>
+              <version>${os-maven-plugin.version}</version>
+            </extension>
+        </extensions>
+
         <plugins>
 
             <plugin>
@@ -213,19 +221,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
                 <version>${maven.source.plugin.version}</version>
-            </plugin>
-            <plugin>
-                <groupId>kr.motd.maven</groupId>
-                <artifactId>os-maven-plugin</artifactId>
-                <version>${os-maven-plugin.version}</version>
-                <executions>
-                    <execution>
-                        <phase>initialize</phase>
-                        <goals>
-                            <goal>detect</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/runlarky/pom.xml
+++ b/runlarky/pom.xml
@@ -85,7 +85,12 @@
                 <version>${protobuf-maven-plugin}</version>
                 <configuration>
                     <protocArtifact>
-                        com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}
+                    <!--
+                        See https://github.com/verygoodsecurity/starlarky/pull/58 for why
+                        ${os.detected.classifier} didn't work in some cases for my environment but
+                        ${os.detected.name}-${os.detected.arch} works better!
+                    -->
+                        com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.name}-${os.detected.arch}
                     </protocArtifact>
                 </configuration>
                 <executions>

--- a/runlarky/src/main/resources/reflect-config.json
+++ b/runlarky/src/main/resources/reflect-config.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "com.verygood.security.larky.nativelib.LarkyGlobals",
+    "name": "com.verygood.security.larky.modules.globals.LarkyGlobals",
     "allDeclaredFields": true,
     "allDeclaredMethods": true,
     "allPublicMethods": true,
@@ -8,7 +8,7 @@
     "allPublicConstructors": true
   },
   {
-    "name": "com.verygood.security.larky.nativelib.PythonBuiltins",
+    "name": "com.verygood.security.larky.modules.globals.PythonBuiltins",
     "allDeclaredFields": true,
     "allDeclaredMethods": true,
     "allPublicMethods": true,
@@ -16,7 +16,7 @@
     "allPublicConstructors": true
   },
   {
-    "name": "com.verygood.security.larky.nativelib.std.Json",
+    "name": "com.verygood.security.larky.modules.JsonModule",
     "allDeclaredFields": true,
     "allDeclaredMethods": true,
     "allPublicMethods": true,
@@ -24,7 +24,7 @@
     "allPublicConstructors": true
   },
   {
-    "name": "com.verygood.security.larky.nativelib.std.Proto",
+    "name": "com.verygood.security.larky.modules.ProtoBufModule",
     "allDeclaredFields": true,
     "allDeclaredMethods": true,
     "allPublicMethods": true,
@@ -32,7 +32,7 @@
     "allPublicConstructors": true
   },
   {
-    "name": "com.verygood.security.larky.nativelib.std.C99Math",
+    "name": "com.verygood.security.larky.modules.C99MathModule",
     "allDeclaredFields": true,
     "allDeclaredMethods": true,
     "allPublicMethods": true,
@@ -40,7 +40,7 @@
     "allPublicConstructors": true
   },
   {
-    "name": "com.verygood.security.larky.nativelib.std.Hashlib",
+    "name": "com.verygood.security.larky.modules.HashModule",
     "allDeclaredFields": true,
     "allDeclaredMethods": true,
     "allPublicMethods": true,
@@ -48,7 +48,7 @@
     "allPublicConstructors": true
   },
   {
-    "name": "com.verygood.security.larky.stdtypes.structs.MutableStruct",
+    "name": "com.verygood.security.larky.modules.RegexModule",
     "allDeclaredFields": true,
     "allDeclaredMethods": true,
     "allPublicMethods": true,
@@ -56,7 +56,7 @@
     "allPublicConstructors": true
   },
   {
-    "name": "com.verygood.security.larky.stdtypes.structs.SimpleStruct",
+    "name": "com.verygood.security.larky.types.structs.MutableStruct",
     "allDeclaredFields": true,
     "allDeclaredMethods": true,
     "allPublicMethods": true,
@@ -64,7 +64,23 @@
     "allPublicConstructors": true
   },
   {
-    "name": "com.verygood.security.larky.nativelib.LarkyProperty",
+    "name": "com.verygood.security.larky.types.structs.SimpleStruct",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true
+  },
+  {
+    "name": "com.verygood.security.larky.types.Property",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allPublicMethods": true,
+    "allDeclaredConstructors": true,
+    "allPublicConstructors": true
+  },
+  {
+    "name": "com.verygood.security.larky.types.Partial",
     "allDeclaredFields": true,
     "allDeclaredMethods": true,
     "allPublicMethods": true,
@@ -89,14 +105,6 @@
   },
   {
     "name": "net.starlark.java.eval.StarlarkList",
-    "allDeclaredFields": true,
-    "allDeclaredMethods": true,
-    "allPublicMethods": true,
-    "allDeclaredConstructors": true,
-    "allPublicConstructors": true
-  },
-  {
-    "name": "com.verygood.security.larky.stdtypes.hashing.HashObject",
     "allDeclaredFields": true,
     "allDeclaredMethods": true,
     "allPublicMethods": true,

--- a/runlarky/src/main/resources/reflect-config.json
+++ b/runlarky/src/main/resources/reflect-config.json
@@ -56,7 +56,7 @@
     "allPublicConstructors": true
   },
   {
-    "name": "com.verygood.security.larky.types.structs.MutableStruct",
+    "name": "com.verygood.security.larky.modules.types.structs.MutableStruct",
     "allDeclaredFields": true,
     "allDeclaredMethods": true,
     "allPublicMethods": true,
@@ -64,7 +64,7 @@
     "allPublicConstructors": true
   },
   {
-    "name": "com.verygood.security.larky.types.structs.SimpleStruct",
+    "name": "com.verygood.security.larky.modules.types.structs.SimpleStruct",
     "allDeclaredFields": true,
     "allDeclaredMethods": true,
     "allPublicMethods": true,
@@ -72,7 +72,7 @@
     "allPublicConstructors": true
   },
   {
-    "name": "com.verygood.security.larky.types.Property",
+    "name": "com.verygood.security.larky.modules.types.Property",
     "allDeclaredFields": true,
     "allDeclaredMethods": true,
     "allPublicMethods": true,
@@ -80,7 +80,7 @@
     "allPublicConstructors": true
   },
   {
-    "name": "com.verygood.security.larky.types.Partial",
+    "name": "com.verygood.security.larky.modules.types.Partial",
     "allDeclaredFields": true,
     "allDeclaredMethods": true,
     "allPublicMethods": true,


### PR DESCRIPTION
Our circleci setup is failing currently because of a minor problem that I ran into with [os-maven-plugin](https://github.com/trustin/os-maven-plugin) when working on #55. After upgrading it to 1.7.0, I couldn't use `${os.detected.classifier}` any longer so I had to pass a flag to maven locally. This transient change was probably due to a misconfigured environment on my part, so to fix it, I had found a workaround to the traditional way of installing this maven plugin. [I set it up to use a `<plugin/>` instead of `<extension/>`](https://github.com/verygoodsecurity/starlarky/blob/master/pom.xml#L217-L229). The goals this plugin ran on are not the same ones that we use in our circleci setup. 

This PR fixes the issue by reverting this change back to an `<extension/>` and uses `${os.detected.name}-${os.detected.arch}`  instead of `${os.detected.classifier}` which worked better for us.