### PR TITLE
X509 minor e

### DIFF
--- a/larky-api/pom.xml
+++ b/larky-api/pom.xml
@@ -45,8 +45,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>${lombok.version}</version>
-            <scope>compile</scope>
+            <version>${org.projectlombok.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -161,15 +160,13 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <slf4j.version>1.7.30</slf4j.version>
-        <org.projectlombok.version>1.18.12</org.projectlombok.version>
+        <org.projectlombok.version>1.18.20</org.projectlombok.version>
         <junit.version>4.13.1</junit.version>
         <google.findbugs.version>3.0.2</google.findbugs.version>
         <maven.source.plugin.version>3.2.1</maven.source.plugin.version>
         <maven.compiler.plugin.version>3.6.2</maven.compiler.plugin.version>
         <os-maven-plugin.version>1.7.0</os-maven-plugin.version>
         <google.errorprone.version>2.5.1</google.errorprone.version>
-        <lombok.version>1.18.20</lombok.version>
-        <slf4j.version>1.7.30</slf4j.version>
     </properties>
 
     <profiles>

--- a/larky/pom.xml
+++ b/larky/pom.xml
@@ -36,7 +36,7 @@
         <maven.compiler.plugin.version>3.6.2</maven.compiler.plugin.version>
         <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
         <libstarlark.version>1.0-SNAPSHOT</libstarlark.version>
-        <org.projectlombok.version>1.18.12</org.projectlombok.version>
+        <org.projectlombok.version>1.18.20</org.projectlombok.version>
         <common.io.version>2.8.0</common.io.version>
         <google.re2j.version>1.6</google.re2j.version>
         <google.flogger.version>0.5.1</google.flogger.version>
@@ -77,7 +77,6 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>${org.projectlombok.version}</version>
-            <scope>provided</scope>
         </dependency>
 
         <dependency>

--- a/larky/src/main/java/com/verygood/security/larky/ModuleSupplier.java
+++ b/larky/src/main/java/com/verygood/security/larky/ModuleSupplier.java
@@ -19,6 +19,8 @@ package com.verygood.security.larky;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import java.util.Map;
+import java.util.function.Function;
 
 import com.verygood.security.larky.modules.BinasciiModule;
 import com.verygood.security.larky.modules.C99MathModule;
@@ -26,6 +28,7 @@ import com.verygood.security.larky.modules.CodecsModule;
 import com.verygood.security.larky.modules.CryptoModule;
 import com.verygood.security.larky.modules.HashModule;
 import com.verygood.security.larky.modules.JsonModule;
+import com.verygood.security.larky.modules.OpenSSLModule;
 import com.verygood.security.larky.modules.ProtoBufModule;
 import com.verygood.security.larky.modules.RegexModule;
 import com.verygood.security.larky.modules.StructModule;
@@ -37,9 +40,6 @@ import com.verygood.security.larky.modules.testing.UnittestModule;
 
 import net.starlark.java.annot.StarlarkBuiltin;
 import net.starlark.java.eval.StarlarkValue;
-
-import java.util.Map;
-import java.util.function.Function;
 
 /**
  * A supplier of modules for Larky
@@ -60,7 +60,8 @@ public class ModuleSupplier {
       CodecsModule.INSTANCE,
       BinasciiModule.INSTANCE,
       StructModule.INSTANCE,
-      CryptoModule.INSTANCE
+      CryptoModule.INSTANCE,
+      OpenSSLModule.INSTANCE
   );
 
   public static final ImmutableSet<StarlarkValue> VGS_MODULES = ImmutableSet.of(

--- a/larky/src/main/java/com/verygood/security/larky/modules/CryptoModule.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/CryptoModule.java
@@ -1,5 +1,7 @@
 package com.verygood.security.larky.modules;
 
+import java.security.Security;
+
 import com.verygood.security.larky.modules.crypto.CryptoCipherModule;
 import com.verygood.security.larky.modules.crypto.CryptoHashModule;
 import com.verygood.security.larky.modules.crypto.CryptoIOModule;
@@ -9,15 +11,12 @@ import com.verygood.security.larky.modules.crypto.CryptoPublicKeyModule;
 import com.verygood.security.larky.modules.crypto.CryptoRandomModule;
 import com.verygood.security.larky.modules.crypto.CryptoSignatureModule;
 import com.verygood.security.larky.modules.crypto.CryptoUtilModule;
-import com.verygood.security.larky.modules.crypto.OpenSSLModule;
 
 import net.starlark.java.annot.StarlarkBuiltin;
 import net.starlark.java.annot.StarlarkMethod;
 import net.starlark.java.eval.StarlarkValue;
 
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
-
-import java.security.Security;
 
 
 @StarlarkBuiltin(
@@ -81,6 +80,4 @@ public class CryptoModule implements StarlarkValue {
   @StarlarkMethod(name="Util", structField = true)
   public CryptoUtilModule Util()  { return CryptoUtilModule.INSTANCE; }
 
-  @StarlarkMethod(name="OpenSSL", structField = true)
-  public OpenSSLModule OpenSSL()  { return OpenSSLModule.INSTANCE; }
 }

--- a/larky/src/main/java/com/verygood/security/larky/modules/OpenSSLModule.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/OpenSSLModule.java
@@ -12,9 +12,9 @@ import net.starlark.java.eval.StarlarkValue;
     doc = "")
 public class OpenSSLModule implements StarlarkValue {
 
-  public static final OpenSSL INSTANCE = OpenSSL.INSTANCE;
+  public static final OpenSSLModule INSTANCE =  new OpenSSLModule();
 
   @StarlarkMethod(name = "OpenSSL", doc = "openssl module", structField = true)
-  public static OpenSSL openSSL() { return INSTANCE; }
+  public static OpenSSL openSSL() { return OpenSSL.INSTANCE; }
 
 }

--- a/larky/src/main/java/com/verygood/security/larky/modules/OpenSSLModule.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/OpenSSLModule.java
@@ -1,0 +1,20 @@
+package com.verygood.security.larky.modules;
+
+import com.verygood.security.larky.modules.openssl.OpenSSL;
+
+import net.starlark.java.annot.StarlarkBuiltin;
+import net.starlark.java.annot.StarlarkMethod;
+import net.starlark.java.eval.StarlarkValue;
+
+@StarlarkBuiltin(
+    name = "jopenssl",
+    category = "BUILTIN",
+    doc = "")
+public class OpenSSLModule implements StarlarkValue {
+
+  public static final OpenSSL INSTANCE = OpenSSL.INSTANCE;
+
+  @StarlarkMethod(name = "OpenSSL", doc = "openssl module", structField = true)
+  public static OpenSSL openSSL() { return INSTANCE; }
+
+}

--- a/larky/src/main/java/com/verygood/security/larky/modules/openssl/OpenSSL.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/openssl/OpenSSL.java
@@ -1,6 +1,22 @@
-package com.verygood.security.larky.modules.crypto;
+package com.verygood.security.larky.modules.openssl;
 
-import com.verygood.security.larky.modules.crypto.Util.SSLUtils;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.security.GeneralSecurityException;
+import java.security.KeyPair;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.SecureRandom;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.security.interfaces.DSAKey;
+import java.security.interfaces.ECKey;
+import java.security.interfaces.RSAKey;
+import java.time.Instant;
+import java.util.Date;
+
 import com.verygood.security.larky.modules.types.LarkyByte;
 import com.verygood.security.larky.modules.types.LarkyByteLike;
 import com.verygood.security.larky.parser.StarlarkUtil;
@@ -37,27 +53,11 @@ import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 import org.bouncycastle.util.io.pem.PemObject;
 import org.bouncycastle.util.io.pem.PemWriter;
 
-import java.io.IOException;
-import java.io.StringWriter;
-import java.math.BigInteger;
-import java.nio.charset.StandardCharsets;
-import java.security.GeneralSecurityException;
-import java.security.KeyPair;
-import java.security.PrivateKey;
-import java.security.PublicKey;
-import java.security.SecureRandom;
-import java.security.cert.CertificateException;
-import java.security.cert.X509Certificate;
-import java.security.interfaces.DSAKey;
-import java.security.interfaces.ECKey;
-import java.security.interfaces.RSAKey;
-import java.time.Instant;
-import java.util.Date;
 import lombok.Builder;
 import lombok.Data;
 
-public class OpenSSLModule implements StarlarkValue {
-  public static final OpenSSLModule INSTANCE = new OpenSSLModule();
+public class OpenSSL implements StarlarkValue {
+  public static final OpenSSL INSTANCE = new OpenSSL();
 
   public static class Loaded implements StarlarkValue {
 

--- a/larky/src/main/java/com/verygood/security/larky/modules/openssl/SSLUtils.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/openssl/SSLUtils.java
@@ -1,4 +1,4 @@
-package com.verygood.security.larky.modules.crypto.Util;
+package com.verygood.security.larky.modules.openssl;
 
 import com.google.common.flogger.FluentLogger;
 import com.google.re2j.Matcher;
@@ -50,14 +50,14 @@ public final class SSLUtils {
     private static final Pattern PRIVKEY_PROCTYPE = Pattern.compile("^Proc-Type:\\s+4,ENCRYPTED\n");
     private static final Pattern PRIVKEY_DEKINFO = Pattern.compile("^DEK-Info:\\s+([^,]+),(\\S+)\n");
 
-    private enum KeyType {
+    enum KeyType {
         UNKNOWN,
         RSA,
         DSA,
         EC
     }
 
-    private enum KeyAlgo {
+    enum KeyAlgo {
         UNKNOWN,
         AES_128_CBC,
         AES_192_CBC,

--- a/larky/src/main/resources/vendor/OpenSSL/crypto.star
+++ b/larky/src/main/resources/vendor/OpenSSL/crypto.star
@@ -6,6 +6,7 @@ load("@stdlib//larky", larky="larky")
 load("@stdlib//types", types="types")
 load("@stdlib//codecs", codecs="codecs")
 load("@stdlib//jcrypto", _JCrypto="jcrypto")
+load("@stdlib//jopenssl", _JOpenSSL="jopenssl")
 load("@stdlib//json", "json")
 
 
@@ -1158,7 +1159,7 @@ def X509():
 
         if digest == None:
             fail('ValueError: No such digest method')
-        self._signed = _JCrypto.OpenSSL.X509_sign(
+        self._signed = _JOpenSSL.OpenSSL.X509_sign(
             pkey._pkey,
             json.dumps({
                 "gmtime_adj_notAfter": self._x509["gmtime_adj_notAfter"],
@@ -1985,7 +1986,7 @@ def dump_certificate(type, cert):
         fail('ValueError: type argument must be FILETYPE_PEM, ' +
              'FILETYPE_ASN1, or FILETYPE_TEXT')
 
-    return _JCrypto.OpenSSL.dump_certificate(cert._signed, fileformat)
+    return _JOpenSSL.OpenSSL.dump_certificate(cert._signed, fileformat)
 
 
 # def dump_publickey(type, pkey):
@@ -2872,7 +2873,7 @@ def load_privatekey(type, buffer, passphrase=None):
         buffer = codecs.encode(buffer, encoding='ascii')
 
     if type == FILETYPE_PEM:
-        evp_pkey = _JCrypto.OpenSSL.load_privatekey(buffer, passphrase)
+        evp_pkey = _JOpenSSL.OpenSSL.load_privatekey(buffer, passphrase)
     elif type == FILETYPE_ASN1:
         fail("Not supported")
     else:

--- a/larky/src/test/java/com/verygood/security/larky/modules/crypto/CryptoPublicKeyModuleTest.java
+++ b/larky/src/test/java/com/verygood/security/larky/modules/crypto/CryptoPublicKeyModuleTest.java
@@ -7,7 +7,12 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import com.google.common.truth.Truth;
+import java.io.IOException;
+import java.math.BigInteger;
+import java.security.KeyPair;
+import java.security.Security;
 
+import com.verygood.security.larky.modules.openssl.SSLUtils;
 import com.verygood.security.larky.modules.utils.NumOpsUtils;
 
 import net.starlark.java.eval.Dict;
@@ -33,10 +38,6 @@ import org.bouncycastle.util.encoders.Hex;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.io.IOException;
-import java.math.BigInteger;
-import java.security.Security;
 
 public class CryptoPublicKeyModuleTest {
 
@@ -229,5 +230,47 @@ public class CryptoPublicKeyModuleTest {
 
   @Test
   public void RSA_import_key() {
+    // # PEM encryption
+    //# With DES and passphrase 'test'
+    String[][] fixture = {
+        {
+            "test",
+            "-----BEGIN RSA PRIVATE KEY-----\n" +
+            "Proc-Type: 4,ENCRYPTED\n" +
+            "DEK-Info: DES-CBC,AF8F9A40BD2FA2FC\n" +
+            "\n" +
+            "Ckl9ex1kaVEWhYC2QBmfaF+YPiR4NFkRXA7nj3dcnuFEzBnY5XULupqQpQI3qbfA\n" +
+            "u8GYS7+b3toWWiHZivHbAAUBPDIZG9hKDyB9Sq2VMARGsX1yW1zhNvZLIiVJzUHs\n" +
+            "C6NxQ1IJWOXzTew/xM2I26kPwHIvadq+/VaT8gLQdjdH0jOiVNaevjWnLgrn1mLP\n" +
+            "BCNRMdcexozWtAFNNqSzfW58MJL2OdMi21ED184EFytIc1BlB+FZiGZduwKGuaKy\n" +
+            "9bMbdb/1PSvsSzPsqW7KSSrTw6MgJAFJg6lzIYvR5F4poTVBxwBX3+EyEmShiaNY\n" +
+            "IRX3TgQI0IjrVuLmvlZKbGWP18FXj7I7k9tSsNOOzllTTdq3ny5vgM3A+ynfAaxp\n" +
+            "dysKznQ6P+IoqML1WxAID4aGRMWka+uArOJ148Rbj9s=\n" +
+            "-----END RSA PRIVATE KEY-----"
+        },
+        {
+            // PKCS8 encryption
+            "winter",
+            "-----BEGIN ENCRYPTED PRIVATE KEY-----\n" +
+            "MIIBpjBABgkqhkiG9w0BBQ0wMzAbBgkqhkiG9w0BBQwwDgQIeZIsbW3O+JcCAggA\n" +
+            "MBQGCCqGSIb3DQMHBAgSM2p0D8FilgSCAWBhFyP2tiGKVpGj3mO8qIBzinU60ApR\n" +
+            "3unvP+N6j7LVgnV2lFGaXbJ6a1PbQXe+2D6DUyBLo8EMXrKKVLqOMGkFMHc0UaV6\n" +
+            "R6MmrsRDrbOqdpTuVRW+NVd5J9kQQh4xnfU/QrcPPt7vpJvSf4GzG0n666Ki50OV\n" +
+            "M/feuVlIiyGXY6UWdVDpcOV72cq02eNUs/1JWdh2uEBvA9fCL0c07RnMrdT+CbJQ\n" +
+            "NjJ7f8ULtp7xvR9O3Al/yJ4Wv3i4VxF1f3MCXzhlUD4I0ONlr0kJWgeQ80q/cWhw\n" +
+            "ntvgJwnCn2XR1h6LA8Wp+0ghDTsL2NhJpWd78zClGhyU4r3hqu1XDjoXa7YCXCix\n" +
+            "jCV15+ViDJzlNCwg+W6lRg18sSLkCT7alviIE0U5tHc6UPbbHwT5QqAxAABaP+nZ\n" +
+            "CGqJGyiwBzrKebjgSm/KRd4C91XqcsysyH2kKPfT51MLAoD4xelOURBP\n" +
+            "-----END ENCRYPTED PRIVATE KEY-----"
+        }
+    };
+    SSLUtils sslUtils = new SSLUtils();
+    KeyPair keyPair;
+
+    keyPair = sslUtils.decodePrivKey(fixture[0][1], fixture[0][0]);
+    assertNotNull(keyPair);
+    //TODO: skip
+    //keyPair = sslUtils.decodePrivKey(fixture[1][1], fixture[1][0]);
+    //assertNotNull(keyPair);
   }
 }

--- a/runlarky/pom.xml
+++ b/runlarky/pom.xml
@@ -32,7 +32,7 @@
         <maven.surefire.plugin.version>2.22.1</maven.surefire.plugin.version>
         <os-maven-plugin.version>1.7.0</os-maven-plugin.version>
         <starlarky.version>1.0-SNAPSHOT</starlarky.version>
-        <org.projectlombok.version>1.18.12</org.projectlombok.version>
+        <org.projectlombok.version>1.18.20</org.projectlombok.version>
         <quarkus-plugin.version>1.8.3.Final</quarkus-plugin.version>
         <quarkus.platform.artifact-id>quarkus-universe-bom</quarkus.platform.artifact-id>
         <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>


### PR DESCRIPTION
## Description of changes in release / Impact of release:

Extracts the openssl logic to a separate module. This does not break existing APIs.

## Documentation

- Introduce `jopenssl` instead of lumping it in the `jcrypto` module.

## Risks of this release

N/A

### Is this a breaking change?

- [ ] Yes
- [X] No

### Is there a way to disable the change?
- [X] Use previous release
- [ ] Use a feature flag
- [ ] No