### PR TITLE
Removing macos from ci workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -315,9 +315,6 @@ workflows:
       - build-dist-linux:
           requires:
             - build-and-test
-      - build-dist-macos:
-          requires:
-            - build-and-test
 
   release:
     jobs:
@@ -328,14 +325,6 @@ workflows:
             branches:
               ignore: /.*/
       - build-dist-linux:
-          filters:
-            tags:
-              only: /^\d+\.\d+\.\d+(?:-[a-zA-Z0-9_.]+){0,1}$/
-            branches:
-              ignore: /.*/
-          requires:
-            - build-dist-maven
-      - build-dist-macos:
           filters:
             tags:
               only: /^\d+\.\d+\.\d+(?:-[a-zA-Z0-9_.]+){0,1}$/


### PR DESCRIPTION
## Description of changes in release / Impact of release:
Removing macos from ci workflow

## Documentation
None.

## Risks of this release
Project may not be compatible with MacOS.

### Is this a breaking change?
- [ ] Yes
- [x] No

### Is there a way to disable the change?
- [x] Use previous release
- [ ] Use a feature flag
- [ ] No

