### PR TITLE
feat: Introduce Peekable(which allows us to peek() at an iterator).

### DIFF
--- a/larky/pom.xml
+++ b/larky/pom.xml
@@ -244,6 +244,13 @@
                 <configuration>
                     <fork>true</fork>
                     <debug>false</debug>
+<!--                    uncomment this if building under jdk11 -->
+<!--                    <compilerArgs>-->
+<!--                        <arg>&#45;&#45;add-modules</arg>-->
+<!--                        <arg>ALL-SYSTEM</arg>-->
+<!--                        <arg>&#45;&#45;add-exports</arg>-->
+<!--                        <arg>java.base/sun.security.x509=ALL-UNNAMED</arg>-->
+<!--                    </compilerArgs>-->
                     <showWarnings>true</showWarnings>
                     <failOnWarning>false</failOnWarning>
                     <showDeprecation>true</showDeprecation>

--- a/larky/src/main/java/com/verygood/security/larky/modules/globals/LarkyGlobals.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/globals/LarkyGlobals.java
@@ -161,4 +161,16 @@ public final class LarkyGlobals {
         .fset(setter != Starlark.NONE ? (StarlarkCallable) setter : null)
         .build();
   }
+
+  @StarlarkMethod(
+        name = "_func_name",
+        parameters = {@Param(name="obj")},
+        useStarlarkThread = true)
+  public String funcName(Object obj, StarlarkThread thread) {
+    if(obj instanceof StarlarkCallable) {
+      return ((StarlarkCallable) obj).getName();
+    }
+    return Starlark.type(obj);
+  }
+
 }

--- a/larky/src/main/resources/stdlib/larky.star
+++ b/larky/src/main/resources/stdlib/larky.star
@@ -92,15 +92,30 @@ def _impl_function_name(f):
     # that knowledge to parse the "NAME" portion out. If this behavior ever
     # changes, we'll need to update this.
     # TODO(bazel-team): Expose a ._name field on functions to avoid this.
-    cls_type = str(f)
-    if 'built-in' in cls_type or '<function ' in cls_type:
-        cls_type = cls_type.split(" ")[-1].rpartition(">")[0]
-    return cls_type
+    return _func_name(f)
+    # cls_type = str(f)
+    # if 'built-in' in cls_type or '<function ' in cls_type:
+    #     cls_type = cls_type.split(" ")[-1].rpartition(">")[0]
+    # return cls_type
 
 
-def _is_instance(instance, some_class):
+def _is_instance(instance, some_class_or_factory):
     t = type(instance)
-    cls_type = _impl_function_name(some_class)
+    # are the types the same?
+    _hasname = None
+    for i in ('__class__', '__name__',):
+        _hasname = getattr(some_class_or_factory, i, None)
+        if _hasname:
+            break
+    if _hasname:
+        _hasname = str(_hasname)
+        if 'built-in' in _hasname or '<function ' in _hasname:
+            _hasname = _hasname.split(" ")[-1].rpartition(">")[0]
+
+    if _hasname and t == _hasname:
+        return True
+    # otherwise
+    cls_type = _impl_function_name(some_class_or_factory)
     # TODO(Larky::Difference) this hack here is specialization for comparing
     #  str to string when we do str(str) in larky, we get
     #  <built-in function str>, but in python, this is <class 'str'>.
@@ -108,6 +123,7 @@ def _is_instance(instance, some_class):
     if t == 'string' and cls_type == 'str':
         return True
     return t == cls_type
+
 
 def translate_bytes(s, original, replace):
     """
@@ -160,7 +176,7 @@ def _zfill(x, leading=4):
         return str(x)
 
 
-def _DeterministicGenerator(func):
+def _DeterministicGenerator(func, *args, **kwargs):
     """
     Exploits iterator protocol support to emulate a generator that
     preserves state by returning an iterator that supports `__getitem__`
@@ -172,13 +188,16 @@ def _DeterministicGenerator(func):
     """
     self = _mutablestruct(__name__='DeterministicGenerator',
                           __class__=_DeterministicGenerator)
-    def __init__(func):
+
+    def __init__(func, *args, **kwargs):
         self.f = func
+        self.args = args
+        self.kwargs = kwargs
         return self
-    self = __init__(func)
+    self = __init__(func, *args, **kwargs)
 
     def __getitem__(i):
-        r = self.f(i)
+        r = self.f(i, *self.args, **self.kwargs)
         if r.is_err and r == StopIteration():
             return IndexError()
         return r.unwrap()
@@ -194,6 +213,100 @@ def _fromkeys(iterable, value=None):
     Create a new dictionary with keys from iterable and values set to value.
     """
     return {key: value for key in iterable}
+
+#
+# def _with(ctx):
+#     l = ctx.__enter__()
+#     try:
+#         f(*args, **kwargs)
+#         if not len(l) > 0:
+#             raise AssertionError("No warning raised when calling %s"
+#                     % f.__name__)
+#         if not l[0].category is DeprecationWarning:
+#             raise AssertionError("First warning for %s is not a " \
+#                     "DeprecationWarning( is %s)" % (f.__name__, l[0]))
+#     finally:
+#         ctx.__exit__()
+#
+
+def _Peekable(iterator, retain_max_elems=5):
+    """An iterable class which can return the next element of the wrapped
+    iterator without advancing it."""
+
+    self = _mutablestruct(__name__='Peekable', __class__=_Peekable)
+    self.SENTINEL = _SENTINEL
+
+    def __init__(iterator, retain_max_elems):
+        self.cache = []
+        self.peeked = []
+        self._retain_max_elems = retain_max_elems
+
+        if hasattr(iterator, '__iter__'):
+            self.iterator = iter(iterator)
+        else:
+            self.iterator = iterator
+        return self
+    self = __init__(iterator, retain_max_elems)
+
+    def __iter__():
+        return self
+    self.__iter__ = __iter__
+
+    def __bool__():
+        rv = self.peek()
+        if rv == StopIteration:
+            return False
+        return True
+    self.__bool__ = __bool__
+
+    def __next__():
+        # TODO: fix this
+        i = self.peeked.pop() if self.peeked else next(self.iterator)
+        self.cache.append(i)
+        self._ensure_size()
+        return i
+    self.__next__ = __next__
+    self.next = __next__
+
+    def peek(default=_SENTINEL):
+        if self.peeked:
+            # we already have done the peek, let's return the head
+            return self.peeked[-1]
+
+        i = next(self.iterator)
+        if i == StopIteration:
+            if default == self.SENTINEL:
+                return StopIteration
+            i = default
+
+        self.peeked.append(i)
+        return i
+    self.peek = peek
+
+    def rewind(n):
+        if not (len(self.cache) >= n):
+            fail("assert len(self.cache) >= n failed!")
+
+        for _ in range(n):
+            self.peeked.append(self.cache.pop())
+    self.rewind = rewind
+
+    def putback(*items):
+        for item in items:
+            self.cache.append(item)
+        self._ensure_size()
+        self.rewind(len(items))
+    self.putback = putback
+
+    def flush():
+        self.cache.clear()
+    self.flush = flush
+
+    def _ensure_size():
+        if len(self.cache) >= self._retain_max_elems:
+            self.cache = self.cache[-self._retain_max_elems :]
+    self._ensure_size = _ensure_size
+    return self
 
 
 larky = _struct(
@@ -217,5 +330,6 @@ larky = _struct(
     ),
     utils=_struct(
         Counter=_Counter,
-        ThreadsafeCounter=_ThreadsafeCounter
+        ThreadsafeCounter=_ThreadsafeCounter,
+        Peekable=_Peekable,
     ))

--- a/larky/src/main/resources/vendor/option/result.star
+++ b/larky/src/main/resources/vendor/option/result.star
@@ -538,16 +538,16 @@ def try_(func):
             return
         # at this point, we have an invalid state transition
         # (wrong try/except/else/finally order!)
-        _current_state = _enum.reverse_mapping[self._current_state]
+        _current_state = _enum._value2member_map_[self._current_state]
         _valid_transitions = ", ".join([
-            "%s => %s" % (_current_state, _enum.reverse_mapping[i])
+            "%s => %s" % (_current_state, _enum._value2member_map_[i])
             for i in _state[self._current_state]
         ])
         fail(("Invalid state transition: %s => %s. " +
               "The try builder was constructed in the wrong order. " +
               "The next valid state transitions allowed are: %s")% (
             _current_state,
-            _enum.reverse_mapping[next_state],
+            _enum._value2member_map_[next_state],
             _valid_transitions,
         ))
 
@@ -575,7 +575,8 @@ def try_(func):
     def build(*args, **kwargs):
         _assert_valid_transition(_enum.BUILD)
         self._current_state = _enum.BUILD
-        rval = safe(self._attempt)(*args, **kwargs)
+        result_func = Result.Ok(self._attempt)
+        rval = result_func.map(lambda func: func(*args, **kwargs))
         if rval.is_err and self._exc:
             for e in self._exc:
                 rval = rval.map_err(e)

--- a/larky/src/main/resources/vendor/pycryptodome.star
+++ b/larky/src/main/resources/vendor/pycryptodome.star
@@ -1,4 +1,0 @@
-load("@stdlib/larky", "larky")
-
-print("hello")
-pycryptodome = larky.struct()

--- a/larky/src/test/resources/test_loading_module.star
+++ b/larky/src/test/resources/test_loading_module.star
@@ -3,7 +3,7 @@
 # load("./testlib/builtinz", "setz") # works
 load("@stdlib//json", "json")
 load("@stdlib//hashlib", "hashlib")
-load("@vendor//pycryptodome", "pycryptodome")
+load("@vendor//Crypto/Hash", "Hash")
 load("testlib/builtinz", "setz", "collections")
 
 

--- a/larky/src/test/resources/vendor_tests/Crypto/Hash/test_SHAKE.star
+++ b/larky/src/test/resources/vendor_tests/Crypto/Hash/test_SHAKE.star
@@ -67,7 +67,7 @@ def SHAKETest_test_digest():
     digest = h.read(90)
 
     # read returns a byte string of the right length
-    asserts.assert_that(types.is_instance(digest, type(b("digest")))).is_true()
+    asserts.assert_that(types.is_bytes(digest)).is_true()
     asserts.assert_that(len(digest)).is_equal_to(90)
 
 def SHAKETest_test_update_after_read():


### PR DESCRIPTION
**Stack**:
- #225
- #224
- #223
- #222
- #221
- #220
- #219
- #218
- #217
- #216
- #215
- #214
- #213
- #212
- #211
- #210
- #209
- #208
- #207
- #206
- #205
- #204
- #203
- #202
- #201


- feat: Modify the Deterministic Generator to take arguments as to pass them to whatever the function it will invoke is.
- feat: Introduce a larky global function called `_func_name` which returns the name of the actual StarlarkCallable to avoid parsing the function name's string to get determinstic subtype testing.
- feat: Leverage the just added feature to modify larky.star's _is_instance and _impl_function_name to get an accurate is_instance. Fix up a test that might've relied on the previous (potentially?) non-deterministic behavior.