### PR TITLE
Changing larky-api jar loading methodology

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,7 +129,8 @@ get-resouces: &get-resources
   run:
     name: Get Additional Resources
     command: |
-      ./scripts/get_resources.sh
+      export LARKY_LIB_HOME=/tmp/larky/lib
+      ./larky-api/scripts/get_resources.sh
 
 
 # === JOBS ===

--- a/larky-api/pom.xml
+++ b/larky-api/pom.xml
@@ -37,15 +37,11 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.springframework</groupId>
-            <artifactId>spring-beans</artifactId>
-            <version>5.2.13.RELEASE</version>
-        </dependency>
-        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
             <version>${slf4j.version}</version>
         </dependency>
+
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>

--- a/larky-api/scripts/get_resources.sh
+++ b/larky-api/scripts/get_resources.sh
@@ -1,8 +1,44 @@
 #!/bin/bash
 
-if [[ -z "${LARKY_HOME}" ]]; then
-  echo "LARKY_HOME not found"
-  exit 1
+# set default verbose level to warning
+__VERBOSE=4
+
+# Setup Logging Infra
+declare LOG_LEVELS
+LOG_LEVELS=([0]="emerg" [1]="alert" [2]="crit" [3]="err" [4]="warning" [5]="notice" [6]="info" [7]="debug")
+function .log () {
+  local LEVEL=${1}
+  shift
+  if [ ${__VERBOSE} -ge ${LEVEL} ]; then
+    echo "[${LOG_LEVELS[$LEVEL]}]" "$@"
+  fi
+}
+
+# Read flags from command line
+while getopts ":dis" o; do
+    case "${o}" in
+        d) #debug
+            __VERBOSE=7
+            ;;
+        i) #debug
+            __VERBOSE=6
+            ;;
+        s) #silent
+            __VERBOSE=3
+            ;;
+        *)
+          ;;
+    esac
+done
+.log 7 "VERBOSE levels set to [${LOG_LEVELS[$__VERBOSE]}]"
+
+
+# Get larky lib home path
+LARKY_LIB_HOME=${LARKY_LIB_HOME:-/larky/lib}
+mkdir -p $LARKY_LIB_HOME
+if [ $? -ne 0 ] ; then
+    .log 3 "could not create directory $LARKY_LIB_HOME"
+    exit
 fi
 
 # Construct GraphQL query to get Larky package versions and jar files
@@ -29,8 +65,10 @@ gql_query='query {
 
 # Get packages from github registry using GraphQL API
 # Parse and clean output into {"packages": [ {v1,jar1},{v2,jar2},...,{vN,jarN} ] }
+.log 6 "Downloading from $url into $LARKY_API_JAR"
 package_json=$(
-  curl  -H 'Content-Type: application/json' \
+  curl  $( (( __VERBOSE < 7 )) && printf %s '-s' ) \
+        -H 'Content-Type: application/json' \
         -H "Authorization: bearer $GITHUB_API_TOKEN" \
         -X POST \
         -d "{\"query\": \"$(echo $gql_query)\"}" \
@@ -50,16 +88,16 @@ package_json=$(
 )
 
 # Download fat jar files from github registry
-API_RESOURCE_HOME=$LARKY_HOME/larky-api/src/main/resources
 echo $package_json | jq -c '.packages[]'| while read i; do
     # get cleaned verion & jar name
     version=$(jq ".version" <<< $i | sed -e 's/^"//' -e 's/"$//')
     url=$(jq ".url" <<< $i | sed -e 's/^"//' -e 's/"$//')
 
     # construct output jar paths
-    LARKY_API_JAR=$API_RESOURCE_HOME/larky-$version-fat.jar
+    LARKY_API_JAR=$LARKY_LIB_HOME/larky-$version-fat.jar
 
     # get jar
-    curl -o $LARKY_API_JAR -L $url
+    .log 6 "Downloading from $url into $LARKY_API_JAR"
+    curl $( (( __VERBOSE < 7 )) && printf %s '-s' ) -o $LARKY_API_JAR -L $url
 
 done


### PR DESCRIPTION
## Description of changes in release / Impact of release:
Changing the way we import larky fat-jars into the api. Previously it was automatically baked into larky-api. Now the user can declare a directory path where the jars will be stored in the LARKY_LIB_HOME environment variable (or `/larky/lib` by default) can put any larky fat-jar inside that directory.

## Documentation
Provided in larky-api/README.md

## Risks of this release
Breaking changes.

### Is this a breaking change?
- [x] Yes
- [ ] No

### If you answered Yes then describe why is it so
Technique for loading larky fat-jars into the project is completely different. If you rely on the previous technique the engine will not detect your jars and it will fail.

### Is there a way to disable the change?
- [x] Use previous release
- [ ] Use a feature flag
- [ ] No

