### PR TITLE
Minor module restructuring and spec conformance to str() and repr() for bytes. [3 of n]

### DIFF
--- a/larky/src/main/java/com/verygood/security/larky/modules/CodecsModule.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/CodecsModule.java
@@ -2,8 +2,8 @@ package com.verygood.security.larky.modules;
 
 import com.google.common.primitives.Bytes;
 
-import com.verygood.security.larky.modules.io.TextUtil;
-import com.verygood.security.larky.modules.types.LarkyByteArray;
+import com.verygood.security.larky.modules.codecs.TextUtil;
+import com.verygood.security.larky.modules.types.LarkyByte;
 
 import net.starlark.java.annot.Param;
 import net.starlark.java.annot.ParamType;
@@ -14,7 +14,6 @@ import net.starlark.java.eval.StarlarkInt;
 import net.starlark.java.eval.StarlarkList;
 import net.starlark.java.eval.StarlarkValue;
 
-import java.nio.charset.CharacterCodingException;
 import java.util.stream.Collectors;
 
 
@@ -82,7 +81,7 @@ public class CodecsModule implements StarlarkValue {
           @Param(
               name = "obj",
               allowedTypes = {
-                  @ParamType(type = LarkyByteArray.class),
+                  @ParamType(type = LarkyByte.class),
               }
           ),
           @Param(
@@ -103,11 +102,7 @@ public class CodecsModule implements StarlarkValue {
           )
       }
   )
-  public String decode(LarkyByteArray bytesToDecode, String encoding, String errors) throws EvalException {
-    try {
-      return TextUtil.decode(bytesToDecode.toBytes());
-    } catch (CharacterCodingException e) {
-      throw new EvalException(e);
-    }
-}
+  public String decode(LarkyByte bytesToDecode, String encoding, String errors) {
+      return TextUtil.starlarkDecodeUtf8(bytesToDecode.toBytes());
+  }
 }

--- a/larky/src/main/java/com/verygood/security/larky/modules/codecs/UnicodeTables.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/codecs/UnicodeTables.java
@@ -7,7 +7,7 @@
 // Generated at 2020-06-09T16:20:06.352Z by Java 1.8.0_181 using Unicode version 6.0.0.0.
 // Do not change this file, your edits will be lost. Instead change UnicodeTablesGenerator.java.
 
-package com.verygood.security.larky.modules.io;
+package com.verygood.security.larky.modules.codecs;
 
 
 import java.util.Collections;

--- a/larky/src/main/java/com/verygood/security/larky/modules/globals/LarkyGlobals.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/globals/LarkyGlobals.java
@@ -2,9 +2,9 @@ package com.verygood.security.larky.modules.globals;
 
 import com.verygood.security.larky.annot.Library;
 import com.verygood.security.larky.annot.StarlarkConstructor;
-import com.verygood.security.larky.modules.io.TextUtil;
-import com.verygood.security.larky.modules.types.LarkyByteArrIterable;
-import com.verygood.security.larky.modules.types.LarkyByteArray;
+import com.verygood.security.larky.modules.codecs.TextUtil;
+import com.verygood.security.larky.modules.types.LarkyByte;
+import com.verygood.security.larky.modules.types.LarkyByteElems;
 import com.verygood.security.larky.modules.types.Partial;
 import com.verygood.security.larky.modules.types.Property;
 import com.verygood.security.larky.modules.types.structs.SimpleStruct;
@@ -20,6 +20,7 @@ import net.starlark.java.eval.Starlark;
 import net.starlark.java.eval.StarlarkCallable;
 import net.starlark.java.eval.StarlarkFunction;
 import net.starlark.java.eval.StarlarkInt;
+import net.starlark.java.eval.StarlarkIterable;
 import net.starlark.java.eval.StarlarkList;
 import net.starlark.java.eval.StarlarkThread;
 import net.starlark.java.eval.Tuple;
@@ -34,9 +35,9 @@ import java.nio.charset.UnsupportedCharsetException;
  * A library of Larky values (keyed by name) that are not part of core Starlark but are common to
  * all Larky star scripts. Examples: struct, json, etc..
  *
- * Namespaced by _ and should only be accessable via @stdlib/larky:
+ * Namespaced by _ and should only be accessible via @stdlib//larky:
  *
- * load("@stdlib/larky", "larky")
+ * load("@stdlib//larky", "larky")
  */
 @Library
 public final class LarkyGlobals {
@@ -128,42 +129,7 @@ public final class LarkyGlobals {
         .build();
   }
 
-  // todo: move this out of here
-  static class CodecHelper {
-    public static final String STRICT = "strict";
-    public static final String IGNORE = "ignore";
-    public static final String REPLACE = "replace";
-    public static final String BACKSLASHREPLACE = "backslashreplace";
-    public static final String NAMEREPLACE = "namereplace";
-    public static final String XMLCHARREFREPLACE = "xmlcharrefreplace";
-    public static final String SURROGATEESCAPE = "surrogateescape";
-    public static final String SURROGATEPASS = "surrogatepass";
-
-    static CodingErrorAction convertCodingErrorAction(String errors) {
-      CodingErrorAction errorAction;
-      switch (errors) {
-        case IGNORE:
-          errorAction = CodingErrorAction.IGNORE;
-          break;
-        case REPLACE:
-        case NAMEREPLACE:
-          errorAction = CodingErrorAction.REPLACE;
-          break;
-        case STRICT:
-        case BACKSLASHREPLACE:
-        case SURROGATEPASS:
-        case SURROGATEESCAPE:
-        case XMLCHARREFREPLACE:
-        default:
-          errorAction = CodingErrorAction.REPORT;
-          break;
-      }
-      return errorAction;
-    }
-
-  }
-
-  @StarlarkMethod(
+   @StarlarkMethod(
       name = "_as_bytearray",
       doc = "Construct an immutable array of bytes from:\n" +
           "  - an iterable yielding integers in range(256)\n" +
@@ -181,14 +147,7 @@ public final class LarkyGlobals {
           "\n" +
           "bytes(string, encoding[, errors]) -> bytes",
       parameters = {
-          @Param(name = "obj", allowedTypes = {
-              @ParamType(type = NoneType.class),
-              @ParamType(type = String.class),
-              @ParamType(type = LarkyByteArray.class),
-              @ParamType(type = LarkyByteArrIterable.class),
-              @ParamType(type = StarlarkInt.class),
-              @ParamType(type = StarlarkList.class),
-          }, defaultValue = "None"),
+          @Param(name = "obj"),
           @Param(name = "encoding", allowedTypes = {
               @ParamType(type = NoneType.class),
               @ParamType(type = String.class),
@@ -200,16 +159,23 @@ public final class LarkyGlobals {
       },
       useStarlarkThread = true
   )
-  public LarkyByteArray asByteArray(
+  public LarkyByte asByteArray(
       Object _obj,
       Object _encoding,
       Object _errors,
       StarlarkThread thread
   ) throws EvalException {
+     if(!LarkyByte.class.isAssignableFrom(_obj.getClass())
+         && !StarlarkIterable.class.isAssignableFrom(_obj.getClass())
+         && !String.class.isAssignableFrom(_obj.getClass())
+         && !NoneType.class.isAssignableFrom(_obj.getClass())) {
+       throw Starlark.errorf("want string, bytes, or iterable of ints. got %s", Starlark.type(_obj));
+     }
+
     //bytes() -> empty bytes object
-    if (Starlark.isNullOrNone(_obj) || LarkyByteArray.class.isAssignableFrom(_obj.getClass())) {
+    if (Starlark.isNullOrNone(_obj) || LarkyByte.class.isAssignableFrom(_obj.getClass())) {
       //TODO(mahmoudimus): potential copy constructor bug if class really is larkybyte..test this!
-      return StarlarkUtil.convertFromNoneable(_obj, new LarkyByteArray(thread));
+      return StarlarkUtil.convertFromNoneable(_obj, new LarkyByte(thread));
     }
 
     // handle case where string is passed in.
@@ -243,8 +209,8 @@ public final class LarkyGlobals {
           codecs.register_error that can handle UnicodeEncodeErrors.
        */
 
-      CodingErrorAction errs = CodecHelper.convertCodingErrorAction(
-          StarlarkUtil.convertFromNoneable(_errors, CodecHelper.STRICT)
+      CodingErrorAction errs = TextUtil.CodecHelper.convertCodingErrorAction(
+          StarlarkUtil.convertFromNoneable(_errors, TextUtil.CodecHelper.STRICT)
       );
 
       CharsetDecoder decoder = charset.newDecoder();
@@ -252,7 +218,7 @@ public final class LarkyGlobals {
       decoder.onUnmappableCharacter(CodingErrorAction.REPLACE);
       decoder.replaceWith(String.valueOf(TextUtil.REPLACEMENT_CHAR));
       //bytes(string, encoding[, errors]) -> bytes
-      return new LarkyByteArray(
+      return new LarkyByte(
           thread,
           decoder.charset()
               .encode(TextUtil.unescapeJavaString((String) _obj))
@@ -272,11 +238,11 @@ public final class LarkyGlobals {
     try {
       switch (classType) {
         case "int":
-          return new LarkyByteArray(thread, ((StarlarkInt) _obj).toIntUnchecked());
+          return new LarkyByte(thread, ((StarlarkInt) _obj).toIntUnchecked());
         case "bytes.elems":
-          return new LarkyByteArray(thread, (LarkyByteArrIterable) _obj);
+          return new LarkyByte(thread, (LarkyByteElems) _obj);
         case "list":
-          return new LarkyByteArray(thread, (StarlarkList<?>) _obj);
+          return new LarkyByte(thread, (StarlarkList<?>) _obj);
         default:
           throw Starlark.errorf("unable to convert '%s' to bytes", classType);
       }

--- a/larky/src/main/java/com/verygood/security/larky/modules/types/LarkyByteElems.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/types/LarkyByteElems.java
@@ -1,6 +1,6 @@
 package com.verygood.security.larky.modules.types;
 
-import com.verygood.security.larky.modules.io.TextUtil;
+import com.verygood.security.larky.modules.codecs.TextUtil;
 
 import net.starlark.java.annot.StarlarkBuiltin;
 import net.starlark.java.eval.Mutability;
@@ -12,15 +12,15 @@ import java.util.AbstractList;
 
 // A function that returns "fromValues".
 @StarlarkBuiltin(name = "bytes.elems")
-public class LarkyByteArrIterable extends AbstractList<StarlarkInt> implements Sequence<StarlarkInt> {
+public class LarkyByteElems extends AbstractList<StarlarkInt> implements Sequence<StarlarkInt> {
 
-  final private LarkyByteArray byteArray;
+  final private LarkyByte byteArray;
 
-  public LarkyByteArrIterable(LarkyByteArray byteArray) {
+  public LarkyByteElems(LarkyByte byteArray) {
     this.byteArray = byteArray;
   }
 
-  public LarkyByteArray getLarkyByteArr() {
+  public LarkyByte getLarkyByteArr() {
     return byteArray;
   }
 

--- a/larky/src/test/resources/stdlib_tests/test_bytes.star
+++ b/larky/src/test/resources/stdlib_tests/test_bytes.star
@@ -1,46 +1,17 @@
 """Unit tests for test_bytes.star"""
 
-load("@stdlib/larky", "larky")
-load("@stdlib/asserts", "asserts")
-load("@stdlib/unittest", "unittest")
-load("@stdlib/builtins", "builtins")
-load("@stdlib/types", "types")
-load("@stdlib/codecs", "codecs")
-load("@stdlib/escapes", "escapes")
+load("@stdlib//larky", "larky")
+load("@vendor//asserts", "asserts")
+load("@stdlib//unittest", "unittest")
+load("@stdlib//builtins", "builtins")
+load("@stdlib//types", "types")
+load("@stdlib//codecs", "codecs")
+load("@vendor//escapes", "escapes")
 
 
 # Tests of 'bytes' (immutable byte strings).
 b = builtins.b
 
-
-# my hack for string escapes
-def string_literal_escape(sequence, escape_char):
-    return r"\%s%s" % (escape_char, sequence)
-
-
-x = larky.partial(string_literal_escape, escape_char="x")
-u = larky.partial(string_literal_escape, escape_char="u")
-U = larky.partial(string_literal_escape, escape_char="U")
-
-
-# remember: decode bytes into string, encode string into bytes
-def _decode(s):
-    return codecs.decode(s, encoding='utf-8', errors='replace')
-
-
-def _encode(s):
-    x = codecs.encode(s, encoding='utf-8')
-    return x
-
-
-def debug(s):
-    print(s, _decode(b(s)))
-    return s
-
-# array.array(
-#  'B',
-#  104, 101, 108, 108, 111, 44, 32, 228, 184, 150, 239, 191, 189, 239, 191, 189]
-# ).tobytes().decode('utf-8') == b"hello, 世��"
 
 # bytes(string) -- UTF-k to UTF-8 transcoding with U+FFFD replacement
 # A bit on replacement:
@@ -53,10 +24,14 @@ hello = builtins.bytes("hello, 世界")
 goodbye = builtins.bytes("goodbye")
 empty = builtins.bytes("")
 
-#nonprinting = builtins.bytes("\t\n\x7F\u200D")  # TAB, NEWLINE, DEL, ZERO_WIDTH_JOINER
-nonprinting = builtins.bytes(escapes.CEscape().raw("\t\n").x("7f").u("200D"))
+nonprinting = builtins.bytes(escapes.CEscape()
+                             .raw("\t\n") # TAB, NEWLINE,
+                             .x("7f") # DEL,
+                             .u("200D")) # ZERO_WIDTH_JOINER
 
 sliced = builtins.bytes("hello, 世界")[:-1]
+# assert.eq(bytes("hello, 世界"[:-1]), b"hello, 世��")
+hello_sliced = "hello, 世界"[:-1]
 
 
 def _test_bytes_are_ints():
@@ -65,8 +40,8 @@ def _test_bytes_are_ints():
     # int in bytes
     asserts.assert_that(97 in b("abc")).is_equal_to(True)  # 97='a'
     asserts.assert_that(100 in b("abc")).is_equal_to(False) # 100='d'
-    # asserts.assert_fails(lambda: 256 in b("abc"), "int in bytes: 256 out of range")
-    # asserts.assert_fails(lambda: -1 in b("abc"), "int in bytes: -1 out of range")
+    asserts.assert_fails(lambda: 256 in b("abc"), "int in bytes: 256 out of range")
+    asserts.assert_fails(lambda: -1 in b("abc"), "int in bytes: -1 out of range")
 
 
 def _test_bytes_vs_string():
@@ -88,24 +63,19 @@ def _test_bytes_vs_string():
     ]))
     asserts.assert_that(
         codecs.decode(sliced, encoding='utf-8', errors='replace')
-    ).is_equal_to("hello, 世�")
+    ).is_equal_to(r"hello, 世\xe7\x95")
 
 
 def _test_bytes_construction():
     # # bytes(iterable of int) -- construct from numeric byte values
-    # assert.eq(bytes([65, 66, 67]), b"ABC")
-    # assert.eq(bytes((65, 66, 67)), b"ABC")
-    # assert.eq(bytes([0xf0, 0x9f, 0x98, 0xbf]), b"😿")
-    # print(builtins.bytes([65, 66, 67]))
-    # TODO: deviation from starlark spec, we can allocate integers...though maybe
-    #  we should remove this..
-    #  asserts.assert_fails(lambda: builtins.bytes(1), "want string, bytes, or iterable of ints")
+    asserts.assert_fails(lambda: builtins.bytes(1),
+                         "want string, bytes.*or iterable")
     asserts.assert_that(builtins.bytes([65, 66, 67])).is_equal_to(b("ABC"))
     asserts.assert_that(builtins.bytes([0xf0, 0x9f, 0x98, 0xbf])).is_equal_to(b("😿"))
     asserts.assert_fails(lambda: builtins.bytes([300]),
                   "out of range: 300, want value in unsigned 8-bit range")
     asserts.assert_fails(lambda: builtins.bytes([b("a")]),
-                 "Cannot cast .*LarkyByteArray to .*StarlarkInt")
+                 "Cannot cast .*LarkyByte to .*StarlarkInt")
 
     # literals .... not really b() simulates a literal...
     asserts.assert_that(b("hello, 世界")).is_equal_to(hello)
@@ -113,27 +83,6 @@ def _test_bytes_construction():
     asserts.assert_that(b("")).is_equal_to(empty)
     asserts.assert_that(b(escapes.CEscape().raw("\t\n").x("7f").u("200D"))).is_equal_to(nonprinting)
     asserts.assert_that("abc").is_not_equal_to(b("abc"))
-
-
-def _test_escape_literal_workaround():
-    escaped = escapes.CEscape().raw("\012").x("ff").u("0400").U("0001F63F")
-    print(_decode(b(''.join(escaped.literal))))
-    print(escaped)
-    print(repr(escaped))
-    print(type(escaped))
-    asserts.assert_that(
-        #b(debug("\012" +
-        b("\012" +
-                string_literal_escape("ff", "x") +
-                string_literal_escape("0400", "u") +
-                string_literal_escape("0001F63F", "U"))
-        ).is_equal_to(b("\n" + string_literal_escape("ff", "x") + "Ѐ😿")) # see scanner tests for more
-    asserts.assert_that(b("".join(["\012", x("ff"), u("0400"), U("0001F63F")]))).is_equal_to(b(r"\n\xffЀ😿")) # see scanner tests for more
-    # TODO: because there are no byte literals, the following assert statement
-    #  asserts.assert_that(b("\012\xff\u0400\U0001F63F")).is_equal_to(b(r"\n\xffЀ😿")) # see scanner tests for more
-    #  has been converted to:
-    asserts.assert_that(b(escaped)).is_equal_to(b(escapes.CEscape().esc("n").x("ff").raw("Ѐ😿")))
-    asserts.assert_that(b(r"\r\n\t")).is_equal_to(builtins.bytes("\\r\\n\\t")) # raw
 
 
 # type
@@ -159,29 +108,33 @@ def _test_truthiness():
     asserts.assert_true(not empty)
 
 
-def _test_codecs_does_transcoding():
-    # TODO(mahmoudimus): we are deviating from the starlark spec
-    # TODO(mahmoudimus): resolve this:
-    #  - starlark does incomplete UTF-8 encoding => U+FFFD
-    #  - python drops it
-    asserts.assert_that(codecs.decode(hello)).is_equal_to("hello, 世界")
-    asserts.assert_that(codecs.decode(hello[:-1])).is_equal_to("hello, 世�")
-    asserts.assert_that(codecs.decode(goodbye)).is_equal_to("goodbye")
-    asserts.assert_that(codecs.decode(empty)).is_equal_to("")
-    # asserts.assert_that(codecs.decode(nonprinting)).is_equal_to("\t\n\x7f\u200d")
-    # asserts.assert_that(codecs.decode(b"\xED\xB0\x80")).is_equal_to("���") # UTF-8 encoding of unpaired surrogate => U+FFFD x 3
+def _test_str_does_transcoding():
+    # starlark spec says that str(bytes) does UTF-8 to UTF-k transcoding.
+    # where K matches the encoding of the host language:
+    #   golang + rust = utf-8 to utf-8
+    #   java = utf-8 to utf-16
+    asserts.assert_that(str(hello)).is_equal_to("hello, 世界")
+    asserts.assert_that(str(hello[:-1])).is_equal_to(r"hello, 世\xe7\x95")
+    asserts.assert_that(str(goodbye)).is_equal_to("goodbye")
+    asserts.assert_that(str(empty)).is_equal_to("")
+    #asserts.assert_that(str(nonprinting)).is_equal_to("\t\n\x7f\u200d")
+    f = builtins.bytes([237, 176, 128])
+    print(repr(f))
+    asserts.assert_that(
+        str(f)
+        # UTF-8 encoding of unpaired surrogate => U+FFFD (for Java).
+        # Compare to Golang, (this is U+FFFD * 3)
+    ).is_equal_to("�")
 
 
 def _test_repr_for_bytes():
     # repr
-    asserts.assert_that(repr(hello)).is_equal_to(r"b'hello, 世界'")
-    asserts.assert_that(repr(goodbye)).is_equal_to("b'goodbye'")
-    asserts.assert_that(repr(empty)).is_equal_to("b''")
-    # TODO(mahmoudimus): I think the repr just has to be the escaped string
-    # TODO: fix
-    # asserts.assert_that(repr(hello[:-1])).is_equal_to(r"b'hello, 世\xe7\x95'")  # (incomplete UTF-8 encoding )
-    # asserts.assert_that(repr(nonprinting)).is_equal_to(r"b'\\t\\n\\x7f\\u200d'")
-
+    asserts.assert_that(repr(hello)).is_equal_to(r'b"hello, 世界"')
+    asserts.assert_that(repr(goodbye)).is_equal_to('b"goodbye"')
+    asserts.assert_that(repr(empty)).is_equal_to('b""')
+    # assert.eq(repr(nonprinting), 'b"\\t\\n\\x7f\\u200d"')
+    asserts.assert_that(repr(nonprinting)).is_equal_to('b"\\t\\n\\x7f\\u200d"')
+    asserts.assert_that(repr(hello[:-1])).is_equal_to(r'b"hello, 世\xe7\x95"')  # (incomplete UTF-8 encoding )
 
 # equality
 def _test_equality():
@@ -194,16 +147,20 @@ def _test_equality():
 def _test_ordered_comparison():
     asserts.assert_that(b("abc")).is_less_than(b("abd"))
     asserts.assert_that(b("abc")).is_less_than(b("abcd"))
-    asserts.assert_that(b(x("7f"))).is_less_than(b(x("80"))) # bytes compare as uint8, not int8
+
+    asserts\
+        .assert_that(b(escapes.CEscape().x("7f")))\
+        .is_less_than(b(escapes.CEscape().x("80"))) # bytes compare as uint8, not int8
 
 
 def _test_bytes_are_dict_hashable():
     # bytes are dict-hashable
     # -> # decode bytes into string!
-    dict = {_decode(hello): 1, _decode(goodbye): 2}
-    dict[_decode(b("goodbye"))] = 3
+    #dict = {_decode(hello): 1, _decode(goodbye): 2}
+    dict = {hello: 1, goodbye: 2}
+    dict[b("goodbye")] = 3
     asserts.assert_that(len(dict)).is_equal_to(2)
-    asserts.assert_that(dict[_decode(goodbye)]).is_equal_to(3)
+    asserts.assert_that(dict[goodbye]).is_equal_to(3)
 
 
 def _test_byte_hashing():
@@ -313,11 +270,10 @@ def _testsuite():
     _suite.addTest(unittest.FunctionTestCase(_test_bytes_in_operator))
     _suite.addTest(unittest.FunctionTestCase(_test_byte_hashing))
     _suite.addTest(unittest.FunctionTestCase(_test_repeat))
-    _suite.addTest(unittest.FunctionTestCase(_test_codecs_does_transcoding))
+    _suite.addTest(unittest.FunctionTestCase(_test_str_does_transcoding))
     _suite.addTest(unittest.FunctionTestCase(_test_bytes_are_ints))
     _suite.addTest(unittest.FunctionTestCase(_test_bytes_vs_string))
     _suite.addTest(unittest.FunctionTestCase(_test_bytes_construction))
-    _suite.addTest(unittest.FunctionTestCase(_test_escape_literal_workaround))
     _suite.addTest(unittest.FunctionTestCase(_test_byte_types))
     _suite.addTest(unittest.FunctionTestCase(_test_byte_len))
     _suite.addTest(unittest.FunctionTestCase(_test_truthiness))
@@ -328,8 +284,7 @@ def _testsuite():
     _suite.addTest(unittest.FunctionTestCase(_test_indexing))
     _suite.addTest(unittest.FunctionTestCase(_test_slicing))
     _suite.addTest(unittest.FunctionTestCase(_test_bytes_are_immutable))
-    # TODO (mahmoudimus):
-    #  _suite.addTest(unittest.FunctionTestCase(_test_byte_ord))
+
     return _suite
 
 


### PR DESCRIPTION
- Move Textutil and UnicodeTables to a different directory (io => codecs) since Starlark does not have any i/o
- Added utility methods to chunk a string into several byte[] chunks
- Added an inverse utility method to concat a bytearray to rejoin the chunked byte[]
- Moved codechelper from LarkyGlobals to TextUtil where it belongs.
- Added a spec conforming method that takes a byte[] array and decodes it into UTF8 as per the Starlark spec