### PR TITLE
feat(compat): migrate python3's functools.cmp_to_key to allow us to convert a python2's cmp= keyword argument for sorter functions into the new python3 key= function.

### DIFF
--- a/larky/src/main/resources/stdlib/functools.star
+++ b/larky/src/main/resources/stdlib/functools.star
@@ -15,3 +15,36 @@ def reduce(function, sequence, initial=larky.SENTINEL):
         value = function(value, element)
 
     return value
+
+
+################################################################################
+### cmp_to_key() function converter
+################################################################################
+
+def cmp_to_key(mycmp):
+    """Convert a cmp= function into a key= function"""
+    def K(obj):
+        def __lt__(other):
+            return mycmp(obj, other.obj) < 0
+        def __gt__(other):
+            return mycmp(obj, other.obj) > 0
+        def __eq__(other):
+            return mycmp(obj, other.obj) == 0
+        def __le__(other):
+            return mycmp(obj, other.obj) <= 0
+        def __ge__(other):
+            return mycmp(obj, other.obj) >= 0
+        __hash__ = None
+
+        return larky.struct(
+            __name__='K',
+            __class__=K,
+            __hash__=__hash__,
+            __lt__=__lt__,
+            __gt__=__gt__,
+            __eq__=__eq__,
+            __le__=__le__,
+            __ge__=__ge__,
+            obj=obj,
+        )
+    return K


### PR DESCRIPTION
**Stack**:
- #225
- #224
- #223
- #222
- #221
- #220
- #219
- #218
- #217
- #216
- #215
- #214
- #213
- #212
- #211
- #210
- #209
- #208
- #207
- #206
- #205
- #204
- #203
- #202
- #201


