### PR TITLE
*MERGE FIRST* - Multidict (Stacked PR #3) SimpleStruct now understands `__getitem__` via `[]` and if iterable, supports iteration directly

### DIFF
--- a/larky/src/test/resources/vendor_tests/multidict/test_mutable_multidict.star
+++ b/larky/src/test/resources/vendor_tests/multidict/test_mutable_multidict.star
@@ -146,7 +146,7 @@ def TestMutableMultiDict_test_set_default():
     asserts.assert_that("one").is_equal_to(d.setdefault("key", "three"))
     asserts.assert_that("three").is_equal_to(d.setdefault("otherkey", "three"))
     asserts.assert_that(d).contains("otherkey")
-    asserts.assert_that("three").is_equal_to(operator.getitem(d, "otherkey"))
+    asserts.assert_that("three").is_equal_to(d["otherkey"])
 
 
 def TestMutableMultiDict_test_popitem():
@@ -292,7 +292,7 @@ def TestCIMutableMultiDict_test_getall():
 
 def TestCIMutableMultiDict_test_ctor():
     d = ci_cls(k1="v1")
-    asserts.assert_that("v1").is_equal_to(operator.getitem(d, "K1"))
+    asserts.assert_that("v1").is_equal_to(d["K1"])
     asserts.assert_that(d.items()).contains(("k1", "v1"))
 
 
@@ -302,7 +302,7 @@ def TestCIMutableMultiDict_test_setitem():
     # see comment in TestMutableMultiDict_test_add about SetIndexable
     # d["k1"] = "v1"
     operator.setitem(d, "k1", "v1")
-    asserts.assert_that("v1").is_equal_to(operator.getitem(d, "K1"))
+    asserts.assert_that("v1").is_equal_to(d["K1"])
     asserts.assert_that(d.items()).contains(("k1", "v1"))
 
 
@@ -430,7 +430,7 @@ def TestCIMutableMultiDict_test_set_default():
     asserts.assert_that("three").is_equal_to(d.setdefault("otherkey", "three"))
     asserts.assert_that(d).contains("otherkey")
     asserts.assert_that(d.items()).contains(("otherkey", "three"))
-    asserts.assert_that("three").is_equal_to(operator.getitem(d, "OTHERKEY"))
+    asserts.assert_that("three").is_equal_to(d["OTHERKEY"])
 
 
 def TestCIMutableMultiDict_test_popitem():


### PR DESCRIPTION
feat(compatibility): SimpleStruct now understands `__getitem__` via `[]` and if iterable, supports iteration directly

- This allows us to use the shorthand subscriptable syntax `[]` if a mutablestruct has a method named `__getitem__`, which helps with developer productivity when using the `multidict` module.

- This allows us a user-defined struct (e.g. `mutablestruct`) to be eligible for `in` operations as well as usage in a loop, as follows:

```python
def SequenceClass(n):
    self = larky.mutablestruct(__name__='SequenceClass',
                               __class__=SequenceClass)

    def __init__(n):
        self.n = n
        return self

    self = __init__(n)

    def __getitem__(i):
        if (0 <= i) and (i < self.n):
            return i
        return IndexError()

    self.__getitem__ = __getitem__
    return self

z = SequenceClass(5)
for i in range(3):
    asserts.assert_that(i in z).is_true()  # in works.
```
as well as:

```python
>>> z = SequenceClass(5)
>>> for i in z:
...     print(i)
0
1
2
3
4
```
