### PR TITLE
feat: Start work by updating Result types in Larky to allow StarlarkThread to be passed to the Error (for a much better error message) when the exception is unwrapped. This diff will allow us to have much clearer stacktraces pinpointing where the error occurred in a `unwrap()` expression.

### DIFF
--- a/larky/src/main/java/com/verygood/security/larky/modules/types/results/Error.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/types/results/Error.java
@@ -5,6 +5,7 @@ import java.util.Objects;
 import net.starlark.java.eval.EvalException;
 import net.starlark.java.eval.Printer;
 import net.starlark.java.eval.Starlark;
+import net.starlark.java.eval.StarlarkThread;
 
 
 public class Error extends EvalException implements Result {
@@ -36,6 +37,21 @@ public class Error extends EvalException implements Result {
     }
     else if(EvalException.class.isAssignableFrom(e.getClass())) {
       return new Error((EvalException) e);
+    }
+    return new Error(e);
+  }
+
+  public static Error withThread(Object e, StarlarkThread thread) {
+    if(Error.class.isAssignableFrom(e.getClass())) {
+      return new Error(e);
+    }
+    else if(e instanceof EvalException) {
+      return new Error((EvalException) e);
+    }
+    else if(e instanceof Starlark.UncheckedEvalException) {
+      final Starlark.UncheckedEvalException e1 = (Starlark.UncheckedEvalException) e;
+      final EvalException evalException = new EvalException(e1.getCause().getMessage(), e1.getCause());
+      return new Error(evalException);
     }
     return new Error(e);
   }

--- a/larky/src/main/java/com/verygood/security/larky/modules/types/results/Result.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/types/results/Result.java
@@ -28,7 +28,7 @@ public interface Result extends StarlarkValue, Comparable<Result> {
     if(error instanceof Result) {
       return (Result) error;
     }
-    return Error.of(error);
+    return Error.withThread(error, thread);
   }
 
   @StarlarkMethod(name = "Ok", parameters = {@Param(name = "value")})


### PR DESCRIPTION
**Stack**:
- #225
- #224
- #223
- #222
- #221
- #220
- #219
- #218
- #217
- #216
- #215
- #214
- #213
- #212
- #211
- #210
- #209
- #208
- #207
- #206
- #205
- #204
- #203
- #202
- #201


