### PR TITLE
*MERGE SECOND* Multidict (Stacked PR #2) (Review after Stacked PR #3)

### DIFF
--- a/larky/src/main/java/com/verygood/security/larky/modules/ResultModule.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/ResultModule.java
@@ -62,7 +62,7 @@ public class ResultModule implements StarlarkValue {
     } catch (EvalException e) {
       return Error.of(e); // for the stack trace.
     } catch (InterruptedException | RuntimeException e) {
-      return error(new EvalException(e.getMessage(), e));
+      return error(new EvalException(e.getMessage(), e.getCause()));
     }
   }
 

--- a/larky/src/main/java/com/verygood/security/larky/modules/testing/AssertionsModule.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/testing/AssertionsModule.java
@@ -5,6 +5,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.errorprone.annotations.FormatMethod;
 import com.google.re2j.Pattern;
 import com.google.re2j.PatternSyntaxException;
+import java.util.Objects;
 
 import com.verygood.security.larky.modules.utils.Reporter;
 
@@ -16,8 +17,6 @@ import net.starlark.java.eval.Starlark;
 import net.starlark.java.eval.StarlarkCallable;
 import net.starlark.java.eval.StarlarkThread;
 import net.starlark.java.eval.StarlarkValue;
-
-import java.util.Objects;
 
 
 @StarlarkBuiltin(
@@ -84,7 +83,7 @@ public class AssertionsModule implements StarlarkValue {
     try {
       Starlark.call(thread, f, ImmutableList.of(), ImmutableMap.of());
       errorMsg = String.format("evaluation succeeded unexpectedly (want error matching %s)", wantError);
-    } catch (EvalException ex) {
+    } catch (Starlark.UncheckedEvalException | EvalException ex) {
       // Verify error matches expectation.
       String msg = ex.getMessage();
       if (pattern.matcher(msg).find()) {

--- a/larky/src/main/java/com/verygood/security/larky/modules/types/LarkyIterator.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/types/LarkyIterator.java
@@ -57,12 +57,9 @@ public abstract class LarkyIterator implements HasBinary, LarkyObject, StarlarkI
 
   final protected ImmutableSet<String> fieldNames = fields.keySet();
 
-  // __iter__() => hasIterField() ? invoke() : hasGetItemField() ? return invoke() : return iterator()
-  // __next__() => hasNextField() ? invoke() : return if not hasNext(): raise StopIterable else return next()
   private StarlarkThread currentThread;
 
   public static LarkyIterator from(Object obj, StarlarkThread thread) throws EvalException {
-    // TODO: add iter(dict)..
     if (obj instanceof LarkyIterator) {
       final LarkyIterator obj1 = (LarkyIterator) obj;
       obj1.setCurrentThread(thread);
@@ -202,8 +199,7 @@ public abstract class LarkyIterator implements HasBinary, LarkyObject, StarlarkI
 
     private LarkyIterableIterator(Iterable<?> obj) {
       this.iterator = obj.iterator();
-      this.type = Starlark.type(obj) + "_iterator";
-
+      this.type = StarlarkUtil.richType(obj) + "_iterator";
     }
 
     public static LarkyIterableIterator of(Iterable<?> obj, StarlarkThread thread) {
@@ -232,7 +228,7 @@ public abstract class LarkyIterator implements HasBinary, LarkyObject, StarlarkI
 
   }
 
-  private static class LarkyObjectIterator extends LarkyIterator {
+  public static class LarkyObjectIterator extends LarkyIterator {
     private final String type;
     protected Supplier<Object> iterator_method;
     protected boolean checkedForNext;

--- a/larky/src/main/java/com/verygood/security/larky/modules/types/LarkyObject.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/types/LarkyObject.java
@@ -4,6 +4,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import com.verygood.security.larky.parser.StarlarkUtil;
+
 import net.starlark.java.eval.EvalException;
 import net.starlark.java.eval.Printer;
 import net.starlark.java.eval.Starlark;
@@ -61,18 +63,7 @@ public interface LarkyObject extends Structure {
    * Returns the name of the type of a value as if by the Starlark expression {@code type(x)}.
    */
   default String type() {
-    try {
-      if (!hasClassField() && !hasNameField()) {
-        return Starlark.type(this);
-      }
-      if(hasNameField()) {
-        return String.valueOf(getField(PyProtocols.__NAME__));
-      }
-      // fall back to __class__ if __name__ doesn't exist
-      return String.valueOf(getField(PyProtocols.__CLASS__));
-    } catch (EvalException e) {
-      throw new RuntimeException(e);
-    }
+    return StarlarkUtil.richType(this);
   }
 
   @Override

--- a/larky/src/main/java/com/verygood/security/larky/parser/StarlarkUtil.java
+++ b/larky/src/main/java/com/verygood/security/larky/parser/StarlarkUtil.java
@@ -25,8 +25,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.verygood.security.larky.modules.types.LarkyObject;
 import com.verygood.security.larky.modules.types.PyProtocols;
-
 
 import net.starlark.java.eval.Dict;
 import net.starlark.java.eval.EvalException;
@@ -212,5 +212,31 @@ public final class StarlarkUtil {
        }
      }
      throw Starlark.errorf("%s is not a callable", Starlark.type(x));
+   }
+
+  /**
+   * Returns the name of the type of {@code x} as if by the Starlark expression {@code type(x)}.
+   *
+   * This respects the __NAME__ and __CLASS__ parameters otherwise falls back to
+   * {@code Starlark.type()}
+   */
+   public static String richType(Object x) {
+    if(x instanceof LarkyObject) {
+      LarkyObject obj = ((LarkyObject) x);
+      try {
+        if (!obj.hasClassField() && !obj.hasNameField()) {
+          return Starlark.type(obj);
+        }
+        if(obj.hasNameField()) {
+          return String.valueOf(obj.getField(PyProtocols.__NAME__));
+        }
+        // fall back to __class__ if __name__ doesn't exist
+        return String.valueOf(obj.getField(PyProtocols.__CLASS__));
+      } catch (EvalException e) {
+        throw new RuntimeException(e);
+      }
+    }
+     // otherwise, just return Starlark.type()
+     return Starlark.type(x);
    }
 }

--- a/larky/src/test/resources/vendor_tests/multidict/test_mutable_multidict.star
+++ b/larky/src/test/resources/vendor_tests/multidict/test_mutable_multidict.star
@@ -146,7 +146,7 @@ def TestMutableMultiDict_test_set_default():
     asserts.assert_that("one").is_equal_to(d.setdefault("key", "three"))
     asserts.assert_that("three").is_equal_to(d.setdefault("otherkey", "three"))
     asserts.assert_that(d).contains("otherkey")
-    asserts.assert_that("three").is_equal_to(operator.getitem(d, "otherkey"))
+    asserts.assert_that("three").is_equal_to(d["otherkey"])
 
 
 def TestMutableMultiDict_test_popitem():
@@ -292,7 +292,7 @@ def TestCIMutableMultiDict_test_getall():
 
 def TestCIMutableMultiDict_test_ctor():
     d = ci_cls(k1="v1")
-    asserts.assert_that("v1").is_equal_to(operator.getitem(d, "K1"))
+    asserts.assert_that("v1").is_equal_to(d["K1"])
     asserts.assert_that(d.items()).contains(("k1", "v1"))
 
 
@@ -302,7 +302,7 @@ def TestCIMutableMultiDict_test_setitem():
     # see comment in TestMutableMultiDict_test_add about SetIndexable
     # d["k1"] = "v1"
     operator.setitem(d, "k1", "v1")
-    asserts.assert_that("v1").is_equal_to(operator.getitem(d, "K1"))
+    asserts.assert_that("v1").is_equal_to(d["K1"])
     asserts.assert_that(d.items()).contains(("k1", "v1"))
 
 
@@ -430,7 +430,7 @@ def TestCIMutableMultiDict_test_set_default():
     asserts.assert_that("three").is_equal_to(d.setdefault("otherkey", "three"))
     asserts.assert_that(d).contains("otherkey")
     asserts.assert_that(d.items()).contains(("otherkey", "three"))
-    asserts.assert_that("three").is_equal_to(operator.getitem(d, "OTHERKEY"))
+    asserts.assert_that("three").is_equal_to(d["OTHERKEY"])
 
 
 def TestCIMutableMultiDict_test_popitem():


### PR DESCRIPTION
- Move Larky type() detection to StarlarkUtil so that it can be invoked statically
- Update asserts.assert_fail to also understand `Starlark.UncheckedEvalException`

Previously, if a method threw  `Starlark#UncheckedEvalException` it was not caught in the `assert_fails` test clause

This lets us assert failures from methods that are overridden but cannot throw a checked exception.

This is leading up to a different changelist that follows shortly.