### PR TITLE
chore: Move x509 support into its own module and introduce an X509Module

### DIFF
--- a/larky/pom.xml
+++ b/larky/pom.xml
@@ -244,6 +244,13 @@
                 <configuration>
                     <fork>true</fork>
                     <debug>false</debug>
+<!--                    uncomment this if building under jdk11 -->
+<!--                    <compilerArgs>-->
+<!--                        <arg>&#45;&#45;add-modules</arg>-->
+<!--                        <arg>ALL-SYSTEM</arg>-->
+<!--                        <arg>&#45;&#45;add-exports</arg>-->
+<!--                        <arg>java.base/sun.security.x509=ALL-UNNAMED</arg>-->
+<!--                    </compilerArgs>-->
                     <showWarnings>true</showWarnings>
                     <failOnWarning>false</failOnWarning>
                     <showDeprecation>true</showDeprecation>

--- a/larky/src/main/java/com/verygood/security/larky/modules/X509Module.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/X509Module.java
@@ -1,0 +1,14 @@
+package com.verygood.security.larky.modules;
+
+import net.starlark.java.annot.StarlarkBuiltin;
+import net.starlark.java.eval.StarlarkValue;
+
+@StarlarkBuiltin(
+    name = "jx509",
+    category = "BUILTIN",
+    doc = "A module that helps expose x509 helpers")
+public class X509Module implements StarlarkValue {
+
+  public static final X509Module INSTANCE =  new X509Module();
+
+}

--- a/larky/src/main/java/com/verygood/security/larky/modules/crypto/Util/SimpleDERReader.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/crypto/Util/SimpleDERReader.java
@@ -1,0 +1,256 @@
+package com.verygood.security.larky.modules.crypto.Util;
+
+import java.math.BigInteger;
+
+public class SimpleDERReader {
+
+  private static final int CONSTRUCTED = 0x20;
+
+  private byte[] buffer;
+  private int pos;
+  private int count;
+
+  /**
+   * Create a new reader.
+   *
+   * @param b The new content of this reader.
+   */
+  public SimpleDERReader(final byte[] b) {
+    resetInput(b);
+  }
+
+  /**
+   * Create a new reader.
+   *
+   * @param b   The new content of this reader.
+   * @param off The position to start reading from.
+   * @param len The size limit of the content.
+   */
+  public SimpleDERReader(final byte[] b, final int off, final int len) {
+    resetInput(b, off, len);
+  }
+
+  /**
+   * Resets the reader state.
+   *
+   * @param b the new content.
+   */
+  public void resetInput(final byte[] b) {
+    resetInput(b, 0, b.length);
+  }
+
+  /**
+   * Resets the reader state.
+   *
+   * @param b   The new content of this reader.
+   * @param off The position to start reading from.
+   * @param len The size limit of the content.
+   */
+  public void resetInput(final byte[] b, final int off, final int len) {
+    buffer = b.clone();
+    pos = off;
+    count = len;
+  }
+
+  /**
+   * Reads a single byte.
+   *
+   * @return The byte from the DER stream.
+   */
+  private byte readByte() {
+    if (count <= 0) {
+      throw new IllegalArgumentException("DER byte array: out of data");
+    }
+    count--;
+    return buffer[pos++];
+  }
+
+  /**
+   * Reads an array of bytes.
+   *
+   * @param len The number of bytes to read.
+   * @return The array of bytes.
+   */
+  private byte[] readBytes(final int len) {
+    if (len > count) {
+      throw new IllegalArgumentException("DER byte array: out of data");
+    }
+    final byte[] b = new byte[len];
+    System.arraycopy(buffer, pos, b, 0, len);
+    pos += len;
+    count -= len;
+    return b;
+  }
+
+  /**
+   * Determine amount of available data.
+   *
+   * @return The number of bytes currently available.
+   */
+  public int available() {
+    return count;
+  }
+
+  // CHECKSTYLE IGNORE MagicNumber FOR NEXT 147 LINES
+
+  /**
+   * Read the length of the next DER object.
+   *
+   * @return The length of the next object in bytes.
+   */
+  private int readLength() {
+    int len = readByte() & 0xff;
+    if ((len & 0x80) == 0) {
+      return len;
+    }
+    int remain = len & 0x7F;
+    if (remain == 0) {
+      return -1;
+    }
+    len = 0;
+    while (remain > 0) {
+      len = len << 8;
+      len = len | (readByte() & 0xff);
+      remain--;
+    }
+    return len;
+  }
+
+  /**
+   * Skips the next DER object.
+   *
+   * @return The type of the DER object just skipped.
+   */
+  public int ignoreNextObject() {
+    final int type = readByte() & 0xff;
+    final int len = readLength();
+    if (len < 0 || len > available()) {
+      throw new IllegalArgumentException("Illegal len in DER object (" + len + ")");
+    }
+    readBytes(len);
+    return type;
+  }
+
+  /**
+   * Reads a big integer value.
+   *
+   * @return The value of the integer.
+   */
+  public BigInteger readInt() {
+    final int type = readByte() & 0xff;
+    if (type != 0x02) {
+      throw new IllegalArgumentException("Expected DER Integer, but found type " + type);
+    }
+    int len = readLength();
+    if (len < 0 || len > available()) {
+      throw new IllegalArgumentException("Illegal len in DER object (" + len + ")");
+    }
+    final byte[] b = readBytes(len);
+    return new BigInteger(b);
+  }
+
+  /**
+   * Reads the type of an constructed (compound) DER object.
+   *
+   * @return The type of the DER constructed object.
+   */
+  public int readConstructedType() {
+    final int type = readByte() & 0xff;
+    if ((type & CONSTRUCTED) != CONSTRUCTED) {
+      throw new IllegalArgumentException("Expected constructed type, but was " + type);
+    }
+    return type & 0x1f;
+  }
+
+  /**
+   * Prepare for reading a constructed (compound) DER object.
+   *
+   * @return A new reader instance for reading the constructed DER object.
+   */
+  public SimpleDERReader readConstructed() {
+    final int len = readLength();
+    if (len < 0 || len > available()) {
+      throw new IllegalArgumentException("Illegal len in DER object (" + len + ")");
+    }
+    SimpleDERReader cr = new SimpleDERReader(buffer, pos, len);
+    pos += len;
+    count -= len;
+    return cr;
+  }
+
+  /**
+   * Reads a DER secuence.
+   *
+   * @return A byte array, containing the sequuence content.
+   */
+  public byte[] readSequenceAsByteArray() {
+    final int type = readByte() & 0xff;
+    if (type != 0x30) {
+      throw new IllegalArgumentException("Expected DER Sequence, but found type " + type);
+    }
+    final int len = readLength();
+    if (len < 0 || len > available()) {
+      throw new IllegalArgumentException("Illegal len in DER object (" + len + ")");
+    }
+    return readBytes(len);
+  }
+
+  /**
+   * Reads an OID.
+   *
+   * @return A String reprensentation of the OID.
+   */
+  public String readOid() {
+    final int type = readByte() & 0xff;
+    if (type != 0x06) {
+      throw new IllegalArgumentException("Expected DER OID, but found type " + type);
+    }
+    final int len = readLength();
+    if (len < 1 || len > available()) {
+      throw new IllegalArgumentException("Illegal len in DER object (" + len + ")");
+    }
+    final byte[] b = readBytes(len);
+    long value = 0;
+    final StringBuilder sb = new StringBuilder(64);
+    switch (b[0] / 40) {
+      case 0:
+        sb.append('0');
+        break;
+      case 1:
+        sb.append('1');
+        b[0] -= 40;
+        break;
+      default:
+        sb.append('2');
+        b[0] -= 80;
+        break;
+    }
+    for (int i = 0; i < len; i++) {
+      value = value << 7 + b[i] & 0x7F;
+      if ((b[i] & 0x80) == 0) {
+        sb.append('.');
+        sb.append(value);
+        value = 0;
+      }
+    }
+    return sb.toString();
+  }
+
+  /**
+   * Reads an octet string.
+   *
+   * @return The content ad byte array.
+   */
+  public byte[] readOctetString() {
+    final int type = readByte() & 0xff;
+    if (type != 0x04 && type != 0x03) {
+      throw new IllegalArgumentException("Expected DER Octetstring, but found type " + type);
+    }
+    final int len = readLength();
+    if (len < 0 || len > available()) {
+      throw new IllegalArgumentException("Illegal len in DER object (" + len + ")");
+    }
+    return readBytes(len);
+  }
+
+}

--- a/larky/src/main/java/com/verygood/security/larky/modules/globals/LarkyGlobals.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/globals/LarkyGlobals.java
@@ -161,4 +161,16 @@ public final class LarkyGlobals {
         .fset(setter != Starlark.NONE ? (StarlarkCallable) setter : null)
         .build();
   }
+
+  @StarlarkMethod(
+        name = "_func_name",
+        parameters = {@Param(name="obj")},
+        useStarlarkThread = true)
+  public String funcName(Object obj, StarlarkThread thread) {
+    if(obj instanceof StarlarkCallable) {
+      return ((StarlarkCallable) obj).getName();
+    }
+    return Starlark.type(obj);
+  }
+
 }

--- a/larky/src/main/java/com/verygood/security/larky/modules/x509/LarkyKeyPair.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/x509/LarkyKeyPair.java
@@ -1,0 +1,162 @@
+package com.verygood.security.larky.modules.x509;
+
+import java.security.KeyFactory;
+import java.security.KeyPair;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.interfaces.DSAKey;
+import java.security.interfaces.ECKey;
+import java.security.interfaces.RSAKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.KeySpec;
+import java.security.spec.RSAPrivateKeySpec;
+import java.security.spec.RSAPublicKeySpec;
+
+import net.starlark.java.annot.StarlarkMethod;
+import net.starlark.java.eval.EvalException;
+import net.starlark.java.eval.Starlark;
+import net.starlark.java.eval.StarlarkBytes;
+import net.starlark.java.eval.StarlarkInt;
+import net.starlark.java.eval.StarlarkValue;
+
+import org.bouncycastle.crypto.params.AsymmetricKeyParameter;
+import org.bouncycastle.crypto.params.RSAKeyParameters;
+import org.bouncycastle.crypto.params.RSAPrivateCrtKeyParameters;
+
+import javax.crypto.interfaces.DHKey;
+
+public class LarkyKeyPair implements StarlarkValue {
+
+  enum KEY_TYPE {
+    UNKNOWN("UNKNOWN"), RSA("RSA"), DSA("DSA"), EC("EC"), DH("DiffieHellman");
+
+    private final String val;
+
+    KEY_TYPE(String val) {
+      this.val = val;
+    }
+
+    @Override
+    public String toString() {
+      return this.val;
+    }
+  }
+
+  public static KEY_TYPE keyType(PrivateKey aPrivate) {
+    if (aPrivate instanceof RSAKey) {
+      return KEY_TYPE.RSA;
+    } else if (aPrivate instanceof DSAKey) {
+      return KEY_TYPE.DSA;
+    } else if (aPrivate instanceof ECKey) {
+      return KEY_TYPE.EC;
+    } else if (aPrivate instanceof DHKey) {
+      return KEY_TYPE.DH;
+    } else {
+      return KEY_TYPE.UNKNOWN;
+    }
+  }
+
+  final private PrivateKey privateKey;
+  final private PublicKey publicKey;
+  final private KEY_TYPE type;
+
+  public LarkyKeyPair(PublicKey aPublic, PrivateKey aPrivate, KEY_TYPE type) {
+    this.privateKey = aPrivate;
+    this.publicKey = aPublic;
+    this.type = type;
+  }
+
+  public static LarkyKeyPair of(AsymmetricKeyParameter publicParam, AsymmetricKeyParameter privateParam, KEY_TYPE keyType) throws EvalException {
+    final KeyFactory kf;
+    try {
+      kf = KeyFactory.getInstance(keyType.toString());
+    } catch (NoSuchAlgorithmException e) {
+      throw new EvalException(e);
+    }
+    KeySpec publicKeySpec = null, privateKeySpec = null;
+    switch(keyType) {
+      case RSA:
+        publicKeySpec = new RSAPublicKeySpec(
+          ((RSAKeyParameters)publicParam).getModulus(),
+          ((RSAKeyParameters)publicParam).getExponent()
+        );
+        if(privateParam != null) {
+          privateKeySpec = new RSAPrivateKeySpec(
+            ((RSAPrivateCrtKeyParameters)privateParam).getModulus(),
+            ((RSAPrivateCrtKeyParameters)privateParam).getExponent()
+          );
+        }
+        break;
+      case DSA:
+      case EC:
+      case DH:
+      case UNKNOWN:
+      default:
+        throw Starlark.errorf("Not valid key type: %s", keyType);
+    }
+    try {
+      PublicKey publicKey = kf.generatePublic(publicKeySpec);
+      PrivateKey privateKey = null;
+      if(privateKeySpec != null) {
+        privateKey = kf.generatePrivate(privateKeySpec);
+      }
+      return new LarkyKeyPair(publicKey, privateKey, keyType);
+    } catch (InvalidKeySpecException e) {
+      throw new EvalException(e);
+    }
+
+  }
+  public LarkyKeyPair(PublicKey aPublic, PrivateKey aPrivate) {
+   this(aPublic, aPrivate, keyType(aPrivate));
+  }
+
+  public LarkyKeyPair(KeyPair kp) {
+    this(kp.getPublic(), kp.getPrivate());
+  }
+
+  public PrivateKey getPrivateKey() {
+    return privateKey;
+  }
+
+  public PublicKey getPublicKey() {
+    return publicKey;
+  }
+
+  @StarlarkMethod(name="public_key")
+  public StarlarkBytes publicKey() {
+    return StarlarkBytes.immutableOf(getPublicKey().getEncoded());
+  }
+
+  @StarlarkMethod(name="private_key")
+  public StarlarkBytes privateKey() {
+    return loadPrivateKey();
+  }
+
+  @StarlarkMethod(name = "pkey", structField = true)
+  public StarlarkBytes loadPrivateKey() {
+    return StarlarkBytes.immutableOf(getPrivateKey().getEncoded());
+  }
+
+  @StarlarkMethod(name = "bits", structField = true)
+  public StarlarkInt bits() throws EvalException {
+    switch (type) {
+      case RSA:
+        return StarlarkInt.of(((RSAKey)getPrivateKey()).getModulus().bitLength());
+      case DSA:
+        return StarlarkInt.of(((DSAKey)getPrivateKey()).getParams().getP().bitLength());
+      case EC:
+        return StarlarkInt.of(((ECKey) getPrivateKey()).getParams().getCurve().getField().getFieldSize());
+      case DH:
+        return StarlarkInt.of(((DHKey)getPrivateKey()).getParams().getL());
+      default:
+        throw new EvalException("Unable to determine length in bits of specified Key instance");
+    }
+  }
+
+  @StarlarkMethod(name = "key_type", structField = true)
+  public String keytype() {
+    return type.toString();
+  }
+
+}

--- a/larky/src/main/java/com/verygood/security/larky/modules/x509/LarkyX509Certificate.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/x509/LarkyX509Certificate.java
@@ -1,0 +1,394 @@
+package com.verygood.security.larky.modules.x509;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.StringWriter;
+import java.security.cert.CertificateEncodingException;
+import java.util.Arrays;
+import java.util.Objects;
+
+import net.starlark.java.annot.Param;
+import net.starlark.java.annot.StarlarkMethod;
+import net.starlark.java.eval.EvalException;
+import net.starlark.java.eval.Starlark;
+import net.starlark.java.eval.StarlarkBytes;
+import net.starlark.java.eval.StarlarkEvalWrapper;
+import net.starlark.java.eval.StarlarkInt;
+import net.starlark.java.eval.StarlarkList;
+import net.starlark.java.eval.StarlarkThread;
+import net.starlark.java.eval.StarlarkValue;
+
+import org.bouncycastle.asn1.ASN1Encoding;
+import org.bouncycastle.asn1.ASN1ObjectIdentifier;
+import org.bouncycastle.asn1.pkcs.PKCSObjectIdentifiers;
+import org.bouncycastle.asn1.x509.Certificate;
+import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo;
+import org.bouncycastle.asn1.x9.X9ObjectIdentifiers;
+import org.bouncycastle.cert.X509CertificateHolder;
+import org.bouncycastle.crypto.Digest;
+import org.bouncycastle.crypto.params.AsymmetricKeyParameter;
+import org.bouncycastle.crypto.params.DHPublicKeyParameters;
+import org.bouncycastle.crypto.params.DSAPublicKeyParameters;
+import org.bouncycastle.crypto.params.ECPublicKeyParameters;
+import org.bouncycastle.crypto.params.RSAKeyParameters;
+import org.bouncycastle.crypto.util.PublicKeyFactory;
+import org.bouncycastle.jcajce.provider.util.DigestFactory;
+import org.bouncycastle.openssl.PEMParser;
+import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
+import org.bouncycastle.operator.DefaultAlgorithmNameFinder;
+
+public class LarkyX509Certificate implements StarlarkValue {
+
+  private static final DefaultAlgorithmNameFinder algFinder = new DefaultAlgorithmNameFinder();
+  private final X509CertificateHolder cert;
+  private transient int hash;   // lazy initialized
+  private transient SubjectPublicKeyInfo certPublicKey;  // lazy initialized
+
+  LarkyX509Certificate(final Certificate cert) {
+    this(new X509CertificateHolder(cert));
+  }
+
+  LarkyX509Certificate(final X509CertificateHolder cert) {
+    this.cert = cert;
+    this.certPublicKey = null;
+    this.hash = -1; // Default to -1
+
+  }
+
+  public static LarkyX509Certificate of(final X509CertificateHolder cert) throws EvalException {
+    Objects.requireNonNull(cert);
+    return new LarkyX509Certificate(cert);
+  }
+
+  public static LarkyX509Certificate of(final Certificate cert) throws EvalException {
+    Objects.requireNonNull(cert);
+    return new LarkyX509Certificate(cert);
+  }
+
+
+  public static LarkyX509Certificate of(final java.security.cert.X509Certificate cert) throws EvalException {
+    try {
+      return of(cert.getEncoded());
+    } catch (CertificateEncodingException e) {
+      throw new EvalException(e);
+    }
+  }
+
+  public static LarkyX509Certificate of(final byte[] encoded) throws EvalException {
+    return of(encoded, 0, encoded.length);
+  }
+
+  public static LarkyX509Certificate of(final byte[] encoded, final int offset, final int length) throws EvalException {
+    Objects.requireNonNull(encoded);
+    // short path
+    try {
+      final Certificate instance = Certificate.getInstance(encoded);
+      return of(instance);
+    }catch(IllegalArgumentException ignored) {
+      // if we cannot just convert to an instance, let's continue to see
+      // if it's a pem-encoded byte array
+    }
+    PEMParser parser;
+    try(ByteArrayInputStream in = new ByteArrayInputStream(encoded, offset, length)) {
+      parser = new PEMParser(new InputStreamReader(in));
+      final Object object = parser.readObject();
+      if (object instanceof X509CertificateHolder) {
+        return of((X509CertificateHolder) object);
+      }
+      else if(object instanceof Certificate) {
+        return of((Certificate) object);
+      }
+      throw Starlark.errorf("Could not parse PEM-encoded certificate");
+    } catch (IOException e) {
+      throw new EvalException(e);
+    }
+  }
+
+  static byte[] digestOf(String hashFunction, byte[] input) {
+    final Digest d = DigestFactory.getDigest(hashFunction);
+    d.update(input, 0, input.length);
+    byte[] result = new byte[d.getDigestSize()];
+    d.doFinal(result, 0);
+    return result;
+  }
+
+  /*
+  Returns bytes using digest passed.
+  */
+  @StarlarkMethod(name = "fingerprint", parameters = {@Param(name = "hash_algorithm")}, useStarlarkThread = true)
+  public StarlarkBytes fingerprint(String digestName, StarlarkThread thread) throws EvalException {
+    byte[] der;
+    try {
+      //der = this.cert.toASN1Structure().getEncoded(ASN1Encoding.DER);
+      der = this.certPublicKey.getEncoded(ASN1Encoding.DER);
+    } catch (IOException e) {
+      throw new EvalException(e);
+    }
+    byte[] digest = digestOf(digestName, der);
+    return StarlarkBytes.of(thread.mutability(), digest);
+      //.hex(":", StarlarkInt.of(0));
+  }
+
+  /*
+    Returns certificate serial number
+  */
+  @StarlarkMethod(name = "serial_number")
+  public StarlarkInt serial_number() {
+    return StarlarkInt.of(this.cert.getSerialNumber());
+  }
+
+
+  /*
+    Returns the certificate version
+  */
+  @StarlarkMethod(name = "version")
+  public StarlarkInt version() {
+    return StarlarkInt.of(this.cert.getVersionNumber());
+  }
+
+
+  /*
+    Returns the public key as bytes
+  */
+  @StarlarkMethod(name = "public_key_as_bytes")
+  public StarlarkBytes public_key_as_bytes() throws EvalException {
+    try {
+      return StarlarkBytes.immutableOf(this.getPublicKey().getEncoded());
+    } catch (IOException e) {
+      throw new EvalException(e);
+    }
+  }
+
+  /*
+    Returns the public key
+  */
+  @StarlarkMethod(name = "public_key")
+  public LarkyKeyPair public_key() throws EvalException {
+    final SubjectPublicKeyInfo publicKey = this.getPublicKey();
+    try {
+//      final AsymmetricKeyParameter key1 = PrivateKeyFactory.createKey(this.cert.getEncoded());
+      final AsymmetricKeyParameter key = PublicKeyFactory.createKey(publicKey);
+      if (key instanceof RSAKeyParameters) {
+        return LarkyKeyPair.of(key, null, LarkyKeyPair.KEY_TYPE.RSA);
+      } else if (key instanceof DSAPublicKeyParameters) {
+        return LarkyKeyPair.of(key, null, LarkyKeyPair.KEY_TYPE.DSA);
+      } else if (key instanceof ECPublicKeyParameters) {
+        return LarkyKeyPair.of(key, null, LarkyKeyPair.KEY_TYPE.EC);
+      }
+      else if (key instanceof DHPublicKeyParameters) {
+        return LarkyKeyPair.of(key, null, LarkyKeyPair.KEY_TYPE.DH);
+      }
+    } catch (IOException e) {
+      throw new EvalException(e);
+
+    }
+    throw Starlark.errorf("Unrecognized public key");
+  }
+
+
+  /*
+   Not before time (represented as UTC datetime)
+  */
+  @StarlarkMethod(name = "not_valid_before")
+  public StarlarkInt not_valid_before() {
+    return StarlarkInt.of(this.cert.getNotBefore().getTime());
+  }
+
+
+  /*
+   Not after time (represented as UTC datetime)
+  */
+  @StarlarkMethod(name = "not_valid_after")
+  public StarlarkInt not_valid_after() {
+    return StarlarkInt.of(this.cert.getNotAfter().getTime());
+
+  }
+
+
+  /*
+    Returns the issuer name object.
+  */
+  @StarlarkMethod(name = "issuer")
+  public String issuer() {
+    return this.cert.getIssuer().toString();
+  }
+
+
+  /*
+  Returns the subject name object.
+  */
+  @StarlarkMethod(name = "subject")
+  public String subject() {
+    return this.cert.getSubject().toString();
+  }
+
+
+  /*
+   Returns a HashAlgorithm corresponding to the type of the digest signed
+   in the certificate.
+   */
+  @StarlarkMethod(name = "signature_hash_algorithm")
+  public String signature_hash_algorithm() throws EvalException {
+    ASN1ObjectIdentifier aid = this.cert.getSignatureAlgorithm().getAlgorithm();
+
+    String algorithm;
+    if (PKCSObjectIdentifiers.rsaEncryption.equals(aid)) {
+      algorithm = "RSA";
+    } else if (X9ObjectIdentifiers.id_dsa.equals(aid)) {
+      algorithm = "DSA";
+    } else if (X9ObjectIdentifiers.id_ecPublicKey.equals(aid)) {
+      algorithm = "EC";
+    } else {
+      algorithm = algFinder.getAlgorithmName(this.getPublicKey().getAlgorithm().getAlgorithm());
+    }
+
+    if (algorithm == null) {
+      throw new EvalException("unsupported key algorithm: " + aid);
+    }
+    return algorithm;
+  }
+
+  private SubjectPublicKeyInfo getPublicKey() {
+    if (certPublicKey == null) {
+      this.certPublicKey = this.cert.getSubjectPublicKeyInfo();
+    }
+    return this.certPublicKey;
+  }
+
+
+  /*
+          Returns the ObjectIdentifier of the signature algorithm.
+          */
+  @StarlarkMethod(name = "signature_algorithm_oid")
+  public String signature_algorithm_oid() {
+    return this.cert.getSignatureAlgorithm().getAlgorithm().toString();
+  }
+
+
+  /*
+    Returns an Extensions object.
+  */
+  @StarlarkMethod(name = "extensions", useStarlarkThread = true)
+  public StarlarkList<?> extensions(StarlarkThread thread) {
+    final ASN1ObjectIdentifier[] oids = this.cert.getExtensions().getExtensionOIDs();
+    String[] ASN1ObjectIdentifiers = Arrays.stream(oids).map(ASN1ObjectIdentifier::toString).toArray(String[]::new);
+    return StarlarkEvalWrapper.zeroCopyList(thread.mutability(), ASN1ObjectIdentifiers);
+  }
+
+
+  /*
+  Returns the signature bytes.
+  */
+  @StarlarkMethod(name = "signature", useStarlarkThread = true)
+  public StarlarkBytes signature(StarlarkThread thread) {
+    return StarlarkBytes.of(thread.mutability(), this.cert.getSignature());
+  }
+
+
+  /*
+     Returns the tbsCertificate payload bytes as defined in RFC 5280.
+     */
+  @StarlarkMethod(name = "tbs_certificate_bytes", useStarlarkThread = true)
+  public StarlarkBytes tbs_certificate_bytes(StarlarkThread thread) throws EvalException {
+    try {
+      return StarlarkBytes.of(thread.mutability(), this.cert.toASN1Structure().getTBSCertificate().getEncoded());
+    } catch (IOException e) {
+      throw new EvalException(e);
+    }
+  }
+
+
+    /*
+    Checks equality.
+    */
+
+  @Override
+  public boolean equals(Object other) {
+    if (other == null) {
+      return false;
+    }
+    if (this == other) {
+      return true;
+    }
+    if (!(other instanceof LarkyX509Certificate)) {
+      return false;
+    }
+    try {
+      byte[] thisCert = this.cert.getEncoded();
+      byte[] otherCert = ((LarkyX509Certificate) other).cert.getEncoded();
+
+      return Arrays.equals(thisCert, otherCert);
+    } catch (IOException e) {
+      return false;
+    }
+  }
+
+  /*
+       Computes a hash.
+       */
+  @Override
+  @StarlarkMethod(name = "hashCode")
+  public int hashCode() {
+    int h = hash;
+    if (h == -1) {
+      try {
+        h = Arrays.hashCode(this.cert.getEncoded());
+      } catch (IOException e) {
+        h = 0;
+      }
+      hash = h;
+    }
+    return h;
+  }
+
+  /*
+  Serializes the certificate to PEM or DER format.
+  */
+  @StarlarkMethod(name = "public_bytes", parameters = {@Param(name = "encoding")}, useStarlarkThread = true)
+  public StarlarkBytes public_bytes(String encoding, StarlarkThread thread) throws EvalException {
+    switch (encoding.toUpperCase()) {
+      case "DER":
+        try {
+          return StarlarkBytes.of(thread.mutability(), this.getPublicKey().getEncoded(ASN1Encoding.DER));
+        } catch (IOException e) {
+          throw new EvalException(e);
+        }
+      case "PEM":
+        return StarlarkBytes.of(
+          thread.mutability(),
+          StarlarkBytes.UTF16toUTF8(to_pem().toCharArray())
+        );
+      case "OpenSSH":
+      case "Raw":
+      case "ANSI X9.62":
+      case "S/MIME":
+      default:
+        throw Starlark.errorf("TypeError: encoding %s must be an item from the Encoding enum", encoding);
+    }
+  }
+
+  @StarlarkMethod(name = "to_der", useStarlarkThread = true)
+  public String to_der(StarlarkThread thread) throws EvalException {
+    try {
+      return StarlarkBytes
+        .of(thread.mutability(), this.cert.getEncoded())
+        .decode("utf-8", "report");
+    } catch (IOException e) {
+      throw new EvalException(e);
+    }
+  }
+
+  @StarlarkMethod(name = "to_pem")
+  public String to_pem() throws EvalException {
+    final StringWriter wo = new StringWriter();
+    try (JcaPEMWriter pWrt = new JcaPEMWriter(wo)) {
+      pWrt.writeObject(this.cert);
+    } catch (IOException e) {
+      throw new EvalException(e);
+    }
+    wo.flush();
+    return wo.toString();
+  }
+
+}

--- a/larky/src/main/java/com/verygood/security/larky/modules/x509/X509ExtensionType.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/x509/X509ExtensionType.java
@@ -1,0 +1,252 @@
+package com.verygood.security.larky.modules.x509;
+
+
+import org.bouncycastle.asn1.ASN1ObjectIdentifier;
+import org.bouncycastle.asn1.x509.Extension;
+
+/**
+ * Enumeration of X.509 certificate extensions.
+ */
+public enum X509ExtensionType {
+
+  // ////////////////////////////////
+  // Active X509Extension OIDs
+  // ////////////////////////////////
+  AuditIdentity(Extension.auditIdentity, "", false),
+
+  /**
+   * AuthorityInfoAccess extension field.
+   */
+  AuthorityInformationAccess(Extension.authorityInfoAccess, "Authority Information Access", false),
+
+  /**
+   * AuthorityKeyIdentifier extension field.
+   */
+  AuthorityKeyIdentifier(Extension.authorityKeyIdentifier, "Authority Key Identifier", false),
+
+  /**
+   * BasicConstraints extension field.
+   */
+  BasicConstraints(Extension.basicConstraints, "Basic Constraints", true),
+
+  /**
+   * CertificatePolicies extension field.
+   */
+  CertificatePolicies(Extension.certificatePolicies, "Certificate Policies", false),
+
+  /**
+   * CRLDistributionPoints extension field.
+   */
+  CRLDistributionPoints(Extension.cRLDistributionPoints, "CRL Distribution Points", false),
+
+  /**
+   * ExtendedKeyUsage extension field.
+   */
+  ExtendedKeyUsage(Extension.extendedKeyUsage, "Extended Key Usage", false),
+
+  /**
+   * IssuerAlternativeName extension field.
+   */
+  IssuerAlternativeName(Extension.issuerAlternativeName, "Issuer Alternative Name", false),
+
+  /**
+   * KeyUsage extension field.
+   */
+  KeyUsage(Extension.keyUsage, "Key Usage", true),
+
+  /**
+   * NameConstraints extension field.
+   */
+  NameConstraints(Extension.nameConstraints, "Name Constraints", true),
+
+  /**
+   * PolicyConstraints extension field.
+   */
+  PolicyConstraints(Extension.policyConstraints, "Policy Constraints", false),
+
+  /**
+   * PolicyMappings extension field.
+   */
+  PolicyMappings(Extension.policyMappings, "Policy Mappings", false),
+
+  /**
+   * PrivateKeyUsage extension field.
+   */
+  PrivateKeyUsagePeriod(Extension.privateKeyUsagePeriod, "Private Key Usage Period", false),
+
+  /**
+   * SubjectAlternativeName extension field.
+   */
+  SubjectAlternativeName(Extension.subjectAlternativeName, "Subject Alternative Name", false),
+
+  /**
+   * SubjectKeyIdentifier extension field.
+   */
+  SubjectKeyIdentifier(Extension.subjectKeyIdentifier, "Subject Key Identifier", false),
+
+  /**
+   * SubjectDirectoryAttributes extension field.
+   */
+  SubjectDirectoryAttributes(Extension.subjectDirectoryAttributes, "Subject Directory Attributes", false),
+  /**
+   * Certificate Issuer
+   */
+  CertificateIssuer(Extension.certificateIssuer, "Certificate Issuer", false),
+  /**
+   * CRL Number
+   */
+  CRLNumber(Extension.cRLNumber, "CRL Number", false),
+  /**
+   * Delta CRL Indicator
+   */
+  DeltaCRLIndicator(Extension.deltaCRLIndicator, "Delta CRL Indicator", false),
+  /**
+   * Expired Certs on CRL
+   */
+
+  ExpiredCertsOnCRL(Extension.expiredCertsOnCRL, "Expired Certs on CRL", false),
+  /**
+   * Freshest CRL
+   */
+
+  FreshestCRL(Extension.freshestCRL, "Freshest CRL Distribution Point", false),
+  /**
+   * Inhibit Any Policy
+   */
+
+  InhibitAnyPolicy(Extension.inhibitAnyPolicy, "Skip Certificates", false),
+  /**
+   * Instruction Code
+   */
+
+  InstructionCode(Extension.instructionCode, "Instruction Code", false),
+  /**
+   * Invalidity Date
+   */
+
+  InvalidityDate(Extension.invalidityDate, "Invalidity Date", false),
+  /**
+   * Issuing Distribution Point
+   */
+
+  IssuingDistributionPoint(Extension.issuingDistributionPoint, "Issuing Distribution Point", false),
+
+  /**
+   * No Revocation Availability
+   */
+
+  NoRevocationAvailability(Extension.noRevAvail, "No Revocation Availability", false),
+
+  /**
+   * Reason code
+   */
+
+  ReasonCode(Extension.reasonCode, "Reason Code", false),
+
+  /**
+   * Subject Information Access
+   */
+
+  SubjectInfoAccess(Extension.subjectInfoAccess, "Subject Information Access", false),
+  /**
+   * Target Information
+   */
+
+  TargetInformation(Extension.targetInformation, "Target Information", false),
+
+  // ////////////////////////////////
+  // RFC3739 QC PRIVATE EXTENSIONS
+  // ////////////////////////////////
+
+  /**
+   * Stores biometric information for authentication purposes.
+   */
+  BiometricInfo(Extension.biometricInfo, "Biometric Info", false),
+
+  /**
+   * Indicates that the certificate is a Qualified Certificate in accordance with a particular legal system.
+   */
+  QcStatements(Extension.qCStatements, "Qualified Certificate Statements", false),
+
+  // ////////////////////////////////
+  // RFC 3709
+  // ////////////////////////////////
+  LogoType(Extension.logoType, "Logo Type", false),
+
+  Unknown(null, "Unknown OID", false);
+
+
+  private final ASN1ObjectIdentifier asn1obj;
+  private final String name;
+  private final boolean isCritical;
+
+  /**
+   * Creates a new type with the given OID value.
+   *
+   * @param asn1obj  ASN1ObjectIdentifier value.
+   * @param name     A friendly name
+   * @param critical True if extension MUST or SHOULD be marked critical under general circumstances, false otherwise.
+   */
+  X509ExtensionType(final ASN1ObjectIdentifier asn1obj, final String name, final boolean critical) {
+    this.asn1obj = asn1obj;
+    this.name = name;
+    this.isCritical = critical;
+  }
+
+  /**
+   * Gets the extension by name.
+   *
+   * @param name Case-sensitive X.509v3 extension name. The acceptable case of extension names is governed by
+   *             conventions in RFC 2459.
+   * @return Extension with given name.
+   * @throws IllegalArgumentException If no extension with given name exists.
+   */
+  public static X509ExtensionType fromName(final String name) {
+    try {
+      return X509ExtensionType.valueOf(X509ExtensionType.class, name);
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException("Invalid X.509v3 extension name " + name);
+    }
+  }
+
+  /**
+   * Resolve the supplied object identifier to a matching type.
+   *
+   * @param oid Object identifier
+   * @return Type or null if none
+   */
+  public static X509ExtensionType fromOid(String oid) {
+    for (X509ExtensionType type : values()) {
+      if (oid.equals(type.getOid())) {
+        return type;
+      }
+    }
+
+    return Unknown;
+  }
+
+  /**
+   * @return True if extension MUST or SHOULD be marked critical under general circumstances according to RFC 2459,
+   * false otherwise.
+   */
+  public boolean isCritical() {
+    return this.isCritical;
+  }
+
+  /**
+   * @return OID value of extension field.
+   */
+  public String getOid() {
+    return this.asn1obj.getId();
+  }
+
+  /**
+   * Returns  name.
+   *
+   * @return Friendly name
+   */
+  @Override
+  public String toString() {
+    return this.name;
+  }
+}

--- a/larky/src/main/java/com/verygood/security/larky/modules/x509/X509KeyUsage.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/x509/X509KeyUsage.java
@@ -1,0 +1,132 @@
+package com.verygood.security.larky.modules.x509;
+
+import org.bouncycastle.asn1.x509.KeyUsage;
+
+/**
+ * Enumeration of bits used in key usage extension field
+ */
+public enum X509KeyUsage {
+
+  /**
+   * Digital signature
+   *  Binary: 10000000
+   *  Hex: 0x80
+   *  Dec: 128
+   *
+   */
+  DIGITAL_SIGNATURE(KeyUsage.digitalSignature, "digitalSignature"),
+
+  /**
+   * Non repudiation
+   *  Binary: 1000000
+   *  Hex: 0x40
+   *  Dec: 64
+   *
+   */
+  NON_REPUDIATION(KeyUsage.nonRepudiation, "nonRepudiation"),
+
+  /**
+   * Key encipherment
+   *  Binary: 100000
+   *  Hex: 0x20
+   *  Dec: 32
+   *
+   */
+  KEY_ENCIPHERMENT(KeyUsage.keyEncipherment, "keyEncipherment"),
+
+  /**
+   * Data encipherment
+   *  Binary: 10000
+   *  Hex: 0x10
+   *  Dec: 16
+   *
+   */
+  DATA_ENCIPHERMENT(KeyUsage.dataEncipherment, "dataEncipherment"),
+
+  /**
+   * Key agreement
+   *  Binary: 100
+   *  Hex: 0x08
+   *  Dec: 8
+   *
+   */
+  KEY_AGREEMENT(KeyUsage.keyAgreement, "keyAgreement"),
+
+  /**
+   * Certificate signing
+   *  Binary: 100
+   *  Hex: 0x04
+   *  Dec: 4
+   *
+   */
+  KEY_CERTIFICATE_SIGNING(KeyUsage.keyCertSign, "keyCertSign"),
+
+  /**
+   * CRL signing
+   *  Binary: 10
+   *  Hex: 0x02
+   *  Dec: 2
+   *
+   */
+  CRL_SIGNING(KeyUsage.cRLSign, "crlSign"),
+
+  /**
+   * Encipher only
+   *  Binary: 1
+   *  Hex: 0x01
+   *  Dec: 1
+   *
+   */
+  ENCIPHER_ONLY(KeyUsage.encipherOnly, "encipherOnly"),
+
+  /**
+   * Decipherment only
+   *  Binary: 1000000000000000
+   *  Hex: 0x8000
+   *  Dec: 32768
+   *
+   */
+  DECIPHERMENT_ONLY(KeyUsage.decipherOnly, "decipherOnly");
+
+  private final int bit;
+  private final String name;
+
+  X509KeyUsage(int bit, String name) {
+    this.bit = bit;
+    this.name = name;
+  }
+
+  /**
+   * Gets the key usage bit as an integer.
+   *
+   * @return The key usage bit as an integer.
+   */
+  public int usageBit() {
+    return bit;
+  }
+
+  /**
+   * Gets the name of the key usage bit.
+   *
+   * @return The name of the key usage bit
+   */
+  public String getName() {
+    return name;
+  }
+
+  /**
+   * Gets the key usage by name.
+   *
+   * @param name Key Usage Bit Name
+   * @return X509KeyUsage with given name.
+   *
+   * @throws IllegalArgumentException If no X509KeyUsage with given name exists.
+   */
+  public static X509KeyUsage fromName(final String name) {
+    try {
+      return X509KeyUsage.valueOf(X509KeyUsage.class, name);
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException("Invalid X509KeyUsage name: " + name);
+    }
+  }
+}

--- a/larky/src/main/resources/stdlib/larky.star
+++ b/larky/src/main/resources/stdlib/larky.star
@@ -92,15 +92,30 @@ def _impl_function_name(f):
     # that knowledge to parse the "NAME" portion out. If this behavior ever
     # changes, we'll need to update this.
     # TODO(bazel-team): Expose a ._name field on functions to avoid this.
-    cls_type = str(f)
-    if 'built-in' in cls_type or '<function ' in cls_type:
-        cls_type = cls_type.split(" ")[-1].rpartition(">")[0]
-    return cls_type
+    return _func_name(f)
+    # cls_type = str(f)
+    # if 'built-in' in cls_type or '<function ' in cls_type:
+    #     cls_type = cls_type.split(" ")[-1].rpartition(">")[0]
+    # return cls_type
 
 
-def _is_instance(instance, some_class):
+def _is_instance(instance, some_class_or_factory):
     t = type(instance)
-    cls_type = _impl_function_name(some_class)
+    # are the types the same?
+    _hasname = None
+    for i in ('__class__', '__name__',):
+        _hasname = getattr(some_class_or_factory, i, None)
+        if _hasname:
+            break
+    if _hasname:
+        _hasname = str(_hasname)
+        if 'built-in' in _hasname or '<function ' in _hasname:
+            _hasname = _hasname.split(" ")[-1].rpartition(">")[0]
+
+    if _hasname and t == _hasname:
+        return True
+    # otherwise
+    cls_type = _impl_function_name(some_class_or_factory)
     # TODO(Larky::Difference) this hack here is specialization for comparing
     #  str to string when we do str(str) in larky, we get
     #  <built-in function str>, but in python, this is <class 'str'>.
@@ -108,6 +123,7 @@ def _is_instance(instance, some_class):
     if t == 'string' and cls_type == 'str':
         return True
     return t == cls_type
+
 
 def translate_bytes(s, original, replace):
     """
@@ -160,7 +176,7 @@ def _zfill(x, leading=4):
         return str(x)
 
 
-def _DeterministicGenerator(func):
+def _DeterministicGenerator(func, *args, **kwargs):
     """
     Exploits iterator protocol support to emulate a generator that
     preserves state by returning an iterator that supports `__getitem__`
@@ -172,13 +188,16 @@ def _DeterministicGenerator(func):
     """
     self = _mutablestruct(__name__='DeterministicGenerator',
                           __class__=_DeterministicGenerator)
-    def __init__(func):
+
+    def __init__(func, *args, **kwargs):
         self.f = func
+        self.args = args
+        self.kwargs = kwargs
         return self
-    self = __init__(func)
+    self = __init__(func, *args, **kwargs)
 
     def __getitem__(i):
-        r = self.f(i)
+        r = self.f(i, *self.args, **self.kwargs)
         if r.is_err and r == StopIteration():
             return IndexError()
         return r.unwrap()
@@ -194,6 +213,100 @@ def _fromkeys(iterable, value=None):
     Create a new dictionary with keys from iterable and values set to value.
     """
     return {key: value for key in iterable}
+
+#
+# def _with(ctx):
+#     l = ctx.__enter__()
+#     try:
+#         f(*args, **kwargs)
+#         if not len(l) > 0:
+#             raise AssertionError("No warning raised when calling %s"
+#                     % f.__name__)
+#         if not l[0].category is DeprecationWarning:
+#             raise AssertionError("First warning for %s is not a " \
+#                     "DeprecationWarning( is %s)" % (f.__name__, l[0]))
+#     finally:
+#         ctx.__exit__()
+#
+
+def _Peekable(iterator, retain_max_elems=5):
+    """An iterable class which can return the next element of the wrapped
+    iterator without advancing it."""
+
+    self = _mutablestruct(__name__='Peekable', __class__=_Peekable)
+    self.SENTINEL = _SENTINEL
+
+    def __init__(iterator, retain_max_elems):
+        self.cache = []
+        self.peeked = []
+        self._retain_max_elems = retain_max_elems
+
+        if hasattr(iterator, '__iter__'):
+            self.iterator = iter(iterator)
+        else:
+            self.iterator = iterator
+        return self
+    self = __init__(iterator, retain_max_elems)
+
+    def __iter__():
+        return self
+    self.__iter__ = __iter__
+
+    def __bool__():
+        rv = self.peek()
+        if rv == StopIteration:
+            return False
+        return True
+    self.__bool__ = __bool__
+
+    def __next__():
+        # TODO: fix this
+        i = self.peeked.pop() if self.peeked else next(self.iterator)
+        self.cache.append(i)
+        self._ensure_size()
+        return i
+    self.__next__ = __next__
+    self.next = __next__
+
+    def peek(default=_SENTINEL):
+        if self.peeked:
+            # we already have done the peek, let's return the head
+            return self.peeked[-1]
+
+        i = next(self.iterator)
+        if i == StopIteration:
+            if default == self.SENTINEL:
+                return StopIteration
+            i = default
+
+        self.peeked.append(i)
+        return i
+    self.peek = peek
+
+    def rewind(n):
+        if not (len(self.cache) >= n):
+            fail("assert len(self.cache) >= n failed!")
+
+        for _ in range(n):
+            self.peeked.append(self.cache.pop())
+    self.rewind = rewind
+
+    def putback(*items):
+        for item in items:
+            self.cache.append(item)
+        self._ensure_size()
+        self.rewind(len(items))
+    self.putback = putback
+
+    def flush():
+        self.cache.clear()
+    self.flush = flush
+
+    def _ensure_size():
+        if len(self.cache) >= self._retain_max_elems:
+            self.cache = self.cache[-self._retain_max_elems :]
+    self._ensure_size = _ensure_size
+    return self
 
 
 larky = _struct(
@@ -217,5 +330,6 @@ larky = _struct(
     ),
     utils=_struct(
         Counter=_Counter,
-        ThreadsafeCounter=_ThreadsafeCounter
+        ThreadsafeCounter=_ThreadsafeCounter,
+        Peekable=_Peekable,
     ))

--- a/larky/src/main/resources/vendor/option/result.star
+++ b/larky/src/main/resources/vendor/option/result.star
@@ -538,16 +538,16 @@ def try_(func):
             return
         # at this point, we have an invalid state transition
         # (wrong try/except/else/finally order!)
-        _current_state = _enum.reverse_mapping[self._current_state]
+        _current_state = _enum._value2member_map_[self._current_state]
         _valid_transitions = ", ".join([
-            "%s => %s" % (_current_state, _enum.reverse_mapping[i])
+            "%s => %s" % (_current_state, _enum._value2member_map_[i])
             for i in _state[self._current_state]
         ])
         fail(("Invalid state transition: %s => %s. " +
               "The try builder was constructed in the wrong order. " +
               "The next valid state transitions allowed are: %s")% (
             _current_state,
-            _enum.reverse_mapping[next_state],
+            _enum._value2member_map_[next_state],
             _valid_transitions,
         ))
 
@@ -575,7 +575,8 @@ def try_(func):
     def build(*args, **kwargs):
         _assert_valid_transition(_enum.BUILD)
         self._current_state = _enum.BUILD
-        rval = safe(self._attempt)(*args, **kwargs)
+        result_func = Result.Ok(self._attempt)
+        rval = result_func.map(lambda func: func(*args, **kwargs))
         if rval.is_err and self._exc:
             for e in self._exc:
                 rval = rval.map_err(e)

--- a/larky/src/main/resources/vendor/pycryptodome.star
+++ b/larky/src/main/resources/vendor/pycryptodome.star
@@ -1,4 +1,0 @@
-load("@stdlib/larky", "larky")
-
-print("hello")
-pycryptodome = larky.struct()

--- a/larky/src/test/resources/test_loading_module.star
+++ b/larky/src/test/resources/test_loading_module.star
@@ -3,7 +3,7 @@
 # load("./testlib/builtinz", "setz") # works
 load("@stdlib//json", "json")
 load("@stdlib//hashlib", "hashlib")
-load("@vendor//pycryptodome", "pycryptodome")
+load("@vendor//Crypto/Hash", "Hash")
 load("testlib/builtinz", "setz", "collections")
 
 

--- a/larky/src/test/resources/vendor_tests/Crypto/Hash/test_SHAKE.star
+++ b/larky/src/test/resources/vendor_tests/Crypto/Hash/test_SHAKE.star
@@ -67,7 +67,7 @@ def SHAKETest_test_digest():
     digest = h.read(90)
 
     # read returns a byte string of the right length
-    asserts.assert_that(types.is_instance(digest, type(b("digest")))).is_true()
+    asserts.assert_that(types.is_bytes(digest)).is_true()
     asserts.assert_that(len(digest)).is_equal_to(90)
 
 def SHAKETest_test_update_after_read():


### PR DESCRIPTION
**Stack**:
- #225
- #224
- #223
- #222
- #221
- #220
- #219
- #218
- #217
- #216
- #215
- #214
- #213
- #212
- #211
- #210
- #209
- #208
- #207
- #206
- #205
- #204
- #203
- #202
- #201


- chore: Extract loaded key and x509 cert starlark types into separate classes.