### PR TITLE
[READY] ✅  -- Introduce result type

### DIFF
--- a/larky/src/main/java/com/verygood/security/larky/ModuleSupplier.java
+++ b/larky/src/main/java/com/verygood/security/larky/ModuleSupplier.java
@@ -31,6 +31,7 @@ import com.verygood.security.larky.modules.JsonModule;
 import com.verygood.security.larky.modules.OpenSSLModule;
 import com.verygood.security.larky.modules.ProtoBufModule;
 import com.verygood.security.larky.modules.RegexModule;
+import com.verygood.security.larky.modules.ResultModule;
 import com.verygood.security.larky.modules.StructModule;
 import com.verygood.security.larky.modules.VaultModule;
 import com.verygood.security.larky.modules.globals.LarkyGlobals;
@@ -61,7 +62,8 @@ public class ModuleSupplier {
       BinasciiModule.INSTANCE,
       StructModule.INSTANCE,
       CryptoModule.INSTANCE,
-      OpenSSLModule.INSTANCE
+      OpenSSLModule.INSTANCE,
+      ResultModule.INSTANCE
   );
 
   public static final ImmutableSet<StarlarkValue> VGS_MODULES = ImmutableSet.of(

--- a/larky/src/main/java/com/verygood/security/larky/modules/ResultModule.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/ResultModule.java
@@ -50,11 +50,10 @@ public class ResultModule implements StarlarkValue {
   @StarlarkMethod(name = "safe",
     parameters = {@Param(name = "func")},
     extraPositionals = @Param(name = "args"),
-    extraKeywords = @Param(name = "kwargs", defaultValue = "{}", doc = "Dictionary of arguments."),
+    extraKeywords = @Param(name = "kwargs", defaultValue = "{}"),
     useStarlarkThread = true
   )
   public static Result safe(StarlarkCallable func, Tuple args, Dict<String, Object> kwargs, StarlarkThread thread) {
-    // we know we are an error instance here since getValue() is null here.
     try {
       return Result.ok(Starlark.call(thread, func, args, kwargs));
     } catch (InterruptedException e) {

--- a/larky/src/main/java/com/verygood/security/larky/modules/ResultModule.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/ResultModule.java
@@ -30,12 +30,16 @@ public class ResultModule implements StarlarkValue {
   public static Result error(Object error) {
     return Result.error(error);
   }
+
   @StarlarkMethod(name = "Ok", parameters = {@Param(name = "value")})
   public static Result ok(Object value) {
     return Result.ok(value);
   }
+
   @StarlarkMethod(name = "of", parameters = {@Param(name = "o")})
   public static Result of(Object o) {
     return Result.of(o);
   }
+
+  
 }

--- a/larky/src/main/java/com/verygood/security/larky/modules/ResultModule.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/ResultModule.java
@@ -2,9 +2,9 @@ package com.verygood.security.larky.modules;
 
 import com.verygood.security.larky.modules.types.results.Result;
 
+import net.starlark.java.annot.Param;
 import net.starlark.java.annot.StarlarkBuiltin;
 import net.starlark.java.annot.StarlarkMethod;
-import net.starlark.java.eval.Starlark;
 import net.starlark.java.eval.StarlarkValue;
 
 
@@ -26,8 +26,21 @@ public class ResultModule implements StarlarkValue {
 
   public static final ResultModule INSTANCE = new ResultModule();
 
-  @StarlarkMethod(name = "Result", doc = "result", structField = true)
-  public Result result() {
-    return Result.of(Starlark.NONE);
+//  @StarlarkMethod(name = "_Result", doc = "result", structField = true)
+//  public Result result() {
+//    return Result.of(Starlark.NONE);
+//  }
+
+  @StarlarkMethod(name = "Error", parameters = {@Param(name = "error")})
+  public static Result error(Object error) {
+    return Result.error(error);
+  }
+  @StarlarkMethod(name = "Ok", parameters = {@Param(name = "value")})
+  public static Result ok(Object value) {
+    return Result.ok(value);
+  }
+  @StarlarkMethod(name = "of", parameters = {@Param(name = "o")})
+  public static Result of(Object o) {
+    return Result.of(o);
   }
 }

--- a/larky/src/main/java/com/verygood/security/larky/modules/ResultModule.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/ResultModule.java
@@ -26,11 +26,6 @@ public class ResultModule implements StarlarkValue {
 
   public static final ResultModule INSTANCE = new ResultModule();
 
-//  @StarlarkMethod(name = "_Result", doc = "result", structField = true)
-//  public Result result() {
-//    return Result.of(Starlark.NONE);
-//  }
-
   @StarlarkMethod(name = "Error", parameters = {@Param(name = "error")})
   public static Result error(Object error) {
     return Result.error(error);

--- a/larky/src/main/java/com/verygood/security/larky/modules/ResultModule.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/ResultModule.java
@@ -5,7 +5,13 @@ import com.verygood.security.larky.modules.types.results.Result;
 import net.starlark.java.annot.Param;
 import net.starlark.java.annot.StarlarkBuiltin;
 import net.starlark.java.annot.StarlarkMethod;
+import net.starlark.java.eval.Dict;
+import net.starlark.java.eval.EvalException;
+import net.starlark.java.eval.Starlark;
+import net.starlark.java.eval.StarlarkCallable;
+import net.starlark.java.eval.StarlarkThread;
 import net.starlark.java.eval.StarlarkValue;
+import net.starlark.java.eval.Tuple;
 
 
 @StarlarkBuiltin(
@@ -41,5 +47,22 @@ public class ResultModule implements StarlarkValue {
     return Result.of(o);
   }
 
-  
+  @StarlarkMethod(name = "safe",
+    parameters = {@Param(name = "func")},
+    extraPositionals = @Param(name = "args"),
+    extraKeywords = @Param(name = "kwargs", defaultValue = "{}", doc = "Dictionary of arguments."),
+    useStarlarkThread = true
+  )
+  public static Result safe(StarlarkCallable func, Tuple args, Dict<String, Object> kwargs, StarlarkThread thread) {
+    // we know we are an error instance here since getValue() is null here.
+    try {
+      return Result.ok(Starlark.call(thread, func, args, kwargs));
+    } catch (InterruptedException e) {
+      return Result.error(new EvalException(e.getMessage(), e));
+    } catch (EvalException e) {
+      return Result.error(e);
+    }
+  }
+
+
 }

--- a/larky/src/main/java/com/verygood/security/larky/modules/ResultModule.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/ResultModule.java
@@ -55,11 +55,11 @@ public class ResultModule implements StarlarkValue {
   )
   public static Result safe(StarlarkCallable func, Tuple args, Dict<String, Object> kwargs, StarlarkThread thread) {
     try {
-      return Result.ok(Starlark.call(thread, func, args, kwargs));
+      return ok(Starlark.call(thread, func, args, kwargs));
     } catch (InterruptedException e) {
-      return Result.error(new EvalException(e.getMessage(), e));
+      return error(new EvalException(e.getMessage(), e));
     } catch (EvalException e) {
-      return Result.error(e);
+      return error(e);
     }
   }
 

--- a/larky/src/main/java/com/verygood/security/larky/modules/ResultModule.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/ResultModule.java
@@ -1,0 +1,33 @@
+package com.verygood.security.larky.modules;
+
+import com.verygood.security.larky.modules.types.results.Result;
+
+import net.starlark.java.annot.StarlarkBuiltin;
+import net.starlark.java.annot.StarlarkMethod;
+import net.starlark.java.eval.Starlark;
+import net.starlark.java.eval.StarlarkValue;
+
+
+@StarlarkBuiltin(
+    name = "jresult",
+    category = "BUILTIN",
+    doc =
+      "Given that Starlark does not support exceptions, there needs to be a way to map python" +
+      "exception handling and control flow to Starlark. One of the more popular ways to " +
+      "do this is to take inspiration from some of the functional programming constructs." +
+      "" +
+      "Taking a page out of Railway Oriented Programming and the Result type of the Rust" +
+      " programming language, we can emulate a Result type that will contain utilities " +
+      "that enable functional style programming in Java (which maps well to Starlark) with" +
+      " under-the-hood error handling without having to define try-catch-blocks or" +
+      " conditionals."
+)
+public class ResultModule implements StarlarkValue {
+
+  public static final ResultModule INSTANCE = new ResultModule();
+
+  @StarlarkMethod(name = "Result", doc = "result", structField = true)
+  public Result result() {
+    return Result.of(Starlark.NONE);
+  }
+}

--- a/larky/src/main/java/com/verygood/security/larky/modules/globals/PythonBuiltins.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/globals/PythonBuiltins.java
@@ -13,6 +13,7 @@ import com.verygood.security.larky.modules.types.LarkyByte;
 import com.verygood.security.larky.modules.types.LarkyByteArray;
 import com.verygood.security.larky.modules.types.LarkyByteLike;
 import com.verygood.security.larky.modules.types.LarkyObject;
+import com.verygood.security.larky.modules.types.PyProtocols;
 import com.verygood.security.larky.parser.StarlarkUtil;
 
 import net.starlark.java.annot.Param;
@@ -121,6 +122,45 @@ public final class PythonBuiltins {
     }
     return StarlarkInt.of(new BigInteger(bytes).intValueExact());
   }
+
+  //override built-in getattr
+
+  @StarlarkMethod(
+       name = "getattr",
+       doc =
+           "Returns the struct's field of the given name if it exists. If not, it either returns "
+               + "<code>default</code> (if specified) or raises an error. "
+               + "<code>getattr(x, \"foobar\")</code> is equivalent to <code>x.foobar</code>."
+               + "<pre class=\"language-python\">getattr(ctx.attr, \"myattr\")\n"
+               + "getattr(ctx.attr, \"myattr\", \"mydefault\")</pre>",
+       parameters = {
+         @Param(name = "x", doc = "The struct whose attribute is accessed."),
+         @Param(name = "name", doc = "The name of the struct attribute."),
+         @Param(
+             name = "default",
+             defaultValue = "unbound",
+             doc =
+                 "The default value to return in case the struct "
+                     + "doesn't have an attribute of the given name.")
+       },
+       useStarlarkThread = true)
+   public Object getattr(Object obj, String name, Object defaultValue, StarlarkThread thread)
+       throws EvalException, InterruptedException {
+    if (LarkyObject.class.isAssignableFrom(obj.getClass())) {
+      // if there's an object with a __getattr__, it will be invoked..
+      Object getAttrMethod = ((LarkyObject) obj).getField(PyProtocols.__GETATTR__);
+      if (getAttrMethod != null) {
+        Object res = Starlark.call(thread, getAttrMethod, Tuple.of(name), Dict.empty());
+        return (res != null) ? res : defaultValue;
+      }
+    }
+     return Starlark.getattr(
+         thread.mutability(),
+         thread.getSemantics(),
+         obj,
+         name,
+         defaultValue == Starlark.UNBOUND ? null : defaultValue);
+   }
 
   //override built-in type
   @StarlarkMethod(

--- a/larky/src/main/java/com/verygood/security/larky/modules/globals/PythonBuiltins.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/globals/PythonBuiltins.java
@@ -1,5 +1,12 @@
 package com.verygood.security.larky.modules.globals;
 
+import java.math.BigInteger;
+import java.nio.charset.Charset;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
+import java.nio.charset.UnsupportedCharsetException;
+
 import com.verygood.security.larky.annot.Library;
 import com.verygood.security.larky.modules.codecs.TextUtil;
 import com.verygood.security.larky.modules.types.LarkyByte;
@@ -25,13 +32,6 @@ import net.starlark.java.eval.Structure;
 import net.starlark.java.eval.Tuple;
 
 import org.apache.commons.text.translate.CharSequenceTranslator;
-
-import java.math.BigInteger;
-import java.nio.charset.Charset;
-import java.nio.charset.CharsetDecoder;
-import java.nio.charset.CodingErrorAction;
-import java.nio.charset.StandardCharsets;
-import java.nio.charset.UnsupportedCharsetException;
 
 
 /**
@@ -272,7 +272,7 @@ public final class PythonBuiltins {
           // fallthrough
           return StarlarkFloat.of(Math.abs(((StarlarkFloat) x).toDouble()));
         default:
-          throw Starlark.errorf("bad operand type for abs(): '%s'", classType);
+          throw Starlark.errorf("TypeError: bad operand type for abs(): '%s'", classType);
       }
     } catch (EvalException | ClassCastException ex) {
       throw Starlark.errorf("%s", ex.getMessage());

--- a/larky/src/main/java/com/verygood/security/larky/modules/testing/UnittestModule.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/testing/UnittestModule.java
@@ -3,6 +3,8 @@ package com.verygood.security.larky.modules.testing;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterators;
+import java.util.Enumeration;
+import java.util.Iterator;
 
 import com.verygood.security.larky.modules.utils.NullPrintStream;
 
@@ -18,12 +20,10 @@ import net.starlark.java.annot.StarlarkBuiltin;
 import net.starlark.java.annot.StarlarkMethod;
 import net.starlark.java.eval.EvalException;
 import net.starlark.java.eval.Starlark;
-import net.starlark.java.eval.StarlarkFunction;
+import net.starlark.java.eval.StarlarkCallable;
 import net.starlark.java.eval.StarlarkThread;
 import net.starlark.java.eval.StarlarkValue;
 
-import java.util.Enumeration;
-import java.util.Iterator;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -65,7 +65,7 @@ public class UnittestModule implements StarlarkValue {
   public Object addFunctionUnderTest(Object function, StarlarkThread thread) {
     LarkyFunctionTestCase tc = new LarkyFunctionTestCase(Starlark.repr(function));
     //TODO: if this fails, we need to return a better error message.
-    tc.setFunction((StarlarkFunction) function);
+    tc.setFunction((StarlarkCallable) function);
     tc.setThread(thread);
     return tc;
   }
@@ -79,7 +79,7 @@ public class UnittestModule implements StarlarkValue {
 
     @Getter
     @Setter
-    private StarlarkFunction function;
+    private StarlarkCallable function;
 
     @SuppressWarnings("CdiInjectionPointsInspection")
     public LarkyFunctionTestCase(String name) {

--- a/larky/src/main/java/com/verygood/security/larky/modules/types/Partial.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/types/Partial.java
@@ -70,6 +70,11 @@ public class Partial implements StarlarkCallable {
         sb.append('_');
       }
     }
+    // remove any trailing _
+    sb.trimToSize();
+    if(sb.subSequence(sb.length()-1,sb.length()).equals("_")) {
+      sb.deleteCharAt(sb.length()-1);
+    }
     return sb.toString();
   }
 

--- a/larky/src/main/java/com/verygood/security/larky/modules/types/results/Error.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/types/results/Error.java
@@ -7,14 +7,6 @@ import net.starlark.java.eval.Printer;
 
 public class Error extends Result {
 
-//  private Object value;
-//   private EvalException error;
-//
-//   Result(Object value, EvalException error) {
-//     this.value = value;
-//     this.error = error;
-//   }
-
   private EvalException error;
 
   Error(EvalException error) {

--- a/larky/src/main/java/com/verygood/security/larky/modules/types/results/Error.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/types/results/Error.java
@@ -1,0 +1,70 @@
+package com.verygood.security.larky.modules.types.results;
+
+import java.util.Objects;
+
+import net.starlark.java.eval.EvalException;
+import net.starlark.java.eval.Printer;
+
+public class Error extends Result {
+
+//  private Object value;
+//   private EvalException error;
+//
+//   Result(Object value, EvalException error) {
+//     this.value = value;
+//     this.error = error;
+//   }
+
+  private EvalException error;
+
+  Error(EvalException error) {
+    this.error = error;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Error result = (Error) o;
+    return Objects.equals(error.getMessage(), result.error.getMessage());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(error);
+  }
+
+  @Override
+  public String toString() {
+    return "Error{" + error + '}';
+  }
+
+  @Override
+  public void str(Printer printer) {
+    printer.append(this.toString());
+  }
+
+  @Override
+  public Object getValue() {
+    return null;
+  }
+
+  @Override
+  public EvalException getError() {
+    return this.error;
+  }
+
+  @Override
+  public boolean isOk() {
+    return false;
+  }
+
+  @Override
+  public boolean isError() {
+    return true;
+  }
+}

--- a/larky/src/main/java/com/verygood/security/larky/modules/types/results/Error.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/types/results/Error.java
@@ -4,13 +4,28 @@ import java.util.Objects;
 
 import net.starlark.java.eval.EvalException;
 import net.starlark.java.eval.Printer;
+import net.starlark.java.eval.Starlark;
 
-public class Error extends Result {
 
-  private EvalException error;
+public class Error implements Result {
+
+  private final Object errValue;
+  private final EvalException exc;
+
+  Error(Object error) {
+    if(EvalException.class.isAssignableFrom(error.getClass())) {
+      this.errValue = ((EvalException) error).getMessage();
+      this.exc = ((EvalException) error);
+    }
+    else {
+      this.errValue = error;
+      this.exc = new EvalException(Starlark.str(error));
+    }
+  }
 
   Error(EvalException error) {
-    this.error = error;
+    this.errValue = error.getMessage();
+    this.exc = error;
   }
 
   @Override
@@ -22,17 +37,19 @@ public class Error extends Result {
       return false;
     }
     Error result = (Error) o;
-    return Objects.equals(error.getMessage(), result.error.getMessage());
+    return Objects.equals(errValue, result.errValue);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(error);
+    // return hash((self._type, self._is_ok, self._val))
+    return Objects.hash(this.getClass(), this.isOk(), errValue);
+    //return Objects.hash(errValue);
   }
 
   @Override
   public String toString() {
-    return "Error{" + error + '}';
+    return "Error{" + errValue + '}';
   }
 
   @Override
@@ -47,7 +64,7 @@ public class Error extends Result {
 
   @Override
   public EvalException getError() {
-    return this.error;
+    return this.exc;
   }
 
   @Override

--- a/larky/src/main/java/com/verygood/security/larky/modules/types/results/Ok.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/types/results/Ok.java
@@ -5,9 +5,9 @@ import java.util.Objects;
 import net.starlark.java.eval.EvalException;
 import net.starlark.java.eval.Printer;
 
-public class Ok extends Result {
+public class Ok implements Result {
 
-  private Object value;
+  private final Object value;
 
   Ok(Object value) {
     this.value = value;
@@ -27,7 +27,7 @@ public class Ok extends Result {
 
   @Override
   public int hashCode() {
-    return Objects.hash(value);
+    return Objects.hash(this.getClass(), this.isOk(), value);
   }
 
   @Override

--- a/larky/src/main/java/com/verygood/security/larky/modules/types/results/Ok.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/types/results/Ok.java
@@ -1,0 +1,62 @@
+package com.verygood.security.larky.modules.types.results;
+
+import java.util.Objects;
+
+import net.starlark.java.eval.EvalException;
+import net.starlark.java.eval.Printer;
+
+public class Ok extends Result {
+
+  private Object value;
+
+  Ok(Object value) {
+    this.value = value;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Ok result = (Ok) o;
+    return Objects.equals(value, result.value);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(value);
+  }
+
+  @Override
+  public String toString() {
+    return "Ok{" + value + '}';
+  }
+
+  @Override
+  public void str(Printer printer) {
+    printer.append(this.toString());
+  }
+
+  @Override
+  public Object getValue() {
+    return this.value;
+  }
+
+  @Override
+  public EvalException getError() {
+    return null;
+  }
+
+  @Override
+  public boolean isOk() {
+    return true;
+  }
+
+  @Override
+  public boolean isError() {
+    return false;
+  }
+}

--- a/larky/src/main/java/com/verygood/security/larky/modules/types/results/Result.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/types/results/Result.java
@@ -81,6 +81,20 @@ public interface Result extends StarlarkValue, Comparable<Result> {
         .orElse(this);
   }
 
+  @StarlarkMethod(name = "flatmap", parameters = {
+    @Param(name = "func")
+  }, allowReturnNones = true, useStarlarkThread = true)
+  default <T> Result flatMap(StarlarkCallable func, StarlarkThread thread) {
+    if(this.isOk()) {
+      try {
+        return ok(Starlark.call(thread, func, Tuple.of(getValue()), Dict.empty()));
+      } catch (EvalException | InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+    }
+    return this;
+  }
+
   @StarlarkMethod(name = "map_err", parameters = {
     @Param(name = "func")
   }, allowReturnNones = true, useStarlarkThread = true)

--- a/larky/src/main/java/com/verygood/security/larky/modules/types/results/Result.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/types/results/Result.java
@@ -1,0 +1,172 @@
+package com.verygood.security.larky.modules.types.results;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+
+import net.starlark.java.annot.Param;
+import net.starlark.java.annot.StarlarkMethod;
+import net.starlark.java.eval.Dict;
+import net.starlark.java.eval.EvalException;
+import net.starlark.java.eval.Printer;
+import net.starlark.java.eval.Starlark;
+import net.starlark.java.eval.StarlarkFunction;
+import net.starlark.java.eval.StarlarkThread;
+import net.starlark.java.eval.StarlarkValue;
+import net.starlark.java.eval.Tuple;
+
+public class Result implements StarlarkValue {
+
+  private Object value;
+  private EvalException error;
+
+  Result(Object value, EvalException error) {
+    this.value = value;
+    this.error = error;
+  }
+
+  @StarlarkMethod(name = "failure", parameters = {@Param(name = "error")})
+  public static Result failure(Object error) {
+    Objects.requireNonNull(error);
+    if (EvalException.class.isAssignableFrom(error.getClass())) {
+      return new Result(null, (EvalException) error);
+    }
+    return new Result(null, new EvalException(String.valueOf(error)));
+  }
+
+  @StarlarkMethod(name = "success", parameters = {@Param(name = "value")})
+  public static Result success(Object value) {
+    Objects.requireNonNull(value);
+    return new Result(value, null);
+  }
+
+  @StarlarkMethod(name = "of", parameters = {@Param(name = "o")})
+  public static Result of(Object o) {
+    if (o instanceof Exception) {
+      return failure(o);
+    }
+    return success(o);
+  }
+
+  @StarlarkMethod(name = "either")
+  public Object getEither() {
+    return value != null ? value : error;
+  }
+
+  @StarlarkMethod(name = "value")
+  public Object getValue() {
+    return value;
+  }
+
+  @StarlarkMethod(name = "error")
+  public EvalException getError() {
+    return error;
+  }
+
+  // copy https://github.com/MaT1g3R/option/blob/master/option/result.py
+  // decided against: https://github.com/dbrgn/result/blob/master/result/result.py
+  @StarlarkMethod(name = "map", parameters = {
+    @Param(name = "func")
+  }, useStarlarkThread = true)
+  public <T> Result map(StarlarkFunction func, StarlarkThread thread) {
+    return of(
+      Optional.ofNullable(getValue())
+        .map((o) -> {
+          try {
+            return Starlark.call(thread, func, Tuple.of(o), Dict.empty());
+          } catch (EvalException | InterruptedException e) {
+            throw new RuntimeException(e);
+          }
+        })
+        .orElse(error));
+  }
+
+  @StarlarkMethod(name = "is_ok", structField = true)
+  public boolean isOk() {
+    return this.value != null && this.error == null;
+  }
+
+  @StarlarkMethod(name = "is_err", structField = true)
+  public boolean isErr() {
+    return this.value == null && this.error != null;
+  }
+
+  @StarlarkMethod(name = "unwrap")
+  public Object unwrap() throws EvalException {
+    return orElseRaiseAs(e -> e);
+  }
+
+  @StarlarkMethod(name = "unwrap_or_else", parameters = {
+    @Param(name = "func")
+  }, useStarlarkThread = true)
+  public Object unwrapOrElse(StarlarkFunction func, StarlarkThread thread) throws EvalException {
+    return
+      Optional.ofNullable(value)
+        .orElseGet(() -> {
+          try {
+            return Starlark.call(thread, func, Tuple.of(), Dict.empty());
+          } catch (EvalException | InterruptedException e) {
+            throw new RuntimeException(e);
+          }
+        });
+  }
+
+  @StarlarkMethod(name = "expect", parameters = {
+    @Param(name = "s")
+  })
+  public Object expect(String s) throws EvalException {
+    if (isOk()) {
+      return value;
+    }
+    throw new EvalException(s);
+  }
+
+  @StarlarkMethod(name = "unwrap_err")
+  public Object unwrapErr() throws EvalException {
+    if (isOk()) {
+      throw new EvalException(String.valueOf(this.value));
+    }
+    return this.value;
+  }
+
+  @StarlarkMethod(name = "expect_err", parameters = {
+    @Param(name = "msg")
+  })
+  public Object expectErr(String msg) throws EvalException {
+    if (isOk()) {
+      throw new EvalException(msg);
+    }
+    return this.value;
+  }
+
+  public <E2 extends EvalException> Object orElseRaiseAs(Function<EvalException, E2> emapper) throws E2 {
+    return Optional.ofNullable(value).orElseThrow(() -> emapper.apply(error));
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    Result result = (Result) o;
+    return Objects.equals(value, result.value) && Objects.equals(error, result.error);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(value, error);
+  }
+
+  @Override
+  public String toString() {
+    return "Result{" + "value=" + value + ", error=" + error + '}';
+  }
+
+  @Override
+  public void str(Printer printer) {
+    printer.append(this.toString());
+  }
+}

--- a/larky/src/main/java/com/verygood/security/larky/modules/types/results/Result.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/types/results/Result.java
@@ -15,8 +15,25 @@ import net.starlark.java.eval.StarlarkThread;
 import net.starlark.java.eval.StarlarkValue;
 import net.starlark.java.eval.Tuple;
 
+import org.jetbrains.annotations.Nullable;
+
 
 public abstract class Result implements StarlarkValue {
+
+  static class StarlarkException extends EvalException implements StarlarkValue {
+
+    public StarlarkException(String message) {
+      super(message);
+    }
+
+    public StarlarkException(String message, @Nullable Throwable cause) {
+      super(message, cause);
+    }
+
+    public StarlarkException(Throwable cause) {
+      super(cause);
+    }
+  }
 
   @StarlarkMethod(name = "Error", parameters = {@Param(name = "error")})
   public static Result error(Object error) {
@@ -24,7 +41,7 @@ public abstract class Result implements StarlarkValue {
     if (EvalException.class.isAssignableFrom(error.getClass())) {
       return new Error((EvalException) error);
     }
-    return new Error(new EvalException(String.valueOf(error)));
+    return new Error(new EvalException(Starlark.str(error)));
   }
 
   @StarlarkMethod(name = "Ok", parameters = {@Param(name = "value")})

--- a/larky/src/main/resources/stdlib/builtins.star
+++ b/larky/src/main/resources/stdlib/builtins.star
@@ -1,3 +1,5 @@
+# try to mimic: https://docs.python.org/3/library/builtins.html
+
 load("@stdlib/larky", "larky")
 load("@stdlib/types", "types")
 load("@stdlib/codecs", "codecs")
@@ -71,9 +73,50 @@ def _bytearray(source, encoding='utf-8', errors='strict'):
     return bytearray(source, encoding, errors)
 
 
+def iter(o, sentinel=None):
+    """
+    Return an iterator object.
+
+    The first argument is interpreted very differently depending on the
+    presence of the second argument. Without a second argument, object
+    must be a collection object which supports the iteration
+    protocol (the __iter__() method), or it must support the sequence
+    protocol (the __getitem__() method with integer arguments starting at 0).
+    If it does not support either of those protocols, TypeError is raised.
+
+    If the second argument, sentinel, is given, then object must be a
+    callable object. The iterator created in this case will call object
+    with no arguments for each call to its __next__() method; if the value
+    returned is equal to sentinel, StopIteration will be raised, otherwise
+    the value will be returned.
+
+    :param o:
+    :param sentinel:
+    :return:
+    """
+    if not any([
+        hasattr(o, '__iter__'),
+        types.is_iterable(o),
+        types.is_string(o),
+    ]):
+        msg = "TypeError: type '%s' is not iterable"
+        msg %= (type(o))
+        fail(msg)
+    iterable = o
+    if types.is_string(o):
+        iterable = o.elems()
+    elif hasattr(o, '__iter__'):
+        iterable = o.__iter__()
+    return iterable
+
+
 # TODO: should we move this to starlark?
+# list of functions from: https://docs.python.org/3/library/functions.html
 builtins = larky.struct(
     bytes=_bytes,
     b=_bytes,
     bytearray=_bytearray,
+    abs=abs,
+    pow=pow,
+    iter=iter,
 )

--- a/larky/src/main/resources/stdlib/builtins.star
+++ b/larky/src/main/resources/stdlib/builtins.star
@@ -110,6 +110,10 @@ def iter(o, sentinel=None):
     return iterable
 
 
+def map(func, iterable):
+    return [func(x) for x in iterable]
+
+
 # TODO: should we move this to starlark?
 # list of functions from: https://docs.python.org/3/library/functions.html
 builtins = larky.struct(
@@ -119,4 +123,5 @@ builtins = larky.struct(
     abs=abs,
     pow=pow,
     iter=iter,
+    map=map,
 )

--- a/larky/src/main/resources/stdlib/larky.star
+++ b/larky/src/main/resources/stdlib/larky.star
@@ -28,6 +28,51 @@ WHILE_LOOP_EMULATION_ITERATION = 4096
 
 _SENTINEL = _sentinel()
 
+
+def _parametrize(testaddr, testcase, param, args):
+    """
+    Emulates the pytest.parametrize() but with some larky differences.
+
+    Decorator a testaddr to create a testcase that is parameterized by `param`
+    and a list of `args` that are set to the param.
+
+    :param testaddr: in Larky, this would be `suite.addTest`
+    :param testcase: in Larky, this would be `unittest.FunctionTestCase`
+    :param param: the parameter to set
+    :param args: The variable parameters to set param to
+    :return: None
+
+    Examples:
+        >>> load("@stdlib//larky", "larky")
+        >>> load("@stdlib//unittest", "unittest")
+        >>> load("@vendor//asserts", "asserts")
+        >>> def _test(val):
+                asserts.assert_eq(val).is_equal_to(val)
+        >>> _suite = unittest.TestSuite()
+        >>> larky.parametrize(
+               _suite.addTest,
+               unittest.FunctionTestCase,
+               'val',
+               [0, None, {}, [], False])(_test)
+    """
+    split_on = ',' if ',' in param else None
+    # cannot import types in larky module, so this test allows
+    # to see if multiple params exist
+    if not hasattr(param, 'append') and split_on:
+        param = param.split(split_on)
+    elif not hasattr(param, 'append'):
+        param = [param]
+
+    def parametrized(func):
+        if len(param) == 1:
+            for arg in args:
+                testaddr(testcase(_partial(func, **dict(zip(param, [arg])))))
+        else:
+            for arg in args:
+                testaddr(testcase(_partial(func, **dict(zip(param, arg)))))
+    return parametrized
+
+
 larky = _struct(
     struct=_struct,
     mutablestruct=_mutablestruct,
@@ -35,5 +80,6 @@ larky = _struct(
     partial=_partial,
     property=_property,
     WHILE_LOOP_EMULATION_ITERATION=WHILE_LOOP_EMULATION_ITERATION,
-    SENTINEL=_SENTINEL
+    SENTINEL=_SENTINEL,
+    parametrize=_parametrize,
 )

--- a/larky/src/main/resources/stdlib/larky.star
+++ b/larky/src/main/resources/stdlib/larky.star
@@ -28,7 +28,7 @@ WHILE_LOOP_EMULATION_ITERATION = 4096
 
 _SENTINEL = _sentinel()
 
-
+# TODO: maybe move to a testutils?
 def _parametrize(testaddr, testcase, param, args):
     """
     Emulates the pytest.parametrize() but with some larky differences.
@@ -46,14 +46,16 @@ def _parametrize(testaddr, testcase, param, args):
         >>> load("@stdlib//larky", "larky")
         >>> load("@stdlib//unittest", "unittest")
         >>> load("@vendor//asserts", "asserts")
+        >>>
         >>> def _test(val):
-                asserts.assert_eq(val).is_equal_to(val)
+        ...    asserts.assert_eq(val).is_equal_to(val)
+        >>>
         >>> _suite = unittest.TestSuite()
         >>> larky.parametrize(
-               _suite.addTest,
-               unittest.FunctionTestCase,
-               'val',
-               [0, None, {}, [], False])(_test)
+        ...    _suite.addTest,
+        ...    unittest.FunctionTestCase,
+        ...    'val',
+        ...    [0, None, {}, [], False])(_test)
     """
     split_on = ',' if ',' in param else None
     # cannot import types in larky module, so this test allows

--- a/larky/src/main/resources/stdlib/operator.star
+++ b/larky/src/main/resources/stdlib/operator.star
@@ -334,9 +334,7 @@ def iconcat(a, b):
         fail(msg)
     if hasattr(a, '__iadd__'):
         return a.__iadd__(b)
-    # if not hasattr(a, '__getitem__'):
-    #     msg = "'%s' object can't be concatenated" % type(a).__name__
-    #     fail("TypeError: " + msg)
+
     _m = getattr(a, '__iconcat__', larky.SENTINEL)
     if _m == larky.SENTINEL:
         a += b

--- a/larky/src/main/resources/stdlib/operator.star
+++ b/larky/src/main/resources/stdlib/operator.star
@@ -31,7 +31,10 @@ def le(a, b):
 
 def eq(a, b):
     "Same as a == b."
-    return a == b
+    _m = getattr(a, '__eq__', larky.SENTINEL)
+    if _m == larky.SENTINEL:
+        return a == b
+    return _m(b)
 
 def ne(a, b):
     "Same as a != b."

--- a/larky/src/main/resources/stdlib/operator.star
+++ b/larky/src/main/resources/stdlib/operator.star
@@ -1,0 +1,441 @@
+"""
+Operator Interface
+
+This module exports a set of functions corresponding to the intrinsic
+operators of Python.
+
+For example, operator.add(x, y) is equivalent to the expression x+y.
+
+The function names are those used for special methods;
+variants without leading and trailing '__' are also provided for convenience.
+
+This is a pure Python implementation of the module.
+Taken from: https://github.com/python/cpython/blob/main/Lib/operator.py
+"""
+load("@stdlib//larky", larky="larky")
+load("@stdlib//types", types="types")
+
+#_abs = abs
+#_pow = pow
+
+
+# Comparison Operations *******************************************************#
+
+def lt(a, b):
+    "Same as a < b."
+    return a < b
+
+def le(a, b):
+    "Same as a <= b."
+    return a <= b
+
+def eq(a, b):
+    "Same as a == b."
+    return a == b
+
+def ne(a, b):
+    "Same as a != b."
+    return a != b
+
+def ge(a, b):
+    "Same as a >= b."
+    return a >= b
+
+def gt(a, b):
+    "Same as a > b."
+    return a > b
+
+# Logical Operations **********************************************************#
+
+def not_(a):
+    "Same as not a."
+    return not a
+
+def truth(a):
+    "Return True if a is true, False otherwise."
+    return True if a else False
+
+def is_(a, b):
+    "Same as a is b."
+    return a == b
+
+def is_not(a, b):
+    "Same as a is not b."
+    return a != b
+
+# Mathematical/Bitwise Operations *********************************************#
+
+def abs_(a):
+    "Same as abs(a)."
+    return abs(a)
+
+def add(a, b):
+    "Same as a + b."
+    return a + b
+
+def and_(a, b):
+    "Same as a & b."
+    return a & b
+
+def floordiv(a, b):
+    "Same as a // b."
+    return a // b
+
+def index(a):
+    "Same as a.__index__()."
+    return a.__index__()
+
+def inv(a):
+    "Same as ~a."
+    return ~a
+invert = inv
+
+def lshift(a, b):
+    "Same as a << b."
+    return a << b
+
+def mod(a, b):
+    "Same as a % b."
+    return a % b
+
+def mul(a, b):
+    "Same as a * b."
+    return a * b
+
+def matmul(a, b):
+    "Same as a @ b."
+    return a.__matmul__(b)
+
+def neg(a):
+    "Same as -a."
+    return -a
+
+def or_(a, b):
+    "Same as a | b."
+    return a | b
+
+def pos(a):
+    "Same as +a."
+    return +a
+
+def pow_(a, b):
+    "Same as a ** b."
+    return pow_(a, b)
+
+def rshift(a, b):
+    "Same as a >> b."
+    return a >> b
+
+def sub(a, b):
+    "Same as a - b."
+    return a - b
+
+def truediv(a, b):
+    "Same as a / b."
+    return a / b
+
+def xor(a, b):
+    "Same as a ^ b."
+    return a ^ b
+
+# Sequence Operations *********************************************************#
+
+def concat(a, b):
+    "Same as a + b, for a and b sequences."
+    if not hasattr(a, '__getitem__'):
+        msg = "'%s' object can't be concatenated" % type(a)
+        fail("TypeError: " + msg)
+    return a + b
+
+def contains(a, b):
+    "Same as b in a (note reversed operands)."
+    return b in a
+
+def countOf(a, b):
+    "Return the number of times b occurs in a."
+    count = 0
+    for i in a:
+        if i == b:
+            count += 1
+    return count
+
+def delitem(a, b):
+    "Same as del a[b]."
+    a.__delitem__(b)   # no del in starlark!
+
+def getitem(a, b):
+    "Same as a[b]."
+    return a.__getitem__(b) if hasattr(a, '__getitem__') else a[b]
+
+def indexOf(a, b):
+    "Return the first index of b in a."
+    for i, j in enumerate(a):
+        if j == b:
+            return i
+    fail("ValueError: " + 'sequence.index(x): x not in sequence')
+
+def setitem(a, b, c):
+    "Same as a[b] = c."
+    if hasattr(a, '__setitem__'):
+        a.__setitem__(b, c)
+    else:
+        a[b] = c
+
+def length_hint(obj, default=0):
+    """
+    Return an estimate of the number of items in obj.
+    This is useful for presizing containers when building from an iterable.
+    If the object supports len(), the result will be exact. Otherwise, it may
+    over- or under-estimate by an arbitrary amount. The result will be an
+    integer >= 0.
+    """
+    fail("not implemented")
+
+def itemgetter(*args):
+    def _itemgetter(obj):
+        return obj[args[0]]
+    def _itemsgetter(obj):
+        return tuple([obj[i] for i in args])
+    if len(args) == 1:
+        return _itemgetter
+    return _itemsgetter
+
+
+def attrgetter(attr):
+    if "." in attr:
+        fail('"." in %s' % attr)
+    def _attrgetter(obj):
+        return getattr(obj, attr)
+    return _attrgetter
+
+
+def methodcaller(name, *args, **kwargs):
+    def _methodcaller(obj):
+        return getattr(obj, name)(*args, **kwargs)
+    return _methodcaller
+
+
+# In-place Operations *********************************************************#
+
+def iadd(a, b):
+    "Same as a += b."
+    a += b
+    return a
+
+def iand(a, b):
+    "Same as a &= b."
+    a &= b
+    return a
+
+def iconcat(a, b):
+    "Same as a += b, for a and b sequences."
+    if not hasattr(a, '__getitem__'):
+        msg = "'%s' object can't be concatenated" % type(a).__name__
+        fail("TypeError: " + msg)
+    a += b
+    return a
+
+def ifloordiv(a, b):
+    "Same as a //= b."
+    a //= b
+    return a
+
+def ilshift(a, b):
+    "Same as a <<= b."
+    a <<= b
+    return a
+
+def imod(a, b):
+    "Same as a %= b."
+    a %= b
+    return a
+
+def imul(a, b):
+    "Same as a *= b."
+    a *= b
+    return a
+
+def imatmul(a, b):
+    "Same as a @= b."
+    a = matmul(a, b)
+    return a
+
+def ior(a, b):
+    "Same as a |= b."
+    a |= b
+    return a
+
+def ipow(a, b):
+    "Same as a **= b."
+    a = pow(a, b)
+    return a
+
+def irshift(a, b):
+    "Same as a >>= b."
+    a >>= b
+    return a
+
+def isub(a, b):
+    "Same as a -= b."
+    a -= b
+    return a
+
+def itruediv(a, b):
+    "Same as a /= b."
+    a /= b
+    return a
+
+def ixor(a, b):
+    "Same as a ^= b."
+    a ^= b
+    return a
+
+# All of these "__func__ = func" assignments have to happen after importing
+# from _operator to make sure they're set to the right function
+__lt__ = lt
+__le__ = le
+__eq__ = eq
+__ne__ = ne
+__ge__ = ge
+__gt__ = gt
+__not__ = not_
+__abs__ = abs
+__add__ = add
+__and__ = and_
+__floordiv__ = floordiv
+__index__ = index
+__inv__ = inv
+__invert__ = invert
+__lshift__ = lshift
+__mod__ = mod
+__mul__ = mul
+__matmul__ = matmul
+__neg__ = neg
+__or__ = or_
+__pos__ = pos
+__pow__ = pow
+__rshift__ = rshift
+__sub__ = sub
+__truediv__ = truediv
+__xor__ = xor
+__concat__ = concat
+__contains__ = contains
+__delitem__ = delitem
+__getitem__ = getitem
+__setitem__ = setitem
+__iadd__ = iadd
+__iand__ = iand
+__iconcat__ = iconcat
+__ifloordiv__ = ifloordiv
+__ilshift__ = ilshift
+__imod__ = imod
+__imul__ = imul
+__imatmul__ = imatmul
+__ior__ = ior
+__ipow__ = ipow
+__irshift__ = irshift
+__isub__ = isub
+__itruediv__ = itruediv
+__ixor__ = ixor
+
+operator = larky.struct(
+    lt=lt,
+    le=le,
+    eq=eq,
+    ne=ne,
+    ge=ge,
+    gt=gt,
+    not_=not_,
+    truth=truth,
+    is_=is_,
+    is_not=is_not,
+    abs_=abs_,
+    add=add,
+    and_=and_,
+    floordiv=floordiv,
+    index=index,
+    inv=inv,
+    invert=invert,
+    lshift=lshift,
+    mod=mod,
+    mul=mul,
+    matmul=matmul,
+    neg=neg,
+    or_=or_,
+    pos=pos,
+    pow_=pow_,
+    rshift=rshift,
+    sub=sub,
+    truediv=truediv,
+    xor=xor,
+    concat=concat,
+    contains=contains,
+    countOf=countOf,
+    delitem=delitem,
+    getitem=getitem,
+    indexOf=indexOf,
+    setitem=setitem,
+    length_hint=length_hint,
+    itemgetter=itemgetter,
+    attrgetter=attrgetter,
+    methodcaller=methodcaller,
+    iadd=iadd,
+    iand=iand,
+    iconcat=iconcat,
+    ifloordiv=ifloordiv,
+    ilshift=ilshift,
+    imod=imod,
+    imul=imul,
+    imatmul=imatmul,
+    ior=ior,
+    ipow=ipow,
+    irshift=irshift,
+    isub=isub,
+    itruediv=itruediv,
+    ixor=ixor,
+    __lt__=__lt__,
+    __le__=__le__,
+    __eq__=__eq__,
+    __ne__=__ne__,
+    __ge__=__ge__,
+    __gt__=__gt__,
+    __not__=__not__,
+    __abs__=__abs__,
+    __add__=__add__,
+    __and__=__and__,
+    __floordiv__=__floordiv__,
+    __index__=__index__,
+    __inv__=__inv__,
+    __invert__=__invert__,
+    __lshift__=__lshift__,
+    __mod__=__mod__,
+    __mul__=__mul__,
+    __matmul__=__matmul__,
+    __neg__=__neg__,
+    __or__=__or__,
+    __pos__=__pos__,
+    __pow__=__pow__,
+    __rshift__=__rshift__,
+    __sub__=__sub__,
+    __truediv__=__truediv__,
+    __xor__=__xor__,
+    __concat__=__concat__,
+    __contains__=__contains__,
+    __delitem__=__delitem__,
+    __getitem__=__getitem__,
+    __setitem__=__setitem__,
+    __iadd__=__iadd__,
+    __iand__=__iand__,
+    __iconcat__=__iconcat__,
+    __ifloordiv__=__ifloordiv__,
+    __ilshift__=__ilshift__,
+    __imod__=__imod__,
+    __imul__=__imul__,
+    __imatmul__=__imatmul__,
+    __ior__=__ior__,
+    __ipow__=__ipow__,
+    __irshift__=__irshift__,
+    __isub__=__isub__,
+    __itruediv__=__itruediv__,
+    __ixor__=__ixor__,
+)

--- a/larky/src/main/resources/stdlib/types.star
+++ b/larky/src/main/resources/stdlib/types.star
@@ -24,6 +24,7 @@ _an_int_type = type(1)
 _a_float_type = type(5.0)
 _a_struct_type = type(larky.struct())
 _a_mutablestruct_type = type(larky.mutablestruct())
+_a_range_type = type(range(1))
 
 
 def _a_function():
@@ -209,8 +210,12 @@ def _is_subclass(sub_class, parent_class):
     return parent_class in mro
 
 
+def _is_range(iterz):
+    return type(iterz) == _a_range_type
+
+
 def _is_iterable(iterz):
-    return _is_tuple(iterz) or _is_list(iterz)
+    return _is_tuple(iterz) or _is_list(iterz) or _is_range(iterz)
 
 
 def _is_bytes(bobj):
@@ -510,6 +515,7 @@ types = larky.struct(
     is_lambda=_is_lambda,
     is_callable=_is_callable,
     is_set=_is_set,
+    is_range=_is_range,
     is_instance=_is_instance,
     is_iterable=_is_iterable,
     is_bytes=_is_bytes,

--- a/larky/src/main/resources/vendor/option/result.star
+++ b/larky/src/main/resources/vendor/option/result.star
@@ -1,25 +1,422 @@
 load("@stdlib//larky", "larky")
+load("@stdlib//types", types="types")
 load("@stdlib//jresult", _JResult="jresult")
+#
+# def _Result(val, is_ok):
+#     """
+#     :class:`Result` is a type that either success (:meth:`Result.Ok`)
+#     or failure (:meth:`Result.Err`).
+#
+#     To create an Ok value, use :meth:`Result.Ok` or :func:`Ok`.
+#
+#     To create a Err value, use :meth:`Result.Err` or :func:`Err`.
+#
+#     Calling the :class:`Result` constructor directly will raise a ``TypeError``.
+#
+#     Examples:
+#         >>> Result.Ok(1)
+#         Ok(1)
+#         >>> Result.Error('Fail!')
+#         Error('Fail!')
+#     """
+#
+#     self = larky.mutablestruct(__class__='Result')
+#
+#     def __init__(val, is_ok):
+#         self._val = val
+#         self._is_ok = is_ok
+#         self._type = _JResult
+#         self._obj = _JResult.Ok(val) if is_ok else _JResult.Error(val)
+#         return self
+#     self = __init__(val, is_ok)
+#
+#     def is_ok():
+#         """
+#         Returns `True` if the result is :meth:`Result.Ok`.
+#
+#         Examples:
+#             >>> Ok(1).is_ok
+#             True
+#             >>> Err(1).is_ok
+#             False
+#         """
+#         return self._is_ok
+#     self.is_ok = larky.property(is_ok)
+#
+#     def is_err():
+#         """
+#         Returns `True` if the result is :meth:`Result.Err`.
+#
+#         Examples:
+#             >>> Ok(1).is_err
+#             False
+#             >>> Err(1).is_err
+#             True
+#         """
+#         return not self._is_ok
+#     self.is_err = larky.property(is_err)
+#
+#     # def ok():
+#     #     """
+#     #     Converts from :class:`Result` [T, E] to :class:`option.option_.Option` [T].
+#     #
+#     #     Returns:
+#     #         :class:`Option` containing the success value if `self` is
+#     #         :meth:`Result.Ok`, otherwise :data:`option.option_.NONE`.
+#     #
+#     #     Examples:
+#     #         >>> Ok(1).ok()
+#     #         Some(1)
+#     #         >>> Err(1).ok()
+#     #         NONE
+#     #     """
+#     #     return Option.Some(self._val) if self._is_ok else NONE  # type: ignore
+#     # self.ok = ok
+#
+#     # def err():
+#     #     """
+#     #     Converts from :class:`Result` [T, E] to :class:`option.option_.Option` [E].
+#     #
+#     #     Returns:
+#     #         :class:`Option` containing the error value if `self` is
+#     #         :meth:`Result.Err`, otherwise :data:`option.option_.NONE`.
+#     #
+#     #     Examples:
+#     #         >>> Ok(1).err()
+#     #         NONE
+#     #         >>> Err(1).err()
+#     #         Some(1)
+#     #     """
+#     #     return NONE if self._is_ok else Option.Some(self._val)  # type: ignore
+#     # self.err = err
+#
+#     def map(op):
+#         """
+#         Applies a function to the contained :meth:`Result.Ok` value.
+#
+#         Args:
+#             op: The function to apply to the :meth:`Result.Ok` value.
+#
+#         Returns:
+#             A :class:`Result` with its success value as the function result
+#             if `self` is an :meth:`Result.Ok` value, otherwise returns
+#             `self`.
+#
+#         Examples:
+#             >>> Ok(1).map(lambda x: x * 2)
+#             Ok(2)
+#             >>> Err(1).map(lambda x: x * 2)
+#             Err(1)
+#         """
+#         return self._obj.map(op)
+#         # return self._type.Ok(op(self._val)) if self._is_ok else self  # type: ignore
+#     self.map = map
+#
+#     def flatmap(op):
+#         """
+#         Applies a function to the contained :meth:`Result.Ok` value.
+#
+#         This is different than :meth:`Result.map` because the function
+#         result is not wrapped in a new :class:`Result`.
+#
+#         Args:
+#             op: The function to apply to the contained :meth:`Result.Ok` value.
+#
+#         Returns:
+#             The result of the function if `self` is an :meth:`Result.Ok` value,
+#              otherwise returns `self`.
+#
+#         Examples:
+#             >>> def sq(x): return Ok(x * x)
+#             >>> def err(x): return Err(x)
+#             >>> Ok(2).flatmap(sq).flatmap(sq)
+#             Ok(16)
+#             >>> Ok(2).flatmap(sq).flatmap(err)
+#             Err(4)
+#             >>> Ok(2).flatmap(err).flatmap(sq)
+#             Err(2)
+#             >>> Err(3).flatmap(sq).flatmap(sq)
+#             Err(3)
+#         """
+#         return op(self._val) if self._is_ok else self  # type: ignore
+#     self.flatmap = flatmap
+#
+#     def map_err(op):
+#         """
+#         Applies a function to the contained :meth:`Result.Err` value.
+#
+#         Args:
+#             op: The function to apply to the :meth:`Result.Err` value.
+#
+#         Returns:
+#             A :class:`Result` with its error value as the function result
+#             if `self` is a :meth:`Result.Err` value, otherwise returns
+#             `self`.
+#
+#         Examples:
+#             >>> Ok(1).map_err(lambda x: x * 2)
+#             Ok(1)
+#             >>> Err(1).map_err(lambda x: x * 2)
+#             Err(2)
+#         """
+#         return self._obj.map_err(op)
+#         # return self if self._is_ok else self._type.Error(op(self._val))  # type: ignore
+#     self.map_err = map_err
+#
+#     def unwrap():
+#         """
+#         Returns the success value in the :class:`Result`.
+#
+#         Returns:
+#             The success value in the :class:`Result`.
+#
+#         Raises:
+#             ``ValueError`` with the message provided by the error value
+#              if the :class:`Result` is a :meth:`Result.Err` value.
+#
+#         Examples:
+#             >>> Ok(1).unwrap()
+#             1
+#             >>> try:
+#             ...     Err(1).unwrap()
+#             ... except ValueError as e:
+#             ...     print(e)
+#             1
+#         """
+#         return self._obj.unwrap()
+#     self.unwrap = unwrap
+#
+#     def unwrap_or(optb):
+#         """
+#         Returns the success value in the :class:`Result` or ``optb``.
+#
+#         Args:
+#             optb: The default return value.
+#
+#         Returns:
+#             The success value in the :class:`Result` if it is a
+#             :meth:`Result.Ok` value, otherwise ``optb``.
+#
+#         Notes:
+#             If you wish to use a result of a function call as the default,
+#             it is recommnded to use :meth:`unwrap_or_else` instead.
+#
+#         Examples:
+#             >>> Ok(1).unwrap_or(2)
+#             1
+#             >>> Err(1).unwrap_or(2)
+#             2
+#         """
+#         return self._obj.unwrap_or(optb)
+#     self.unwrap_or = unwrap_or
+#
+#     def unwrap_or_else(op):
+#         """
+#         Returns the sucess value in the :class:`Result` or computes a default
+#         from the error value.
+#
+#         Args:
+#             op: The function to computes default with.
+#
+#         Returns:
+#             The success value in the :class:`Result` if it is
+#              a :meth:`Result.Ok` value, otherwise ``op(E)``.
+#
+#         Examples:
+#             >>> Ok(1).unwrap_or_else(lambda e: e * 10)
+#             1
+#             >>> Err(1).unwrap_or_else(lambda e: e * 10)
+#             10
+#         """
+#         return self._obj.unwrap_or_else(op)
+#         # return self._val if self._is_ok else op(self._val)  # type: ignore
+#     self.unwrap_or_else = unwrap_or_else
+#
+#     def expect(msg):
+#         """
+#         Returns the success value in the :class:`Result` or raises
+#         a ``ValueError`` with a provided message.
+#
+#         Args:
+#             msg: The error message.
+#
+#         Returns:
+#             The success value in the :class:`Result` if it is
+#             a :meth:`Result.Ok` value.
+#
+#         Raises:
+#             ``ValueError`` with ``msg`` as the message if the
+#             :class:`Result` is a :meth:`Result.Err` value.
+#
+#         Examples:
+#             >>> Ok(1).expect('no')
+#             1
+#             >>> try:
+#             ...     Err(1).expect('no')
+#             ... except ValueError as e:
+#             ...     print(e)
+#             no
+#         """
+#         return self._obj.expect(msg)
+#     self.expect = expect
+#
+#     def unwrap_err():
+#         """
+#         Returns the error value in a :class:`Result`.
+#
+#         Returns:
+#             The error value in the :class:`Result` if it is a
+#             :meth:`Result.Err` value.
+#
+#         Raises:
+#             ``ValueError`` with the message provided by the success value
+#              if the :class:`Result` is a :meth:`Result.Ok` value.
+#
+#         Examples:
+#             >>> try:
+#             ...     Ok(1).unwrap_err()
+#             ... except ValueError as e:
+#             ...     print(e)
+#             1
+#             >>> Err('Oh No').unwrap_err()
+#             'Oh No'
+#         """
+#         self._obj.unwrap_err()
+#     self.unwrap_err = unwrap_err
+#
+#     def expect_err(msg):
+#         """
+#         Returns the error value in a :class:`Result`, or raises a
+#         ``ValueError`` with the provided message.
+#
+#         Args:
+#             msg: The error message.
+#
+#         Returns:
+#             The error value in the :class:`Result` if it is a
+#             :meth:`Result.Err` value.
+#
+#         Raises:
+#             ``ValueError`` with the message provided by ``msg`` if
+#             the :class:`Result` is a :meth:`Result.Ok` value.
+#
+#         Examples:
+#             >>> try:
+#             ...     Ok(1).expect_err('Oh No')
+#             ... except ValueError as e:
+#             ...     print(e)
+#             Oh No
+#             >>> Err(1).expect_err('Yes')
+#             1
+#         """
+#         self._obj.expect_err(msg)
+#     self.expect_err = expect_err
+#
+#
+#     def __bool__():
+#         return self._is_ok
+#     self.__bool__ = __bool__
+#
+#     def __repr__():
+#         return ''.join([
+#             'Ok' if self._is_ok else 'Err', '({', repr(self._val), '})'
+#         ])
+#
+#     self.__repr__ = __repr__
+#
+#     def __hash__():
+#         return hash((self._type, self._is_ok, self._val))
+#     self.__hash__ = __hash_
+#
+#     def __eq__(other):
+#         return (types.is_instance(other, self._type)
+#                 and self._is_ok == other._is_ok
+#                 and self._val == other._val)
+#     self.__eq__ = __eq__
+#
+#     def __ne__(other):
+#         return (not types.is_instance(other, self._type)
+#                 or self._is_ok != other._is_ok
+#                 or self._val != other._val)
+#     self.__ne__ = __ne__
+#
+#     def __lt__(other):
+#         if types.is_instance(other, self._type):
+#             if self._is_ok == other._is_ok:
+#                 return self._val < other._val
+#             return self._is_ok
+#         fail("NotImplemented")
+#     self.__lt__ = __lt__
+#
+#     def __le__(other):
+#         if types.is_instance(other, self._type):
+#             if self._is_ok == other._is_ok:
+#                 return self._val <= other._val
+#             return self._is_ok
+#         fail("NotImplemented")
+#     self.__le__ = __le__
+#
+#     def __gt__(other):
+#         if types.is_instance(other, self._type):
+#             if self._is_ok == other._is_ok:
+#                 return self._val > other._val
+#             return other._is_ok
+#         fail("NotImplemented")
+#     self.__gt__ = __gt__
+#
+#     def __ge__(other):
+#         if types.is_instance(other, self._type):
+#             if self._is_ok == other._is_ok:
+#                 return self._val >= other._val
+#             return other._is_ok
+#         fail("NotImplemented")
+#     self.__ge__ = __ge__
+#     return self
+#
+#
+# def Ok(val):
+#     """Shortcut function for :meth:`Result.Ok`.
+#
+#     Contains the success value.
+#
+#     Args:
+#          val: The success value.
+#     Returns:
+#          The :class:`Result` containing the success value.
+#     Examples:
+#         >>> res = Result.Ok(1)
+#         >>> res
+#         Ok(1)
+#         >>> res.is_ok
+#         True
+#     """
+#     return _Result(val, True)
+#
+#
+# def Error(err):
+#     """Shortcut function for :meth:`Result.Err`.
+#
+#     Contains the error value.
+#
+#     Args:
+#         err: The error value.
+#     Returns:
+#         The :class:`Result` containing the error value.
+#     Examples:
+#         >>> res = Result.Error('Oh No')
+#         >>> res
+#         Err('Oh No')
+#         >>> res.is_err
+#         True
+#     """
+#     return _Result(err, False)
 
+def Ok(val):
 
-def _Ok(val):
-    """
-    Contains the success value.
-    Args:
-         val: The success value.
-    Returns:
-         The :class:`Result` containing the success value.
-    Examples:
-        >>> res = Result.Ok(1)
-        >>> res
-        Ok(1)
-        >>> res.is_ok
-        True
-    """
     return _JResult.Ok(val)
 
 
-def _Error(val):
+def Error(val):
     """
     Contains the error value.
     Args:
@@ -27,7 +424,7 @@ def _Error(val):
     Returns:
         The :class:`Result` containing the error value.
     Examples:
-        >>> res = Result.Err('Oh No')
+        >>> res = Result.Error('Oh No')
         >>> res
         Err('Oh No')
         >>> res.is_err
@@ -36,12 +433,37 @@ def _Error(val):
     return _JResult.Error(val)
 
 
-def _of(o):
+def safe(function):
+    """
+    Decorator to convert exception-throwing function to ``Result`` container.
+
+    This decorator only works with sync functions. Example:
+
+    .. code:: python
+        >>> load("@stdlib//larky", "larky")
+        >>> load("@vendor//result", Result="Result", safe="safe")
+        >>> load("@vendor//asserts", "asserts")
+      >>> def might_raise(arg: int) -> float:
+      ...     return 1 / arg
+      >>> asserts.assert_that(safe(might_raise)(1)).is_equal_to(Ok(1.0))
+      >>> asserts.assert_true(types.is_instance(safe(might_raise)(0), Error))
+
+    """
+    def decorator(*args, **kwargs):
+        return _JResult.safe(function(*args, **kwargs))
+        # try:
+        #     return Success(function(*args, **kwargs))
+        # except Exception as exc:
+        #     return Failure(exc)
+    return decorator
+
+
+def of(o):
     return _JResult.of(o)
 
-
 Result = larky.struct(
-    Ok=_Ok,
-    Error=_Error,
-    of=_of
+    Ok=Ok,
+    Error=Error,
+    safe=safe,
+    of=of,
 )

--- a/larky/src/main/resources/vendor/option/result.star
+++ b/larky/src/main/resources/vendor/option/result.star
@@ -440,26 +440,26 @@ def safe(function):
     This decorator only works with sync functions. Example:
 
     .. code:: python
-        >>> load("@stdlib//larky", "larky")
-        >>> load("@vendor//result", Result="Result", safe="safe")
-        >>> load("@vendor//asserts", "asserts")
-      >>> def might_raise(arg: int) -> float:
+
+      >>> load("@stdlib//larky", "larky")
+      >>> load("@vendor//result", Result="Result", safe="safe")
+      >>> load("@vendor//asserts", "asserts")
+      >>> def might_raise(arg):
       ...     return 1 / arg
       >>> asserts.assert_that(safe(might_raise)(1)).is_equal_to(Ok(1.0))
-      >>> asserts.assert_true(types.is_instance(safe(might_raise)(0), Error))
+      >>> failed = safe(might_raise)(0)
+      >>> asserts.assert_fails(lambda: failed.unwrap(), ".*division by zero")
+      >>> asserts.assert_true(failed.is_err)
 
     """
     def decorator(*args, **kwargs):
-        return _JResult.safe(function(*args, **kwargs))
-        # try:
-        #     return Success(function(*args, **kwargs))
-        # except Exception as exc:
-        #     return Failure(exc)
+        return _JResult.safe(function, *args, **kwargs)
     return decorator
 
 
 def of(o):
     return _JResult.of(o)
+
 
 Result = larky.struct(
     Ok=Ok,

--- a/larky/src/main/resources/vendor/option/result.star
+++ b/larky/src/main/resources/vendor/option/result.star
@@ -1,0 +1,47 @@
+load("@stdlib//larky", "larky")
+load("@stdlib//jresult", _JResult="jresult")
+
+
+def _Ok(val):
+    """
+    Contains the success value.
+    Args:
+         val: The success value.
+    Returns:
+         The :class:`Result` containing the success value.
+    Examples:
+        >>> res = Result.Ok(1)
+        >>> res
+        Ok(1)
+        >>> res.is_ok
+        True
+    """
+    return _JResult.Ok(val)
+
+
+def _Error(val):
+    """
+    Contains the error value.
+    Args:
+        err: The error value.
+    Returns:
+        The :class:`Result` containing the error value.
+    Examples:
+        >>> res = Result.Err('Oh No')
+        >>> res
+        Err('Oh No')
+        >>> res.is_err
+        True
+    """
+    return _JResult.Error(val)
+
+
+def _of(o):
+    return _JResult.of(o)
+
+
+Result = larky.struct(
+    Ok=_Ok,
+    Error=_Error,
+    of=_of
+)

--- a/larky/src/test/resources/stdlib_tests/test_larky.star
+++ b/larky/src/test/resources/stdlib_tests/test_larky.star
@@ -14,7 +14,7 @@ def _test_namespace_exposes_larky_builtins():
     :return: None
     """
     items = sorted(dir(larky))
-    asserts.assert_that(items).is_length(7)
+    asserts.assert_that(items).is_length(8)
     asserts.assert_that(items).is_equal_to(sorted([
         "SENTINEL",
         "mutablestruct",
@@ -23,6 +23,7 @@ def _test_namespace_exposes_larky_builtins():
         "struct",
         "to_dict",
         "WHILE_LOOP_EMULATION_ITERATION",
+        "parametrize"
     ]))
 
 

--- a/larky/src/test/resources/stdlib_tests/test_operator.star
+++ b/larky/src/test/resources/stdlib_tests/test_operator.star
@@ -284,8 +284,8 @@ def OperatorTestCase_test_matmul():
 
 def OperatorTestCase_test_neg():
     operator = module
-    asserts.assert_fails(lambda : operator.neg(), ".*?TypeError")
-    asserts.assert_fails(lambda : operator.neg(None), ".*?TypeError")
+    asserts.assert_fails(lambda : operator.neg(), "missing 1 required positional argument")
+    asserts.assert_fails(lambda : operator.neg(None), "unsupported unary operation: -\\w+")
     asserts.assert_that(operator.neg(5)).is_equal_to(-5)
     asserts.assert_that(operator.neg(-5)).is_equal_to(5)
     asserts.assert_that(operator.neg(0)).is_equal_to(0)
@@ -293,14 +293,14 @@ def OperatorTestCase_test_neg():
 
 def OperatorTestCase_test_bitwise_or():
     operator = module
-    asserts.assert_fails(lambda : operator.or_(), ".*?TypeError")
-    asserts.assert_fails(lambda : operator.or_(None, None), ".*?TypeError")
+    asserts.assert_fails(lambda : operator.or_(), "missing 2 required positional arguments")
+    asserts.assert_fails(lambda : operator.or_(None, None), "unsupported binary operation: \\w+ \\| \\w+")
     asserts.assert_that(operator.or_(0xa, 0x5)).is_equal_to(0xf)
 
 def OperatorTestCase_test_pos():
     operator = module
-    asserts.assert_fails(lambda : operator.pos(), ".*?TypeError")
-    asserts.assert_fails(lambda : operator.pos(None), ".*?TypeError")
+    asserts.assert_fails(lambda : operator.pos(), "missing 1 required positional argument")
+    asserts.assert_fails(lambda : operator.pos(None), "unsupported unary operation: \\+\\w+")
     asserts.assert_that(operator.pos(5)).is_equal_to(5)
     asserts.assert_that(operator.pos(-5)).is_equal_to(-5)
     asserts.assert_that(operator.pos(0)).is_equal_to(0)
@@ -308,24 +308,24 @@ def OperatorTestCase_test_pos():
 
 def OperatorTestCase_test_pow():
     operator = module
-    asserts.assert_fails(lambda : operator.pow(), ".*?TypeError")
-    asserts.assert_fails(lambda : operator.pow(None, None), ".*?TypeError")
+    asserts.assert_fails(lambda : operator.pow(), "missing 2 required positional arguments")
+    asserts.assert_fails(lambda : operator.pow(None, None), ".*?got value of type '\\w+', want 'int'")
     asserts.assert_that(operator.pow(3,5)).is_equal_to(pow(3, 5))
-    asserts.assert_fails(lambda : operator.pow(1), ".*?TypeError")
-    asserts.assert_fails(lambda : operator.pow(1, 2, 3), ".*?TypeError")
+    asserts.assert_fails(lambda : operator.pow(1), "missing 1 required positional argument")
+    asserts.assert_fails(lambda : operator.pow(1, 2, 3), ".*?accepts no more than 2 positional arguments but got")
 
 def OperatorTestCase_test_rshift():
     operator = module
-    asserts.assert_fails(lambda : operator.rshift(), ".*?TypeError")
-    asserts.assert_fails(lambda : operator.rshift(None, 42), ".*?TypeError")
+    asserts.assert_fails(lambda : operator.rshift(), "missing 2 required positional arguments")
+    asserts.assert_fails(lambda : operator.rshift(None, 42), ".*?unsupported binary operation: \\w+ >> \\w+")
     asserts.assert_that(operator.rshift(5, 1)).is_equal_to(2)
     asserts.assert_that(operator.rshift(5, 0)).is_equal_to(5)
-    asserts.assert_fails(lambda : operator.rshift(2, -1), ".*?ValueError")
+    asserts.assert_fails(lambda : operator.rshift(2, -1), ".*?negative shift count")
 
 def OperatorTestCase_test_contains():
     operator = module
-    asserts.assert_fails(lambda : operator.contains(), ".*?TypeError")
-    asserts.assert_fails(lambda : operator.contains(None, None), ".*?TypeError")
+    asserts.assert_fails(lambda : operator.contains(), "missing 2 required positional arguments")
+    asserts.assert_fails(lambda : operator.contains(None, None), ".*?TypeError: type '\\w+' is not iterable")
     asserts.assert_fails(lambda : operator.contains(BadIterable(), 1), ".*?ZeroDivisionError")
     asserts.assert_that(operator.contains(range(4), 2)).is_true()
     asserts.assert_that(operator.contains(range(4), 5)).is_false()
@@ -333,16 +333,16 @@ def OperatorTestCase_test_contains():
 def OperatorTestCase_test_setitem():
     operator = module
     a = list(range(3))
-    asserts.assert_fails(lambda : operator.setitem(a), ".*?TypeError")
-    asserts.assert_fails(lambda : operator.setitem(a, None, None), ".*?TypeError")
+    asserts.assert_fails(lambda : operator.setitem(a), "missing 2 required positional arguments")
+    asserts.assert_fails(lambda : operator.setitem(a, None, None), ".*?got \\w+ for list index, want int")
     asserts.assert_that(operator.setitem(a, 0, 2)).is_none()
     asserts.assert_that(a).is_equal_to([2, 1, 2])
-    asserts.assert_fails(lambda : operator.setitem(a, 4, 2), ".*?IndexError")
+    asserts.assert_fails(lambda : operator.setitem(a, 4, 2), ".*?index out of range")
 
 def OperatorTestCase_test_sub():
     operator = module
-    asserts.assert_fails(lambda : operator.sub(), ".*?TypeError")
-    asserts.assert_fails(lambda : operator.sub(None, None), ".*?TypeError")
+    asserts.assert_fails(lambda : operator.sub(), "missing 2 required positional arguments")
+    asserts.assert_fails(lambda : operator.sub(None, None), ".*?unsupported binary operation: \\w+ \\- \\w+")
     asserts.assert_that(operator.sub(5, 2)).is_equal_to(3)
 
 def OperatorTestCase_test_truth():
@@ -353,7 +353,7 @@ def OperatorTestCase_test_truth():
             fail(" SyntaxError")
         self.__bool__ = __bool__
         return self
-    asserts.assert_fails(lambda : operator.truth(), ".*?TypeError")
+    asserts.assert_fails(lambda : operator.truth(), "missing 1 required positional argument")
     asserts.assert_fails(lambda : operator.truth(C()), ".*?SyntaxError")
     asserts.assert_that(operator.truth(5)).is_true()
     asserts.assert_that(operator.truth([0])).is_true()
@@ -362,8 +362,8 @@ def OperatorTestCase_test_truth():
 
 def OperatorTestCase_test_bitwise_xor():
     operator = module
-    asserts.assert_fails(lambda : operator.xor(), ".*?TypeError")
-    asserts.assert_fails(lambda : operator.xor(None, None), ".*?TypeError")
+    asserts.assert_fails(lambda : operator.xor(), "missing 2 required positional arguments")
+    asserts.assert_fails(lambda : operator.xor(None, None), ".*?unsupported binary operation: \\w+ \\^ \\w+")
     asserts.assert_that(operator.xor(0xb, 0xc)).is_equal_to(0x7)
 
 def OperatorTestCase_test_is():
@@ -371,18 +371,20 @@ def OperatorTestCase_test_is():
     a = 'xyzpdq'
     b = a
     c = a[:3] + b[3:]
-    asserts.assert_fails(lambda : operator.is_(), ".*?TypeError")
+    asserts.assert_fails(lambda : operator.is_(), "missing 2 required positional arguments")
     asserts.assert_that(operator.is_(a, b)).is_true()
-    asserts.assert_that(operator.is_(a,c)).is_false()
+    # in starlark, there is no is operator, so this test will never be false!
+    # asserts.assert_that(operator.is_(a,c)).is_false()
 
 def OperatorTestCase_test_is_not():
     operator = module
     a = 'xyzpdq'
     b = a
     c = a[:3] + b[3:]
-    asserts.assert_fails(lambda : operator.is_not(), ".*?TypeError")
+    asserts.assert_fails(lambda : operator.is_not(), "missing 2 required positional arguments")
     asserts.assert_that(operator.is_not(a, b)).is_false()
-    asserts.assert_that(operator.is_not(a,c)).is_true()
+    # in starlark, there is no is operator, so this test will never be true!
+    # asserts.assert_that(operator.is_not(a,c)).is_true()
 
 def OperatorTestCase_test_attrgetter():
     operator = module
@@ -393,13 +395,13 @@ def OperatorTestCase_test_attrgetter():
     a.name = 'arthur'
     f = operator.attrgetter('name')
     asserts.assert_that(f(a)).is_equal_to('arthur')
-    asserts.assert_fails(lambda : f(), ".*?TypeError")
-    asserts.assert_fails(lambda : f(a, 'dent'), ".*?TypeError")
-    asserts.assert_fails(lambda : f(a, surname='dent'), ".*?TypeError")
+    asserts.assert_fails(lambda : f(), "missing 1 required positional argument")
+    asserts.assert_fails(lambda : f(a, 'dent'), ".*?accepts no more than 1 positional argument")
+    asserts.assert_fails(lambda : f(a, surname='dent'), ".*?got unexpected keyword argument")
     f = operator.attrgetter('rank')
-    asserts.assert_fails(lambda : f(a), ".*?AttributeError")
+    asserts.assert_fails(lambda : f(a), ".*?value has no field or method")
     asserts.assert_fails(lambda : operator.attrgetter(2), ".*?TypeError")
-    asserts.assert_fails(lambda : operator.attrgetter(), ".*?TypeError")
+    asserts.assert_fails(lambda : operator.attrgetter(), ".*?TypeError: attrgetter expected 1 argument")
 
     # multiple gets
     record = A()
@@ -421,35 +423,36 @@ def OperatorTestCase_test_attrgetter():
     a.name = 'arthur'
     a.child = A()
     a.child.name = 'thomas'
-    f = operator.attrgetter('child.name')
-    asserts.assert_that(f(a)).is_equal_to('thomas')
-    asserts.assert_fails(lambda : f(a.child), ".*?AttributeError")
-    f = operator.attrgetter('name', 'child.name')
-    asserts.assert_that(f(a)).is_equal_to(('arthur', 'thomas'))
-    f = operator.attrgetter('name', 'child.name', 'child.child.name')
-    asserts.assert_fails(lambda : f(a), ".*?AttributeError")
-    f = operator.attrgetter('child.')
-    asserts.assert_fails(lambda : f(a), ".*?AttributeError")
-    f = operator.attrgetter('.child')
-    asserts.assert_fails(lambda : f(a), ".*?AttributeError")
-
-    a.child.child = A()
-    a.child.child.name = 'johnson'
-    f = operator.attrgetter('child.child.name')
-    asserts.assert_that(f(a)).is_equal_to('johnson')
-    f = operator.attrgetter('name', 'child.name', 'child.child.name')
-    asserts.assert_that(f(a)).is_equal_to(('arthur', 'thomas', 'johnson'))
+    asserts.assert_fails(lambda : operator.attrgetter('child.name'), ".*not supported")
+    # f = operator.attrgetter('child.name')
+    # asserts.assert_that(f(a)).is_equal_to('thomas')
+    # asserts.assert_fails(lambda : f(a.child), ".*?AttributeError")
+    # f = operator.attrgetter('name', 'child.name')
+    # asserts.assert_that(f(a)).is_equal_to(('arthur', 'thomas'))
+    # f = operator.attrgetter('name', 'child.name', 'child.child.name')
+    # asserts.assert_fails(lambda : f(a), ".*?AttributeError")
+    # f = operator.attrgetter('child.')
+    # asserts.assert_fails(lambda : f(a), ".*?AttributeError")
+    # f = operator.attrgetter('.child')
+    # asserts.assert_fails(lambda : f(a), ".*?AttributeError")
+    #
+    # a.child.child = A()
+    # a.child.child.name = 'johnson'
+    # f = operator.attrgetter('child.child.name')
+    # asserts.assert_that(f(a)).is_equal_to('johnson')
+    # f = operator.attrgetter('name', 'child.name', 'child.child.name')
+    # asserts.assert_that(f(a)).is_equal_to(('arthur', 'thomas', 'johnson'))
 
 def OperatorTestCase_test_itemgetter():
     operator = module
     a = 'ABCDE'
     f = operator.itemgetter(2)
     asserts.assert_that(f(a)).is_equal_to('C')
-    asserts.assert_fails(lambda : f(), ".*?TypeError")
-    asserts.assert_fails(lambda : f(a, 3), ".*?TypeError")
-    asserts.assert_fails(lambda : f(a, size=3), ".*?TypeError")
+    asserts.assert_fails(lambda : f(), "missing 1 required positional argument")
+    asserts.assert_fails(lambda : f(a, 3), ".*?accepts no more than 1 positional argument but got")
+    asserts.assert_fails(lambda : f(a, size=3), ".*?got unexpected keyword argument")
     f = operator.itemgetter(10)
-    asserts.assert_fails(lambda : f(a), ".*?IndexError")
+    asserts.assert_fails(lambda : f(a), ".*?index out of range")
     def C():
         self = larky.mutablestruct(__class__='C')
         def __getitem__(name):
@@ -459,14 +462,14 @@ def OperatorTestCase_test_itemgetter():
     asserts.assert_fails(lambda : operator.itemgetter(42)(C()), ".*?SyntaxError")
 
     f = operator.itemgetter('name')
-    asserts.assert_fails(lambda : f(a), ".*?TypeError")
+    asserts.assert_fails(lambda : f(a), ".*?got string for string index, want int")
     asserts.assert_fails(lambda : operator.itemgetter(), ".*?TypeError")
 
     d = dict(key='val')
     f = operator.itemgetter('key')
     asserts.assert_that(f(d)).is_equal_to('val')
     f = operator.itemgetter('nonkey')
-    asserts.assert_fails(lambda : f(d), ".*?KeyError")
+    asserts.assert_fails(lambda : f(d), '.*?key "nonkey" not found in dictionary')
 
     # example used in the docs
     inventory = [('apple', 3), ('banana', 2), ('pear', 5), ('orange', 1)]
@@ -478,23 +481,24 @@ def OperatorTestCase_test_itemgetter():
     # multiple gets
     data = list(map(str, range(20)))
     asserts.assert_that(operator.itemgetter(2,10,5)(data)).is_equal_to(('2', '10', '5'))
-    asserts.assert_fails(lambda : operator.itemgetter(2, 'x', 5)(data), ".*?TypeError")
+    asserts.assert_fails(lambda : operator.itemgetter(2, 'x', 5)(data), ".*?got string for sequence index, want int")
 
     # interesting indices
-    t = tuple('abcde')
+    t = tuple('abcde'.elems())
     asserts.assert_that(operator.itemgetter(-1)(t)).is_equal_to('e')
     #asserts.assert_that(operator.itemgetter(slice(2, 4))(t)).is_equal_to(('c', 'd'))
-    def T():
-        'Tuple subclass'
-        self = larky.mutablestruct(__class__='T')
-        return self
-    asserts.assert_that(operator.itemgetter(0)(T('abc'))).is_equal_to('a')
+    # Larky does not support any subclasses
+    # def T():
+    #     'Tuple subclass'
+    #     self = larky.mutablestruct(__class__='T')
+    #     return self
+    # asserts.assert_that(operator.itemgetter(0)(T('abc'))).is_equal_to('a')
     asserts.assert_that(operator.itemgetter(0)(['a', 'b', 'c'])).is_equal_to('a')
     asserts.assert_that(operator.itemgetter(0)(range(100, 200))).is_equal_to(100)
 
 def OperatorTestCase_test_methodcaller():
     operator = module
-    asserts.assert_fails(lambda : operator.methodcaller(), ".*?TypeError")
+    asserts.assert_fails(lambda : operator.methodcaller(), "missing 1 required positional argument")
     asserts.assert_fails(lambda : operator.methodcaller(12), ".*?TypeError")
     def A():
         self = larky.mutablestruct(__class__='A')
@@ -510,19 +514,20 @@ def OperatorTestCase_test_methodcaller():
         return self
     a = A()
     f = operator.methodcaller('foo')
-    asserts.assert_fails(lambda : f(a), ".*?IndexError")
+    asserts.assert_fails(lambda : f(a), ".*?index out of range")
     f = operator.methodcaller('foo', 1, 2)
     asserts.assert_that(f(a)).is_equal_to(3)
-    asserts.assert_fails(lambda : f(), ".*?TypeError")
-    asserts.assert_fails(lambda : f(a, 3), ".*?TypeError")
-    asserts.assert_fails(lambda : f(a, spam=3), ".*?TypeError")
+    asserts.assert_fails(lambda : f(), ".*?missing 1 required positional argument")
+    asserts.assert_fails(lambda : f(a, 3), ".*?accepts no more than 1 positional argument")
+    asserts.assert_fails(lambda : f(a, spam=3), ".*?got unexpected keyword argument")
     f = operator.methodcaller('bar')
     asserts.assert_that(f(a)).is_equal_to(42)
-    asserts.assert_fails(lambda : f(a, a), ".*?TypeError")
+    asserts.assert_fails(lambda : f(a, a), ".*?accepts no more than 1 positional argument")
     f = operator.methodcaller('bar', f=5)
     asserts.assert_that(f(a)).is_equal_to(5)
-    f = operator.methodcaller('baz', name='spam', self='eggs')
-    asserts.assert_that(f(a)).is_equal_to(('spam', 'eggs'))
+    # Larky does not support multiple values with same name as parameters
+    # f = operator.methodcaller('baz', name='spam', self='eggs')
+    # asserts.assert_that(f(a)).is_equal_to(('spam', 'eggs'))
 
 def OperatorTestCase_test_inplace():
     operator = module
@@ -607,23 +612,23 @@ def _testsuite():
     _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_mod))
     _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_mul))
     # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_matmul))
-    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_neg))
-    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_bitwise_or))
-    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_pos))
-    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_pow))
-    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_rshift))
-    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_contains))
-    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_setitem))
-    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_sub))
-    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_truth))
-    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_bitwise_xor))
-    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_is))
-    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_is_not))
-    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_attrgetter))
-    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_itemgetter))
-    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_methodcaller))
-    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_inplace))
-    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_dunder_is_original))
+    _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_neg))
+    _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_bitwise_or))
+    _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_pos))
+    _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_pow))
+    _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_rshift))
+    _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_contains))
+    _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_setitem))
+    _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_sub))
+    _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_truth))
+    _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_bitwise_xor))
+    _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_is))
+    _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_is_not))
+    _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_attrgetter))
+    _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_itemgetter))
+    _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_methodcaller))
+    _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_inplace))
+    _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_dunder_is_original))
     return _suite
 
 _runner = unittest.TextTestRunner()

--- a/larky/src/test/resources/stdlib_tests/test_operator.star
+++ b/larky/src/test/resources/stdlib_tests/test_operator.star
@@ -245,28 +245,28 @@ def OperatorTestCase_test_indexOf():
 
 def OperatorTestCase_test_invert():
     operator = module
-    asserts.assert_fails(lambda : operator.invert(), "missing 1 required positional arguments")
-    asserts.assert_fails(lambda : operator.invert(None), ".*?TypeError")
+    asserts.assert_fails(lambda : operator.invert(), "missing 1 required positional argument")
+    asserts.assert_fails(lambda : operator.invert(None), "unsupported unary operation\\: \\~")
     asserts.assert_that(operator.inv(4)).is_equal_to(-5)
 
 def OperatorTestCase_test_lshift():
     operator = module
     asserts.assert_fails(lambda : operator.lshift(), "missing 2 required positional arguments")
-    asserts.assert_fails(lambda : operator.lshift(None, 42), ".*?TypeError")
+    asserts.assert_fails(lambda : operator.lshift(None, 42), "unsupported binary operation: \\w+ << \\w+")
     asserts.assert_that(operator.lshift(5, 1)).is_equal_to(10)
     asserts.assert_that(operator.lshift(5, 0)).is_equal_to(5)
-    asserts.assert_fails(lambda : operator.lshift(2, -1), ".*?ValueError")
+    asserts.assert_fails(lambda : operator.lshift(2, -1), "negative shift count: -1")
 
 def OperatorTestCase_test_mod():
     operator = module
     asserts.assert_fails(lambda : operator.mod(), "missing 2 required positional arguments")
-    asserts.assert_fails(lambda : operator.mod(None, 42), ".*?TypeError")
+    asserts.assert_fails(lambda : operator.mod(None, 42), "unsupported binary operation: \\w+ % \\w+")
     asserts.assert_that(operator.mod(5, 2)).is_equal_to(1)
 
 def OperatorTestCase_test_mul():
     operator = module
     asserts.assert_fails(lambda : operator.mul(), "missing 2 required positional arguments")
-    asserts.assert_fails(lambda : operator.mul(None, None), ".*?TypeError")
+    asserts.assert_fails(lambda : operator.mul(None, None), "unsupported binary operation: \\w+ \\* \\w+")
     asserts.assert_that(operator.mul(5, 2)).is_equal_to(10)
 
 
@@ -311,9 +311,6 @@ def _testsuite():
     # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_methodcaller))
     # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_inplace))
     # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_dunder_is_original))
-    # _suite.addTest(unittest.FunctionTestCase(OperatorPickleTestCase_test_attrgetter))
-    # _suite.addTest(unittest.FunctionTestCase(OperatorPickleTestCase_test_itemgetter))
-    # _suite.addTest(unittest.FunctionTestCase(OperatorPickleTestCase_test_methodcaller))
     return _suite
 
 _runner = unittest.TextTestRunner()

--- a/larky/src/test/resources/stdlib_tests/test_operator.star
+++ b/larky/src/test/resources/stdlib_tests/test_operator.star
@@ -6,6 +6,7 @@ load("@stdlib//larky", "larky")
 load("@stdlib//operator", module="operator")
 load("@stdlib//unittest", "unittest")
 load("@vendor//asserts", "asserts")
+load("@stdlib//builtins", map="map")
 
 
 def Seq1(lst):
@@ -269,6 +270,318 @@ def OperatorTestCase_test_mul():
     asserts.assert_fails(lambda : operator.mul(None, None), "unsupported binary operation: \\w+ \\* \\w+")
     asserts.assert_that(operator.mul(5, 2)).is_equal_to(10)
 
+def OperatorTestCase_test_matmul():
+    operator = module
+    asserts.assert_fails(lambda : operator.matmul(), ".*?TypeError")
+    asserts.assert_fails(lambda : operator.matmul(42, 42), ".*?TypeError")
+    def M():
+        self = larky.mutablestruct(__class__='M')
+        def __matmul__(other):
+            return other - 1
+        self.__matmul__ = __matmul__
+        return self
+    asserts.assert_that(operator.matmul(M(), 42)).is_equal_to(41)
+
+def OperatorTestCase_test_neg():
+    operator = module
+    asserts.assert_fails(lambda : operator.neg(), ".*?TypeError")
+    asserts.assert_fails(lambda : operator.neg(None), ".*?TypeError")
+    asserts.assert_that(operator.neg(5)).is_equal_to(-5)
+    asserts.assert_that(operator.neg(-5)).is_equal_to(5)
+    asserts.assert_that(operator.neg(0)).is_equal_to(0)
+    asserts.assert_that(operator.neg(-0)).is_equal_to(0)
+
+def OperatorTestCase_test_bitwise_or():
+    operator = module
+    asserts.assert_fails(lambda : operator.or_(), ".*?TypeError")
+    asserts.assert_fails(lambda : operator.or_(None, None), ".*?TypeError")
+    asserts.assert_that(operator.or_(0xa, 0x5)).is_equal_to(0xf)
+
+def OperatorTestCase_test_pos():
+    operator = module
+    asserts.assert_fails(lambda : operator.pos(), ".*?TypeError")
+    asserts.assert_fails(lambda : operator.pos(None), ".*?TypeError")
+    asserts.assert_that(operator.pos(5)).is_equal_to(5)
+    asserts.assert_that(operator.pos(-5)).is_equal_to(-5)
+    asserts.assert_that(operator.pos(0)).is_equal_to(0)
+    asserts.assert_that(operator.pos(-0)).is_equal_to(0)
+
+def OperatorTestCase_test_pow():
+    operator = module
+    asserts.assert_fails(lambda : operator.pow(), ".*?TypeError")
+    asserts.assert_fails(lambda : operator.pow(None, None), ".*?TypeError")
+    asserts.assert_that(operator.pow(3,5)).is_equal_to(pow(3, 5))
+    asserts.assert_fails(lambda : operator.pow(1), ".*?TypeError")
+    asserts.assert_fails(lambda : operator.pow(1, 2, 3), ".*?TypeError")
+
+def OperatorTestCase_test_rshift():
+    operator = module
+    asserts.assert_fails(lambda : operator.rshift(), ".*?TypeError")
+    asserts.assert_fails(lambda : operator.rshift(None, 42), ".*?TypeError")
+    asserts.assert_that(operator.rshift(5, 1)).is_equal_to(2)
+    asserts.assert_that(operator.rshift(5, 0)).is_equal_to(5)
+    asserts.assert_fails(lambda : operator.rshift(2, -1), ".*?ValueError")
+
+def OperatorTestCase_test_contains():
+    operator = module
+    asserts.assert_fails(lambda : operator.contains(), ".*?TypeError")
+    asserts.assert_fails(lambda : operator.contains(None, None), ".*?TypeError")
+    asserts.assert_fails(lambda : operator.contains(BadIterable(), 1), ".*?ZeroDivisionError")
+    asserts.assert_that(operator.contains(range(4), 2)).is_true()
+    asserts.assert_that(operator.contains(range(4), 5)).is_false()
+
+def OperatorTestCase_test_setitem():
+    operator = module
+    a = list(range(3))
+    asserts.assert_fails(lambda : operator.setitem(a), ".*?TypeError")
+    asserts.assert_fails(lambda : operator.setitem(a, None, None), ".*?TypeError")
+    asserts.assert_that(operator.setitem(a, 0, 2)).is_none()
+    asserts.assert_that(a).is_equal_to([2, 1, 2])
+    asserts.assert_fails(lambda : operator.setitem(a, 4, 2), ".*?IndexError")
+
+def OperatorTestCase_test_sub():
+    operator = module
+    asserts.assert_fails(lambda : operator.sub(), ".*?TypeError")
+    asserts.assert_fails(lambda : operator.sub(None, None), ".*?TypeError")
+    asserts.assert_that(operator.sub(5, 2)).is_equal_to(3)
+
+def OperatorTestCase_test_truth():
+    operator = module
+    def C():
+        self = larky.mutablestruct(__class__='C')
+        def __bool__():
+            fail(" SyntaxError")
+        self.__bool__ = __bool__
+        return self
+    asserts.assert_fails(lambda : operator.truth(), ".*?TypeError")
+    asserts.assert_fails(lambda : operator.truth(C()), ".*?SyntaxError")
+    asserts.assert_that(operator.truth(5)).is_true()
+    asserts.assert_that(operator.truth([0])).is_true()
+    asserts.assert_that(operator.truth(0)).is_false()
+    asserts.assert_that(operator.truth([])).is_false()
+
+def OperatorTestCase_test_bitwise_xor():
+    operator = module
+    asserts.assert_fails(lambda : operator.xor(), ".*?TypeError")
+    asserts.assert_fails(lambda : operator.xor(None, None), ".*?TypeError")
+    asserts.assert_that(operator.xor(0xb, 0xc)).is_equal_to(0x7)
+
+def OperatorTestCase_test_is():
+    operator = module
+    a = 'xyzpdq'
+    b = a
+    c = a[:3] + b[3:]
+    asserts.assert_fails(lambda : operator.is_(), ".*?TypeError")
+    asserts.assert_that(operator.is_(a, b)).is_true()
+    asserts.assert_that(operator.is_(a,c)).is_false()
+
+def OperatorTestCase_test_is_not():
+    operator = module
+    a = 'xyzpdq'
+    b = a
+    c = a[:3] + b[3:]
+    asserts.assert_fails(lambda : operator.is_not(), ".*?TypeError")
+    asserts.assert_that(operator.is_not(a, b)).is_false()
+    asserts.assert_that(operator.is_not(a,c)).is_true()
+
+def OperatorTestCase_test_attrgetter():
+    operator = module
+    def A():
+        self = larky.mutablestruct(__class__='A')
+        return self
+    a = A()
+    a.name = 'arthur'
+    f = operator.attrgetter('name')
+    asserts.assert_that(f(a)).is_equal_to('arthur')
+    asserts.assert_fails(lambda : f(), ".*?TypeError")
+    asserts.assert_fails(lambda : f(a, 'dent'), ".*?TypeError")
+    asserts.assert_fails(lambda : f(a, surname='dent'), ".*?TypeError")
+    f = operator.attrgetter('rank')
+    asserts.assert_fails(lambda : f(a), ".*?AttributeError")
+    asserts.assert_fails(lambda : operator.attrgetter(2), ".*?TypeError")
+    asserts.assert_fails(lambda : operator.attrgetter(), ".*?TypeError")
+
+    # multiple gets
+    record = A()
+    record.x = 'X'
+    record.y = 'Y'
+    record.z = 'Z'
+    asserts.assert_that(operator.attrgetter('x','z','y')(record)).is_equal_to(('X', 'Z', 'Y'))
+    asserts.assert_fails(lambda : operator.attrgetter(('x', (), 'y')), ".*?TypeError")
+    def C():
+        self = larky.mutablestruct(__class__='C')
+        def __getattr__(name):
+            fail(" SyntaxError")
+        self.__getattr__ = __getattr__
+        return self
+    asserts.assert_fails(lambda : operator.attrgetter('foo')(C()), ".*?SyntaxError")
+
+    # recursive gets
+    a = A()
+    a.name = 'arthur'
+    a.child = A()
+    a.child.name = 'thomas'
+    f = operator.attrgetter('child.name')
+    asserts.assert_that(f(a)).is_equal_to('thomas')
+    asserts.assert_fails(lambda : f(a.child), ".*?AttributeError")
+    f = operator.attrgetter('name', 'child.name')
+    asserts.assert_that(f(a)).is_equal_to(('arthur', 'thomas'))
+    f = operator.attrgetter('name', 'child.name', 'child.child.name')
+    asserts.assert_fails(lambda : f(a), ".*?AttributeError")
+    f = operator.attrgetter('child.')
+    asserts.assert_fails(lambda : f(a), ".*?AttributeError")
+    f = operator.attrgetter('.child')
+    asserts.assert_fails(lambda : f(a), ".*?AttributeError")
+
+    a.child.child = A()
+    a.child.child.name = 'johnson'
+    f = operator.attrgetter('child.child.name')
+    asserts.assert_that(f(a)).is_equal_to('johnson')
+    f = operator.attrgetter('name', 'child.name', 'child.child.name')
+    asserts.assert_that(f(a)).is_equal_to(('arthur', 'thomas', 'johnson'))
+
+def OperatorTestCase_test_itemgetter():
+    operator = module
+    a = 'ABCDE'
+    f = operator.itemgetter(2)
+    asserts.assert_that(f(a)).is_equal_to('C')
+    asserts.assert_fails(lambda : f(), ".*?TypeError")
+    asserts.assert_fails(lambda : f(a, 3), ".*?TypeError")
+    asserts.assert_fails(lambda : f(a, size=3), ".*?TypeError")
+    f = operator.itemgetter(10)
+    asserts.assert_fails(lambda : f(a), ".*?IndexError")
+    def C():
+        self = larky.mutablestruct(__class__='C')
+        def __getitem__(name):
+            fail(" SyntaxError")
+        self.__getitem__ = __getitem__
+        return self
+    asserts.assert_fails(lambda : operator.itemgetter(42)(C()), ".*?SyntaxError")
+
+    f = operator.itemgetter('name')
+    asserts.assert_fails(lambda : f(a), ".*?TypeError")
+    asserts.assert_fails(lambda : operator.itemgetter(), ".*?TypeError")
+
+    d = dict(key='val')
+    f = operator.itemgetter('key')
+    asserts.assert_that(f(d)).is_equal_to('val')
+    f = operator.itemgetter('nonkey')
+    asserts.assert_fails(lambda : f(d), ".*?KeyError")
+
+    # example used in the docs
+    inventory = [('apple', 3), ('banana', 2), ('pear', 5), ('orange', 1)]
+    getcount = operator.itemgetter(1)
+    asserts.assert_that(list(map(getcount, inventory))).is_equal_to([3, 2, 5, 1])
+    asserts.assert_that(sorted(inventory, key=getcount)).is_equal_to(
+        [('orange', 1), ('banana', 2), ('apple', 3), ('pear', 5)])
+
+    # multiple gets
+    data = list(map(str, range(20)))
+    asserts.assert_that(operator.itemgetter(2,10,5)(data)).is_equal_to(('2', '10', '5'))
+    asserts.assert_fails(lambda : operator.itemgetter(2, 'x', 5)(data), ".*?TypeError")
+
+    # interesting indices
+    t = tuple('abcde')
+    asserts.assert_that(operator.itemgetter(-1)(t)).is_equal_to('e')
+    #asserts.assert_that(operator.itemgetter(slice(2, 4))(t)).is_equal_to(('c', 'd'))
+    def T():
+        'Tuple subclass'
+        self = larky.mutablestruct(__class__='T')
+        return self
+    asserts.assert_that(operator.itemgetter(0)(T('abc'))).is_equal_to('a')
+    asserts.assert_that(operator.itemgetter(0)(['a', 'b', 'c'])).is_equal_to('a')
+    asserts.assert_that(operator.itemgetter(0)(range(100, 200))).is_equal_to(100)
+
+def OperatorTestCase_test_methodcaller():
+    operator = module
+    asserts.assert_fails(lambda : operator.methodcaller(), ".*?TypeError")
+    asserts.assert_fails(lambda : operator.methodcaller(12), ".*?TypeError")
+    def A():
+        self = larky.mutablestruct(__class__='A')
+        def foo(*args, **kwds):
+            return args[0] + args[1]
+        self.foo = foo
+        def bar(f=42):
+            return f
+        self.bar = bar
+        def baz(*args, **kwds):
+            return kwds['name'], kwds['self']
+        self.baz = baz
+        return self
+    a = A()
+    f = operator.methodcaller('foo')
+    asserts.assert_fails(lambda : f(a), ".*?IndexError")
+    f = operator.methodcaller('foo', 1, 2)
+    asserts.assert_that(f(a)).is_equal_to(3)
+    asserts.assert_fails(lambda : f(), ".*?TypeError")
+    asserts.assert_fails(lambda : f(a, 3), ".*?TypeError")
+    asserts.assert_fails(lambda : f(a, spam=3), ".*?TypeError")
+    f = operator.methodcaller('bar')
+    asserts.assert_that(f(a)).is_equal_to(42)
+    asserts.assert_fails(lambda : f(a, a), ".*?TypeError")
+    f = operator.methodcaller('bar', f=5)
+    asserts.assert_that(f(a)).is_equal_to(5)
+    f = operator.methodcaller('baz', name='spam', self='eggs')
+    asserts.assert_that(f(a)).is_equal_to(('spam', 'eggs'))
+
+def OperatorTestCase_test_inplace():
+    operator = module
+    def C():
+        self = larky.mutablestruct(__class__='C')
+        def __iadd__     (other): return "iadd"
+        self.__iadd__ = __iadd__
+        def __iand__     (other): return "iand"
+        self.__iand__ = __iand__
+        def __ifloordiv__(other): return "ifloordiv"
+        self.__ifloordiv__ = __ifloordiv__
+        def __ilshift__  (other): return "ilshift"
+        self.__ilshift__ = __ilshift__
+        def __imod__     (other): return "imod"
+        self.__imod__ = __imod__
+        def __imul__     (other): return "imul"
+        self.__imul__ = __imul__
+        def __imatmul__  (other): return "imatmul"
+        self.__imatmul__ = __imatmul__
+        def __ior__      (other): return "ior"
+        self.__ior__ = __ior__
+        def __ipow__     (other): return "ipow"
+        self.__ipow__ = __ipow__
+        def __irshift__  (other): return "irshift"
+        self.__irshift__ = __irshift__
+        def __isub__     (other): return "isub"
+        self.__isub__ = __isub__
+        def __itruediv__ (other): return "itruediv"
+        self.__itruediv__ = __itruediv__
+        def __ixor__     (other): return "ixor"
+        self.__ixor__ = __ixor__
+        def __getitem__(other): return 5  # so that C is a sequence
+        self.__getitem__ = __getitem__
+        return self
+    c = C()
+    asserts.assert_that(operator.iadd     (c, 5)).is_equal_to("iadd")
+    asserts.assert_that(operator.iand     (c, 5)).is_equal_to("iand")
+    asserts.assert_that(operator.ifloordiv(c, 5)).is_equal_to("ifloordiv")
+    asserts.assert_that(operator.ilshift  (c, 5)).is_equal_to("ilshift")
+    asserts.assert_that(operator.imod     (c, 5)).is_equal_to("imod")
+    asserts.assert_that(operator.imul     (c, 5)).is_equal_to("imul")
+    asserts.assert_that(operator.imatmul  (c, 5)).is_equal_to("imatmul")
+    asserts.assert_that(operator.ior      (c, 5)).is_equal_to("ior")
+    asserts.assert_that(operator.ipow     (c, 5)).is_equal_to("ipow")
+    asserts.assert_that(operator.irshift  (c, 5)).is_equal_to("irshift")
+    asserts.assert_that(operator.isub     (c, 5)).is_equal_to("isub")
+    asserts.assert_that(operator.itruediv (c, 5)).is_equal_to("itruediv")
+    asserts.assert_that(operator.ixor     (c, 5)).is_equal_to("ixor")
+    asserts.assert_that(operator.iconcat  (c, c)).is_equal_to("iadd")
+
+def OperatorTestCase_test_dunder_is_original():
+    operator = module
+
+    names = [name for name in dir(operator) if not name.startswith('_')]
+    for name in names:
+        orig = getattr(operator, name)
+        dunder = getattr(operator, '__' + name.strip('_') + '__', None)
+        if dunder:
+            asserts.assert_that(dunder).is_equal_to(orig)
 
 def _testsuite():
     _suite = unittest.TestSuite()

--- a/larky/src/test/resources/stdlib_tests/test_operator.star
+++ b/larky/src/test/resources/stdlib_tests/test_operator.star
@@ -56,8 +56,12 @@ def Seq2(lst):
     return self
 
 
-def BadIterable___iter__():
-    fail(" ZeroDivisionError")
+def BadIterable():
+    self = larky.mutablestruct(__class__='BadIterable')
+    def __iter__():
+        fail(" ZeroDivisionError")
+    self.__iter__ = __iter__
+    return self
 
 
 def OperatorTestCase_test_lt():
@@ -125,29 +129,170 @@ def OperatorTestCase_test_general():
     asserts.assert_(im([1, 2, 3]) == (1, 3))
 
 
+def OperatorTestCase_test_ne():
+    operator = module
+    def C():
+        self = larky.mutablestruct(__class__='C')
+        def __ne__(other):
+            fail(" SyntaxError")
+        self.__ne__ = __ne__
+        return self
+    asserts.assert_fails(lambda : operator.ne(), "missing 2 required positional arguments: a, b")
+    asserts.assert_fails(lambda : operator.ne(C(), C()), ".*?SyntaxError")
+    asserts.assert_that(operator.ne(1, 0)).is_true()
+    asserts.assert_that(operator.ne(1, 0.0)).is_true()
+    asserts.assert_that(operator.ne(1, 1)).is_false()
+    asserts.assert_that(operator.ne(1, 1.0)).is_false()
+    asserts.assert_that(operator.ne(1, 2)).is_true()
+    asserts.assert_that(operator.ne(1, 2.0)).is_true()
+
+
+def OperatorTestCase_test_ge():
+    operator = module
+    asserts.assert_fails(lambda : operator.ge(), "missing 2 required positional arguments: a, b")
+    asserts.assert_that(operator.ge(1, 0)).is_true()
+    asserts.assert_that(operator.ge(1, 0.0)).is_true()
+    asserts.assert_that(operator.ge(1, 1)).is_true()
+    asserts.assert_that(operator.ge(1, 1.0)).is_true()
+    asserts.assert_that(operator.ge(1, 2)).is_false()
+    asserts.assert_that(operator.ge(1, 2.0)).is_false()
+
+
+def OperatorTestCase_test_gt():
+    operator = module
+    asserts.assert_fails(lambda : operator.gt(), "missing 2 required positional arguments: a, b")
+    asserts.assert_that(operator.gt(1, 0)).is_true()
+    asserts.assert_that(operator.gt(1, 0.0)).is_true()
+    asserts.assert_that(operator.gt(1, 1)).is_false()
+    asserts.assert_that(operator.gt(1, 1.0)).is_false()
+    asserts.assert_that(operator.gt(1, 2)).is_false()
+    asserts.assert_that(operator.gt(1, 2.0)).is_false()
+
+
+def OperatorTestCase_test_abs():
+    operator = module
+    asserts.assert_fails(lambda : operator.abs(), "missing 1 required positional argument: a")
+    asserts.assert_fails(lambda : operator.abs(None), ".*?TypeError")
+    asserts.assert_that(operator.abs(-1)).is_equal_to(1)
+    asserts.assert_that(operator.abs(1)).is_equal_to(1)
+
+
+def OperatorTestCase_test_add():
+    operator = module
+    asserts.assert_fails(lambda : operator.add(), "missing 2 required positional arguments: a, b")
+    asserts.assert_fails(lambda : operator.add(None, None), "unsupported binary operation")
+    asserts.assert_that(operator.add(3, 4)).is_equal_to(7)
+
+
+def OperatorTestCase_test_bitwise_and():
+    operator = module
+    asserts.assert_fails(lambda : operator.and_(), "missing 2 required positional arguments: a, b")
+    asserts.assert_fails(lambda : operator.and_(None, None), "unsupported binary operation")
+    asserts.assert_that(operator.and_(0xf, 0xa)).is_equal_to(0xa)
+
+def OperatorTestCase_test_concat():
+    operator = module
+    asserts.assert_fails(lambda : operator.concat(), "missing 2 required positional arguments: a, b")
+    asserts.assert_fails(lambda : operator.concat(None, None), ".*?TypeError")
+    asserts.assert_that(operator.concat('py', 'thon')).is_equal_to('python')
+    asserts.assert_that(operator.concat([1, 2], [3, 4])).is_equal_to([1, 2, 3, 4])
+    asserts.assert_that(operator.concat(Seq1([5, 6]), Seq1([7]))).is_equal_to([5, 6, 7])
+    asserts.assert_that(operator.concat(Seq2([5, 6]), Seq2([7]))).is_equal_to([5, 6, 7])
+    asserts.assert_fails(lambda : operator.concat(13, 29), ".*?TypeError")
+
+def OperatorTestCase_test_countOf():
+    operator = module
+    asserts.assert_fails(lambda : operator.countOf(), "missing 2 required positional arguments: a, b")
+    asserts.assert_fails(lambda : operator.countOf(None, None), "type '.*' is not iterable")
+    asserts.assert_fails(lambda : operator.countOf(BadIterable(), 1), ".*?ZeroDivisionError")
+    asserts.assert_that(operator.countOf([1, 2, 1, 3, 1, 4], 3)).is_equal_to(1)
+    asserts.assert_that(operator.countOf([1, 2, 1, 3, 1, 4], 5)).is_equal_to(0)
+
+def OperatorTestCase_test_delitem():
+    operator = module
+    a = [4, 3, 2, 1]
+    asserts.assert_fails(lambda : operator.delitem(a), "missing 1 required positional argument")
+    asserts.assert_fails(lambda : operator.delitem(a, None), ".*?TypeError")
+    asserts.assert_that(operator.delitem(a, 1)).is_none()
+    asserts.assert_that(a).is_equal_to([4, 2, 1])
+
+def OperatorTestCase_test_floordiv():
+    operator = module
+    asserts.assert_fails(lambda : operator.floordiv(5), "missing 1 required positional argument")
+    asserts.assert_fails(lambda : operator.floordiv(None, None), "unsupported binary operation")
+    asserts.assert_that(operator.floordiv(5, 2)).is_equal_to(2)
+
+def OperatorTestCase_test_truediv():
+    operator = module
+    asserts.assert_fails(lambda : operator.truediv(5), "missing 1 required positional argument")
+    asserts.assert_fails(lambda : operator.truediv(None, None), "unsupported binary operation")
+    asserts.assert_that(operator.truediv(5, 2)).is_equal_to(2.5)
+
+def OperatorTestCase_test_getitem():
+    operator = module
+    a = range(10)
+    asserts.assert_fails(lambda : operator.getitem(), "missing 2 required positional arguments")
+    asserts.assert_fails(lambda : operator.getitem(a, None), "got \\w+ for sequence index, want int")
+    asserts.assert_that(operator.getitem(a, 2)).is_equal_to(2)
+
+def OperatorTestCase_test_indexOf():
+    operator = module
+    asserts.assert_fails(lambda : operator.indexOf(), "missing 2 required positional arguments")
+    asserts.assert_fails(lambda : operator.indexOf(None, None), "type '\\w+' is not iterable")
+    asserts.assert_fails(lambda : operator.indexOf(BadIterable(), 1), ".*?ZeroDivisionError")
+    asserts.assert_that(operator.indexOf([4, 3, 2, 1], 3)).is_equal_to(1)
+    asserts.assert_fails(lambda : operator.indexOf([4, 3, 2, 1], 0), ".*?ValueError")
+
+def OperatorTestCase_test_invert():
+    operator = module
+    asserts.assert_fails(lambda : operator.invert(), "missing 1 required positional arguments")
+    asserts.assert_fails(lambda : operator.invert(None), ".*?TypeError")
+    asserts.assert_that(operator.inv(4)).is_equal_to(-5)
+
+def OperatorTestCase_test_lshift():
+    operator = module
+    asserts.assert_fails(lambda : operator.lshift(), "missing 2 required positional arguments")
+    asserts.assert_fails(lambda : operator.lshift(None, 42), ".*?TypeError")
+    asserts.assert_that(operator.lshift(5, 1)).is_equal_to(10)
+    asserts.assert_that(operator.lshift(5, 0)).is_equal_to(5)
+    asserts.assert_fails(lambda : operator.lshift(2, -1), ".*?ValueError")
+
+def OperatorTestCase_test_mod():
+    operator = module
+    asserts.assert_fails(lambda : operator.mod(), "missing 2 required positional arguments")
+    asserts.assert_fails(lambda : operator.mod(None, 42), ".*?TypeError")
+    asserts.assert_that(operator.mod(5, 2)).is_equal_to(1)
+
+def OperatorTestCase_test_mul():
+    operator = module
+    asserts.assert_fails(lambda : operator.mul(), "missing 2 required positional arguments")
+    asserts.assert_fails(lambda : operator.mul(None, None), ".*?TypeError")
+    asserts.assert_that(operator.mul(5, 2)).is_equal_to(10)
+
+
 def _testsuite():
     _suite = unittest.TestSuite()
     _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_general))
     _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_lt))
     _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_le))
     _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_eq))
-    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_ne))
-    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_ge))
-    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_gt))
-    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_abs))
-    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_add))
-    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_bitwise_and))
-    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_concat))
-    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_countOf))
-    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_delitem))
-    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_floordiv))
-    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_truediv))
-    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_getitem))
-    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_indexOf))
-    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_invert))
-    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_lshift))
-    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_mod))
-    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_mul))
+    _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_ne))
+    _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_ge))
+    _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_gt))
+    _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_abs))
+    _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_add))
+    _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_bitwise_and))
+    _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_concat))
+    _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_countOf))
+    _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_delitem))
+    _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_floordiv))
+    _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_truediv))
+    _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_getitem))
+    _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_indexOf))
+    _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_invert))
+    _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_lshift))
+    _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_mod))
+    _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_mul))
     # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_matmul))
     # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_neg))
     # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_bitwise_or))

--- a/larky/src/test/resources/stdlib_tests/test_operator.star
+++ b/larky/src/test/resources/stdlib_tests/test_operator.star
@@ -1,0 +1,180 @@
+"""Unit testing for operator.star.
+
+copy most tests from: https://github.com/python/cpython/blob/main/Lib/test/test_operator.py
+"""
+load("@stdlib//larky", "larky")
+load("@stdlib//operator", module="operator")
+load("@stdlib//unittest", "unittest")
+load("@vendor//asserts", "asserts")
+
+
+def Seq1(lst):
+    self = larky.mutablestruct(__class__='Seq1')
+    def __init__(lst):
+        self.lst = lst
+        return self
+    self = __init__(lst)
+    def __len__():
+        return len(self.lst)
+    self.__len__ = __len__
+    def __getitem__(i):
+        return self.lst[i]
+    self.__getitem__ = __getitem__
+    def __add__(other):
+        return self.lst + other.lst
+    self.__add__ = __add__
+    def __mul__(other):
+        return self.lst * other
+    self.__mul__ = __mul__
+    def __rmul__(other):
+        return other * self.lst
+    self.__rmul__ = __rmul__
+    return self
+
+
+def Seq2(lst):
+    self = larky.mutablestruct(__class__='Seq2')
+    def __init__(lst):
+        self.lst = lst
+        return self
+    self = __init__(lst)
+    def __len__():
+        return len(self.lst)
+    self.__len__ = __len__
+    def __getitem__(i):
+        return self.lst[i]
+    self.__getitem__ = __getitem__
+    def __add__(other):
+        return self.lst + other.lst
+    self.__add__ = __add__
+    def __mul__(other):
+        return self.lst * other
+    self.__mul__ = __mul__
+    def __rmul__(other):
+        return other * self.lst
+    self.__rmul__ = __rmul__
+    return self
+
+
+def BadIterable___iter__():
+    fail(" ZeroDivisionError")
+
+
+def OperatorTestCase_test_lt():
+    operator = module
+    asserts.assert_fails(lambda : operator.lt(), "missing 2 required positional arguments: a, b")
+    asserts.assert_that(operator.lt(1, 0)).is_false()
+    asserts.assert_that(operator.lt(1, 0.0)).is_false()
+    asserts.assert_that(operator.lt(1, 1)).is_false()
+    asserts.assert_that(operator.lt(1, 1.0)).is_false()
+    asserts.assert_that(operator.lt(1, 2)).is_true()
+    asserts.assert_that(operator.lt(1, 2.0)).is_true()
+
+def OperatorTestCase_test_le():
+    operator = module
+    asserts.assert_fails(lambda : operator.le(), "missing 2 required positional arguments: a, b")
+    asserts.assert_that(operator.le(1, 0)).is_false()
+    asserts.assert_that(operator.le(1, 0.0)).is_false()
+    asserts.assert_that(operator.le(1, 1)).is_true()
+    asserts.assert_that(operator.le(1, 1.0)).is_true()
+    asserts.assert_that(operator.le(1, 2)).is_true()
+    asserts.assert_that(operator.le(1, 2.0)).is_true()
+
+def OperatorTestCase_test_eq():
+    operator = module
+    def C():
+        self = larky.mutablestruct(__class__='C')
+        def __eq__(other):
+            fail(" SyntaxError")
+        self.__eq__ = __eq__
+        return self
+    asserts.assert_fails(lambda : operator.eq(), "missing 2 required positional arguments: a, b")
+    asserts.assert_fails(lambda : operator.eq(C(), C()), ".*?SyntaxError")
+    asserts.assert_that(operator.eq(1, 0)).is_false()
+    asserts.assert_that(operator.eq(1, 0.0)).is_false()
+    asserts.assert_that(operator.eq(1, 1)).is_true()
+    asserts.assert_that(operator.eq(1, 1.0)).is_true()
+    asserts.assert_that(operator.eq(1, 2)).is_false()
+    asserts.assert_that(operator.eq(1, 2.0)).is_false()
+
+
+def OperatorTestCase_test_general():
+    def A():
+        self = larky.mutablestruct(__class__='A')
+        def method(*args, **kwargs):
+            return (args, kwargs)
+        self.method = method
+        return self
+
+    a = A()
+
+    a.name = "foo"
+    f = module.attrgetter('name')
+    asserts.assert_(f(a) == "foo")
+
+    fm = module.methodcaller("method")
+    asserts.assert_(fm(a) == ((), {}))
+
+    fm = module.methodcaller("method", 1, 2, 3, kw1="foo", kw2=10)
+    asserts.assert_(fm(a) == ((1, 2, 3), {"kw1": "foo", "kw2": 10}))
+
+    im = module.itemgetter(1)
+    asserts.assert_(im([1, 2, 3]) == 2)
+
+    im = module.itemgetter(0, 2)
+    asserts.assert_(im([1, 2, 3]) == (1, 3))
+
+
+def _testsuite():
+    _suite = unittest.TestSuite()
+    _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_general))
+    _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_lt))
+    _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_le))
+    _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_eq))
+    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_ne))
+    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_ge))
+    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_gt))
+    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_abs))
+    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_add))
+    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_bitwise_and))
+    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_concat))
+    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_countOf))
+    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_delitem))
+    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_floordiv))
+    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_truediv))
+    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_getitem))
+    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_indexOf))
+    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_invert))
+    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_lshift))
+    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_mod))
+    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_mul))
+    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_matmul))
+    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_neg))
+    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_bitwise_or))
+    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_pos))
+    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_pow))
+    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_rshift))
+    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_contains))
+    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_setitem))
+    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_sub))
+    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_truth))
+    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_bitwise_xor))
+    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_is))
+    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_is_not))
+    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_attrgetter))
+    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_itemgetter))
+    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_methodcaller))
+    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_inplace))
+    # _suite.addTest(unittest.FunctionTestCase(OperatorTestCase_test_dunder_is_original))
+    # _suite.addTest(unittest.FunctionTestCase(OperatorPickleTestCase_test_attrgetter))
+    # _suite.addTest(unittest.FunctionTestCase(OperatorPickleTestCase_test_itemgetter))
+    # _suite.addTest(unittest.FunctionTestCase(OperatorPickleTestCase_test_methodcaller))
+    return _suite
+
+_runner = unittest.TextTestRunner()
+_runner.run(_testsuite())
+
+
+
+
+

--- a/larky/src/test/resources/vendor_tests/option/test_result.star
+++ b/larky/src/test/resources/vendor_tests/option/test_result.star
@@ -1,0 +1,98 @@
+"""Unit tests for @vendor//result.star"""
+load("@stdlib//larky", "larky")
+load("@stdlib//unittest", "unittest")
+load("@vendor//asserts", "asserts")
+load("@vendor//option/result", Result="Result")
+load("@stdlib//operator", "operator")
+
+
+def _test_api():
+    f = Result.Ok(1)
+    asserts.assert_that(str(f)).is_equal_to("Ok{1}")
+    asserts.assert_that(f.map(lambda x: x+x).value()).is_equal_to(2)
+    asserts.assert_true(f.is_ok)
+    asserts.assert_false(f.is_err)
+
+    ##
+
+    d = Result.Error("oh no!")
+    asserts.assert_that(str(d)).is_equal_to("Error{oh no!}")
+    asserts.assert_false(d.is_ok)
+    asserts.assert_true(d.is_err)
+
+
+# @parametrize('val', [0, None, {}, [], False])
+def _test_factory_ok_0():
+    res = Result.Ok(0)
+    asserts.assert_true(res.is_ok)
+    asserts.assert_that(res.value()).is_equal_to(0)
+
+
+# @parametrize('err', [0, None, '', [], False])
+# def _test_factory_err(err):
+#     res = Result.Err(err)
+#     assert not res._is_ok
+#     assert res._val == err
+
+
+def _test_factory_ok(val):
+    res = Result.Ok(val)
+    asserts.assert_true(res.is_ok)
+    asserts.assert_that(res.value()).is_equal_to(val)
+
+
+def _test_map(obj, call, exp):
+    asserts.assert_that(obj.map(call)).is_equal_to(exp)
+
+
+def _test_map_err(obj, call, exp):
+    asserts.assert_that(obj.map_err(call)).is_equal_to(exp)
+
+
+def _test_unwrap(obj, exp, ok):
+    if ok:
+        asserts.assert_that(obj.unwrap()).is_equal_to(exp)
+    else:
+        asserts.assert_fails(obj.unwrap, ".*%s" % exp) # assert fails with msg
+
+
+def _testsuite():
+    _suite = unittest.TestSuite()
+    _suite.addTest(unittest.FunctionTestCase(_test_api))
+    _suite.addTest(unittest.FunctionTestCase(_test_factory_ok_0))
+    # very verbose way of writing:
+    # @parametrize('val', [0, None, '', [], False])
+    # def _test_factory_err(val):
+    larky.parametrize(
+        _suite.addTest,
+        unittest.FunctionTestCase,
+        'val',
+        [0, None, {}, [], False])(_test_factory_ok)
+    larky.parametrize(
+        _suite.addTest,
+        unittest.FunctionTestCase,
+        'obj,call,exp', [
+            (Result.Ok(1), str, Result.Ok('1')),
+            (Result.Error(1), str, Result.Error(1))
+        ])(_test_map)
+    larky.parametrize(
+        _suite.addTest,
+        unittest.FunctionTestCase,
+        'obj,call,exp', [
+        (Result.Ok(1), str, Result.Ok(1)),
+        (Result.Error(1), str, Result.Error('1'))
+        ])(_test_map_err)
+    larky.parametrize(
+        _suite.addTest,
+        unittest.FunctionTestCase,
+        'obj,exp,ok', [
+        (Result.Ok(1), 1, True),
+        (Result.Ok(None), None, True),
+        (Result.Error(1), 1, False),
+    ])(_test_unwrap)
+    # _suite.addTest(unittest.FunctionTestCase(_test_factory_err))
+    return _suite
+
+
+_runner = unittest.TextTestRunner()
+_runner.run(_testsuite())

--- a/larky/src/test/resources/vendor_tests/option/test_result.star
+++ b/larky/src/test/resources/vendor_tests/option/test_result.star
@@ -4,6 +4,7 @@ Port of: https://github.com/MaT1g3R/option/blob/master/tests/test_result.py
 """
 load("@stdlib//larky", "larky")
 load("@stdlib//re", "re")
+load("@stdlib//types", types="types")
 load("@stdlib//unittest", "unittest")
 load("@vendor//asserts", "asserts")
 load("@vendor//option/result",
@@ -26,26 +27,8 @@ def _test_safe_success():
 def _test_safe_failure():
     """Ensures that safe decorator works correctly for Failure case."""
     failed = safe(_function)(0)
-    asserts.assert_fails(lambda: failed.unwrap(), ".*ZeroDivisionError")
-
-    # from returns.result import Success, safe
-    #
-    #
-    # @safe
-    # def _function(number: int) -> float:
-    #     return number / number
-    #
-    #
-    # def test_safe_success():
-    #     """Ensures that safe decorator works correctly for Success case."""
-    #     assert _function(1) == Success(1.0)
-    #
-    #
-    # def test_safe_failure():
-    #     """Ensures that safe decorator works correctly for Failure case."""
-    #     failed = _function(0)
-    #     assert isinstance(failed.failure(), ZeroDivisionError)
-    pass
+    asserts.assert_fails(lambda: failed.unwrap(), ".*division by zero")
+    asserts.assert_true(failed.is_err)
 
 
 def _test_api():
@@ -280,8 +263,6 @@ def _testsuite():
             (Error(1), Error(1))
         ],
     )(test_le_ge)
-
-    # _suite.addTest(unittest.FunctionTestCase(_test_factory_err))
     return _suite
 
 

--- a/larky/src/test/resources/vendor_tests/option/test_result.star
+++ b/larky/src/test/resources/vendor_tests/option/test_result.star
@@ -1,13 +1,15 @@
 """Unit tests for @vendor//result.star"""
 load("@stdlib//larky", "larky")
+load("@stdlib//re", "re")
 load("@stdlib//unittest", "unittest")
 load("@vendor//asserts", "asserts")
 load("@vendor//option/result", Result="Result")
 
+
 def _test_api():
     f = Result.Ok(1)
     asserts.assert_that(str(f)).is_equal_to("Ok{1}")
-    asserts.assert_that(f.map(lambda x: x+x).value()).is_equal_to(2)
+    asserts.assert_that(f.map(lambda x: x + x).value()).is_equal_to(2)
     asserts.assert_true(f.is_ok)
     asserts.assert_false(f.is_err)
 
@@ -19,24 +21,19 @@ def _test_api():
     asserts.assert_true(d.is_err)
 
 
-# @parametrize('val', [0, None, {}, [], False])
-def _test_factory_ok_0():
-    res = Result.Ok(0)
-    asserts.assert_true(res.is_ok)
-    asserts.assert_that(res.value()).is_equal_to(0)
-
-
-# @parametrize('err', [0, None, '', [], False])
-# def _test_factory_err(err):
-#     res = Result.Err(err)
-#     assert not res._is_ok
-#     assert res._val == err
-
-
 def _test_factory_ok(val):
     res = Result.Ok(val)
     asserts.assert_true(res.is_ok)
     asserts.assert_that(res.value()).is_equal_to(val)
+
+
+def _test_factory_err(err):
+    res = Result.Error(err)
+    asserts.assert_false(res.is_ok)
+    asserts.assert_true(res.is_err)
+    asserts.assert_fails(lambda: res.unwrap(), re.escape("%s" % err))
+    # asserts.assert_that(res.error()).is_not_none()
+    # asserts.assert_that(res.error()).is_equal_to(err)
 
 
 def _test_map(obj, call, exp):
@@ -51,43 +48,48 @@ def _test_unwrap(obj, exp, ok):
     if ok:
         asserts.assert_that(obj.unwrap()).is_equal_to(exp)
     else:
-        asserts.assert_fails(obj.unwrap, ".*%s" % exp) # assert fails with msg
+        asserts.assert_fails(obj.unwrap, ".*%s" % exp)  # assert fails with msg
 
 
 def _testsuite():
     _suite = unittest.TestSuite()
     _suite.addTest(unittest.FunctionTestCase(_test_api))
-    _suite.addTest(unittest.FunctionTestCase(_test_factory_ok_0))
     # very verbose way of writing:
     # @parametrize('val', [0, None, '', [], False])
     # def _test_factory_err(val):
     larky.parametrize(
-        _suite.addTest,
-        unittest.FunctionTestCase,
-        'val',
-        [0, None, {}, [], False])(_test_factory_ok)
+        _suite.addTest, unittest.FunctionTestCase, "val", [0, None, {}, [], False]
+    )(_test_factory_ok)
+
+    larky.parametrize(
+        _suite.addTest, unittest.FunctionTestCase, "err", [0, None, "", [], False]
+    )(_test_factory_err)
+
     larky.parametrize(
         _suite.addTest,
         unittest.FunctionTestCase,
-        'obj,call,exp', [
-            (Result.Ok(1), str, Result.Ok('1')),
-            (Result.Error(1), str, Result.Error(1))
-        ])(_test_map)
+        "obj,call,exp",
+        [(Result.Ok(1), str, Result.Ok("1")), (Result.Error(1), str, Result.Error(1))],
+    )(_test_map)
+
     larky.parametrize(
         _suite.addTest,
         unittest.FunctionTestCase,
-        'obj,call,exp', [
-        (Result.Ok(1), str, Result.Ok(1)),
-        (Result.Error(1), str, Result.Error('1'))
-        ])(_test_map_err)
+        "obj,call,exp",
+        [(Result.Ok(1), str, Result.Ok(1)), (Result.Error(1), str, Result.Error("1"))],
+    )(_test_map_err)
+
     larky.parametrize(
         _suite.addTest,
         unittest.FunctionTestCase,
-        'obj,exp,ok', [
-        (Result.Ok(1), 1, True),
-        (Result.Ok(None), None, True),
-        (Result.Error(1), 1, False),
-    ])(_test_unwrap)
+        "obj,exp,ok",
+        [
+            (Result.Ok(1), 1, True),
+            (Result.Ok(None), None, True),
+            (Result.Error(1), 1, False),
+        ],
+    )(_test_unwrap)
+
     # _suite.addTest(unittest.FunctionTestCase(_test_factory_err))
     return _suite
 

--- a/larky/src/test/resources/vendor_tests/option/test_result.star
+++ b/larky/src/test/resources/vendor_tests/option/test_result.star
@@ -1,15 +1,57 @@
-"""Unit tests for @vendor//result.star"""
+"""Unit tests for @vendor//result.star
+
+Port of: https://github.com/MaT1g3R/option/blob/master/tests/test_result.py
+"""
 load("@stdlib//larky", "larky")
 load("@stdlib//re", "re")
 load("@stdlib//unittest", "unittest")
 load("@vendor//asserts", "asserts")
-load("@vendor//option/result", Result="Result")
+load("@vendor//option/result",
+     Result="Result",
+     Ok="Ok",
+     Error="Error",
+     safe="safe")
+
+
+def _function(number):
+    return number / number
+
+
+def _test_safe_success():
+    """Ensures that safe decorator works correctly for Success case."""
+    asserts.assert_that(safe(_function)(1)).is_equal_to(Ok(1.0))
+    asserts.assert_that(safe(_function)(1)).is_not_equal_to(Error(1.0))
+
+
+def _test_safe_failure():
+    """Ensures that safe decorator works correctly for Failure case."""
+    failed = safe(_function)(0)
+    asserts.assert_fails(lambda: failed.unwrap(), ".*ZeroDivisionError")
+
+    # from returns.result import Success, safe
+    #
+    #
+    # @safe
+    # def _function(number: int) -> float:
+    #     return number / number
+    #
+    #
+    # def test_safe_success():
+    #     """Ensures that safe decorator works correctly for Success case."""
+    #     assert _function(1) == Success(1.0)
+    #
+    #
+    # def test_safe_failure():
+    #     """Ensures that safe decorator works correctly for Failure case."""
+    #     failed = _function(0)
+    #     assert isinstance(failed.failure(), ZeroDivisionError)
+    pass
 
 
 def _test_api():
     f = Result.Ok(1)
     asserts.assert_that(str(f)).is_equal_to("Ok{1}")
-    asserts.assert_that(f.map(lambda x: x + x).value()).is_equal_to(2)
+    asserts.assert_that(f.map(lambda x: x + x).unwrap()).is_equal_to(2)
     asserts.assert_true(f.is_ok)
     asserts.assert_false(f.is_err)
 
@@ -24,7 +66,7 @@ def _test_api():
 def _test_factory_ok(val):
     res = Result.Ok(val)
     asserts.assert_true(res.is_ok)
-    asserts.assert_that(res.value()).is_equal_to(val)
+    asserts.assert_that(res._val).is_equal_to(val)
 
 
 def _test_factory_err(err):
@@ -32,9 +74,6 @@ def _test_factory_err(err):
     asserts.assert_false(res.is_ok)
     asserts.assert_true(res.is_err)
     asserts.assert_fails(lambda: res.unwrap(), re.escape("%s" % err))
-    # asserts.assert_that(res.error()).is_not_none()
-    # asserts.assert_that(res.error()).is_equal_to(err)
-
 
 def _test_map(obj, call, exp):
     asserts.assert_that(obj.map(call)).is_equal_to(exp)
@@ -51,9 +90,62 @@ def _test_unwrap(obj, exp, ok):
         asserts.assert_fails(obj.unwrap, ".*%s" % exp)  # assert fails with msg
 
 
+def _test_unwrap_or(obj, optb, exp):
+    asserts.assert_that(obj.unwrap_or(optb)).is_equal_to(exp)
+
+
+def test_unwrap_or_else(obj, op, exp):
+    asserts.assert_that(obj.unwrap_or_else(op)).is_equal_to(exp)
+
+
+def test_except(obj, ok, exp):
+    if ok:
+        asserts.assert_that(obj.expect('')).is_equal_to(exp)
+    else:
+        asserts.assert_fails(lambda:  obj.expect('ValueError'), ".*ValueError")
+
+
+def test_unwrap_expect_err(obj, err, exp):
+    if err:
+        asserts.assert_that(obj.unwrap_err()).is_equal_to(exp)
+        asserts.assert_that(obj.expect_err('')).is_equal_to(exp)
+    else:
+        asserts.assert_fails(lambda:  obj.unwrap_err(), ".*")
+        asserts.assert_fails(lambda:  obj.expect_err(''), ".*")
+
+
+def test_eq(o1, o2):
+
+    asserts.assert_that(o1).is_equal_to(o2)
+    asserts.assert_that(o1).is_not_equal_to(o1._val)
+    asserts.assert_that(o1._val).is_not_equal_to(o1)
+
+
+def test_neq(o1, o2):
+    asserts.assert_that(o1).is_not_equal_to(o2)
+    asserts.assert_that(o1).is_not_equal_to(o1._val)
+    asserts.assert_that(o1._val).is_not_equal_to(o1)
+
+
+def test_lt_gt(o1, o2):
+    asserts.assert_true(o1 < o2)
+    asserts.assert_true(o1 <= o2)
+    asserts.assert_true(o2 > o1)
+    asserts.assert_true(o2 >= o1)
+
+
+def test_le_ge(o1, o2):
+    asserts.assert_true(o1 <= o2)
+    asserts.assert_true(o1 >= o2)
+
+
 def _testsuite():
     _suite = unittest.TestSuite()
     _suite.addTest(unittest.FunctionTestCase(_test_api))
+
+    _suite.addTest(unittest.FunctionTestCase(_test_safe_success))
+    _suite.addTest(unittest.FunctionTestCase(_test_safe_failure))
+
     # very verbose way of writing:
     # @parametrize('val', [0, None, '', [], False])
     # def _test_factory_err(val):
@@ -89,6 +181,105 @@ def _testsuite():
             (Result.Error(1), 1, False),
         ],
     )(_test_unwrap)
+
+    larky.parametrize(
+        _suite.addTest,
+        unittest.FunctionTestCase,
+        "obj,optb,exp",
+        [
+            (Result.Ok(0), 11, 0),
+            (Result.Error(11), 0, 0),
+        ],
+    )(_test_unwrap_or)
+
+    larky.parametrize(
+        _suite.addTest,
+        unittest.FunctionTestCase,
+        'obj,op,exp',
+        [
+            (Ok('asd'), len, 'asd'),
+            (Result.Error('asd'), len, 3),
+        ],
+    )(test_unwrap_or_else)
+
+    larky.parametrize(
+        _suite.addTest,
+        unittest.FunctionTestCase,
+        'obj,ok,exp',
+        [
+            (Ok(1), True, 1),
+            (Result.Error(1), False, ''),
+            (Ok(None), True, None)
+        ],
+    )(test_except)
+
+    larky.parametrize(
+        _suite.addTest,
+        unittest.FunctionTestCase,
+        'obj,err,exp',
+        [
+            (Ok(1), False, ''),
+            (Result.Error(None), True, None),
+        ],
+    )(test_unwrap_expect_err)
+
+    # Starlark does not support hashes except for string or byte values
+    # larky.parametrize(
+    #     _suite.addTest,
+    #     unittest.FunctionTestCase,
+    #     'obj1,obj2,eq',
+    #     [
+    #         (Ok(1), Ok(1), True),
+    #         (Result.Error(1), Result.Error(1), True),
+    #         (Ok(1), Result.Error(1), False)
+    #     ],
+    # )(test_hash)
+
+    larky.parametrize(
+        _suite.addTest,
+        unittest.FunctionTestCase,
+        'o1,o2',
+        [
+            (Ok(''), Ok('')),
+            (Ok([]), Ok([])),
+            (Result.Error('aa'), Result.Error('aa')),
+            (Result.Error({}), Result.Error({}))
+        ],
+    )(test_eq)
+
+    larky.parametrize(
+        _suite.addTest,
+        unittest.FunctionTestCase,
+        'o1,o2',
+        [
+            (Ok(''), Result.Error('')),
+            (Result.Error([]), Ok([])),
+            (Ok({}), Result.Error({})),
+            (Ok(1), Ok(2)),
+            (Result.Error(2), Result.Error(3))
+        ],
+    )(test_neq)
+
+    larky.parametrize(
+        _suite.addTest,
+        unittest.FunctionTestCase,
+        'o1,o2',
+        [
+            (Ok(2), Result.Error(1)),
+            (Ok(1), Ok(2)),
+            (Error(1), Result.Error(2))
+        ],
+    )(test_lt_gt)
+
+    larky.parametrize(
+        _suite.addTest,
+        unittest.FunctionTestCase,
+        'o1,o2',
+        [
+            (Ok(1), Ok(1)),
+            (Error(1), Error(1))
+        ],
+    )(test_le_ge)
 
     # _suite.addTest(unittest.FunctionTestCase(_test_factory_err))
     return _suite

--- a/larky/src/test/resources/vendor_tests/option/test_result.star
+++ b/larky/src/test/resources/vendor_tests/option/test_result.star
@@ -3,8 +3,6 @@ load("@stdlib//larky", "larky")
 load("@stdlib//unittest", "unittest")
 load("@vendor//asserts", "asserts")
 load("@vendor//option/result", Result="Result")
-load("@stdlib//operator", "operator")
-
 
 def _test_api():
     f = Result.Ok(1)


### PR DESCRIPTION
## Description of changes in release / Impact of release:

Given that Starlark does not support exceptions, there needs to be a way to map python exception handling and control flow to Starlark. One of the more popular ways to do this is to take inspiration from some of the functional programming constructs.

Copied this interface: https://github.com/MaT1g3R/option/blob/master/option/result.py

## Documentation

Documentation here: https://mat1g3r.github.io/option/

Use like this:

```python
load("@stdlib//jresult", _jresult="jresult")

f = _jresult.Result.success(1)
print(f)
print("-----")
print(f.map(lambda x: x+x).value())
print(f.is_ok == True)
print(f.is_err == False)
```

output:

```
0520 19:19:23.134 INFO: stdlib/larky.star:31:6: Result{value=1, error=null}
0520 19:19:23.134 INFO: stdlib/larky.star:32:6: -----
0520 19:19:23.139 INFO: stdlib/larky.star:33:6: 2
0520 19:19:23.140 INFO: stdlib/larky.star:34:6: True
0520 19:19:23.140 INFO: stdlib/larky.star:35:6: True
```

And:

```python
load("@stdlib//jresult", _jresult="jresult")

d = _jresult.Result.failure("oh no!")
print(d)
print(d.is_ok == False)
print(d.is_err == True)
```

output:

```
0520 19:19:23.143 INFO: stdlib/larky.star:37:6: Result{value=null, error=oh no!}
0520 19:19:23.144 INFO: stdlib/larky.star:38:6: True
0520 19:19:23.144 INFO: stdlib/larky.star:39:6: True
```

## Risks of this release
None.

### Is this a breaking change?
- [ ] Yes
- [X] No

### Is there a way to disable the change?
- [X] Use previous release
- [ ] Use a feature flag
- [ ] No

#### Additional details go here

Will make migration of python constructs using py2star much easier!