### PR TITLE
AES Key (Un)wrap with padding

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# https://github.com/github/linguist/tree/47b109be3657fe3d5933fba6840a6ceea0f94498#overrides
+# allows *.star files to be rendered like *.bzl files
+*.star linguist-language=Starlark

--- a/larky/src/main/java/com/verygood/security/larky/modules/SysModule.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/SysModule.java
@@ -6,11 +6,19 @@ import net.starlark.java.annot.StarlarkBuiltin;
 import net.starlark.java.annot.StarlarkMethod;
 import net.starlark.java.eval.StarlarkValue;
 
-
+/**
+ * A very simple module that just exposes basic information <b><i>JUST for portability
+ * reasons.</i></b>
+ *
+ * This module will just expose things like <code>maxint</code> or <code>byteorder</code>,
+ * just to make it easier to port certain things.
+ *
+ * There is *NO* intention to making this 100% compatible with Python's sys module.
+ */
 @StarlarkBuiltin(
     name = "sys",
     category = "BUILTIN",
-    doc = "Larky system-specific parameters and functions")
+    doc = "*Larky* system-specific parameters and functions")
 public class SysModule implements StarlarkValue {
 
   public static final SysModule INSTANCE = new SysModule();
@@ -22,7 +30,20 @@ public class SysModule implements StarlarkValue {
     NATIVE = (ByteOrder.nativeOrder() == ByteOrder.LITTLE_ENDIAN) ? LITTLE : BIG;
   }
 
-  @StarlarkMethod(name = "byteorder", doc = "the system byte order", structField = true)
+  /**
+   * An indicator of the native byte order. This will have the value 'big' on
+   * big-endian (most-significant byte first) platforms, and 'little' on little-endian
+   * (least-significant byte first) platforms.
+   *
+   * @return 'big on big-endian (MSB) platforms or 'little' on little-endian (LSB) platforms
+   */
+  @StarlarkMethod(
+    name = "byteorder",
+    doc = "An indicator of the native byte order. This will have the value 'big' on " +
+            "big-endian (most-significant byte first) platforms, and 'little' on " +
+            "little-endian (least-significant byte first) platforms." +
+            "\n",
+    structField = true)
   public static String byteOrder() {
     return NATIVE;
   }

--- a/larky/src/test/resources/vendor_tests/jose/test_jose.star
+++ b/larky/src/test/resources/vendor_tests/jose/test_jose.star
@@ -1,10 +1,18 @@
-load("@stdlib//unittest", "unittest")
-load("@vendor//asserts", "asserts")
-load("@vendor//jose/jwe", jwe="jwe")
+load("@stdlib//base64", base64="base64")
+load("@stdlib//binascii", binascii="binascii")
+load("@stdlib//json", json="json")
+load("@stdlib//larky", larky="larky")
+load("@stdlib//unittest", unittest="unittest")
+load("@vendor//Crypto/Cipher/AES", AES="AES")
+load("@vendor//Crypto/Hash/SHA512", SHA512="SHA512")
+load("@vendor//Crypto/Protocol/KDF", PBKDF2="PBKDF2")
+load("@vendor//Crypto/Util/Padding", pad="pad", unpad="unpad")
+load("@vendor//asserts", asserts="asserts")
 load("@vendor//jose/backends", AESKey="AESKey")
 load("@vendor//jose/constants", ALGORITHMS="ALGORITHMS")
-load("@stdlib//binascii", "binascii")
-load("@stdlib//larky", larky="larky")
+load("@vendor//jose/jwe", jwe="jwe")
+load("@vendor//jose/jwk", jwk="jwk")
+
 
 
 def test_encrypt_and_decrypt_jwe_with_defaults():
@@ -30,13 +38,67 @@ def test_aes_unwrap_key(kek, output, data, algo):
 
 
 def test_vector_RFC_3394_wrap():
-    #test vector from RFC 3394
+    # test vector from RFC 3394
     algo = "A128KW"
     kek = binascii.unhexlify("000102030405060708090A0B0C0D0E0F")
     plain = binascii.unhexlify("00112233445566778899AABBCCDDEEFF")
     data = binascii.unhexlify("1FA68B0A8112B447AEF34BD8FB5A7B829D3E862371D2CFE5")
     aes = AESKey(kek, algo)
     asserts.eq(aes.wrap(plain, algo), data)
+
+
+def test_vector_RFC_3394_unwrap():
+    # test vector from RFC 3394
+    algo = "A128KW"
+    kek = binascii.unhexlify("000102030405060708090A0B0C0D0E0F")
+    cipher = binascii.unhexlify("1FA68B0A8112B447AEF34BD8FB5A7B829D3E862371D2CFE5")
+    plain = binascii.unhexlify("00112233445566778899AABBCCDDEEFF")
+    aes = AESKey(kek, algo)
+    asserts.eq(aes.unwrap(cipher, headers={}, enc_alg=algo), plain)
+
+
+def test_vector_RFC_5649_7_wrap():
+    # test vector from RFC 5649 - 7 octets
+    # https://datatracker.ietf.org/doc/html/rfc5649#section-6
+    algo = "A192KW"
+    kek = binascii.unhexlify("5840DF6E29B02AF1AB493B705BF16EA1AE8338F4DCC176A8")
+    cipher = binascii.unhexlify("AFBEB0F07DFBF5419200F2CCB50BB24F")
+    plain = binascii.unhexlify("466F7250617369")
+    aes = AESKey(kek, algo)
+    asserts.eq(aes.wrap(plain, algo, headers={"with_padding": True}), cipher)
+
+
+def test_vector_RFC_5649_7_unwrap():
+    # test vector from RFC 5649 - 7 octets
+    # https://datatracker.ietf.org/doc/html/rfc5649#section-6
+    algo = "A192KW"
+    kek = binascii.unhexlify("5840DF6E29B02AF1AB493B705BF16EA1AE8338F4DCC176A8")
+    cipher = binascii.unhexlify("AFBEB0F07DFBF5419200F2CCB50BB24F")
+    plain = binascii.unhexlify("466F7250617369")
+    aes = AESKey(kek, algo)
+    asserts.eq(aes.unwrap(cipher, headers={"with_padding": True}, enc_alg=algo), plain)
+
+
+def test_vector_RFC_5649_20_wrap():
+    # test vector from RFC 5649 - 20 octets
+    # https://datatracker.ietf.org/doc/html/rfc5649#section-6
+    algo = "A192KW"
+    kek = binascii.unhexlify("5840DF6E29B02AF1AB493B705BF16EA1AE8338F4DCC176A8")
+    cipher = binascii.unhexlify("138BDEAA9B8FA7FC61F97742E72248EE5AE6AE5360D1AE6A5F54F373FA543B6A")
+    plain = binascii.unhexlify("C37B7E6492584340BED12207808941155068F738")
+    aes = AESKey(kek, algo)
+    asserts.eq(aes.wrap(plain, algo, headers={"with_padding": True}), cipher)
+
+
+def test_vector_RFC_5649_20_unwrap():
+    # test vector from RFC 5649 - 20 octets
+    # https://datatracker.ietf.org/doc/html/rfc5649#section-6
+    algo = "A192KW"
+    kek = binascii.unhexlify("5840DF6E29B02AF1AB493B705BF16EA1AE8338F4DCC176A8")
+    cipher = binascii.unhexlify("138BDEAA9B8FA7FC61F97742E72248EE5AE6AE5360D1AE6A5F54F373FA543B6A")
+    plain = binascii.unhexlify("C37B7E6492584340BED12207808941155068F738")
+    aes = AESKey(kek, algo)
+    asserts.eq(aes.unwrap(cipher, headers={"with_padding": True}, enc_alg=algo), plain)
 
 
 def _testsuite():
@@ -59,6 +121,12 @@ def _testsuite():
         ]
     )(test_aes_unwrap_key)
     _suite.addTest(unittest.FunctionTestCase(test_vector_RFC_3394_wrap))
+    _suite.addTest(unittest.FunctionTestCase(test_vector_RFC_3394_unwrap))
+    _suite.addTest(unittest.FunctionTestCase(test_vector_RFC_5649_7_wrap))
+    _suite.addTest(unittest.FunctionTestCase(test_vector_RFC_5649_7_unwrap))
+    _suite.addTest(unittest.FunctionTestCase(test_vector_RFC_5649_20_wrap))
+    _suite.addTest(unittest.FunctionTestCase(test_vector_RFC_5649_20_unwrap))
+
     return _suite
 
 


### PR DESCRIPTION
## Description of changes in release / Impact of release:

Support RFC 5649

## Documentation

When calling `aes.unwrap` or `aes.wrap`, just set `with_padding` to `True` as part of the headers.

## Risks of this release
None

### Is this a breaking change?
- [ ] Yes
- [X] No

### Is there a way to disable the change?
- [X] Use previous release
- [ ] Use a feature flag
- [ ] No
