### PR TITLE
chore: remove usage of `safe()` vs `Result.Ok()` + `map` pattern.

### DIFF
--- a/larky/pom.xml
+++ b/larky/pom.xml
@@ -244,6 +244,13 @@
                 <configuration>
                     <fork>true</fork>
                     <debug>false</debug>
+<!--                    uncomment this if building under jdk11 -->
+<!--                    <compilerArgs>-->
+<!--                        <arg>&#45;&#45;add-modules</arg>-->
+<!--                        <arg>ALL-SYSTEM</arg>-->
+<!--                        <arg>&#45;&#45;add-exports</arg>-->
+<!--                        <arg>java.base/sun.security.x509=ALL-UNNAMED</arg>-->
+<!--                    </compilerArgs>-->
                     <showWarnings>true</showWarnings>
                     <failOnWarning>false</failOnWarning>
                     <showDeprecation>true</showDeprecation>

--- a/larky/src/main/resources/vendor/option/result.star
+++ b/larky/src/main/resources/vendor/option/result.star
@@ -538,16 +538,16 @@ def try_(func):
             return
         # at this point, we have an invalid state transition
         # (wrong try/except/else/finally order!)
-        _current_state = _enum.reverse_mapping[self._current_state]
+        _current_state = _enum._value2member_map_[self._current_state]
         _valid_transitions = ", ".join([
-            "%s => %s" % (_current_state, _enum.reverse_mapping[i])
+            "%s => %s" % (_current_state, _enum._value2member_map_[i])
             for i in _state[self._current_state]
         ])
         fail(("Invalid state transition: %s => %s. " +
               "The try builder was constructed in the wrong order. " +
               "The next valid state transitions allowed are: %s")% (
             _current_state,
-            _enum.reverse_mapping[next_state],
+            _enum._value2member_map_[next_state],
             _valid_transitions,
         ))
 
@@ -575,7 +575,8 @@ def try_(func):
     def build(*args, **kwargs):
         _assert_valid_transition(_enum.BUILD)
         self._current_state = _enum.BUILD
-        rval = safe(self._attempt)(*args, **kwargs)
+        result_func = Result.Ok(self._attempt)
+        rval = result_func.map(lambda func: func(*args, **kwargs))
         if rval.is_err and self._exc:
             for e in self._exc:
                 rval = rval.map_err(e)

--- a/larky/src/main/resources/vendor/pycryptodome.star
+++ b/larky/src/main/resources/vendor/pycryptodome.star
@@ -1,4 +1,0 @@
-load("@stdlib/larky", "larky")
-
-print("hello")
-pycryptodome = larky.struct()

--- a/larky/src/test/resources/test_loading_module.star
+++ b/larky/src/test/resources/test_loading_module.star
@@ -3,7 +3,7 @@
 # load("./testlib/builtinz", "setz") # works
 load("@stdlib//json", "json")
 load("@stdlib//hashlib", "hashlib")
-load("@vendor//pycryptodome", "pycryptodome")
+load("@vendor//Crypto/Hash", "Hash")
 load("testlib/builtinz", "setz", "collections")
 
 


### PR DESCRIPTION
**Stack**:
- #225
- #224
- #223
- #222
- #221
- #220
- #219
- #218
- #217
- #216
- #215
- #214
- #213
- #212
- #211
- #210
- #209
- #208
- #207
- #206
- #205
- #204
- #203
- #202
- #201


