### PR TITLE
feat(compat): Update `hashlib.star` `Crypto/Hash/__init__.star` to have further compatible Python API

### DIFF
--- a/larky/src/main/resources/stdlib/hashlib.star
+++ b/larky/src/main/resources/stdlib/hashlib.star
@@ -52,7 +52,7 @@ load("@vendor//Crypto/Hash/SHA512", SHA512="SHA512")
 load("@vendor//Crypto/Hash/SHAKE128", SHAKE128="SHAKE128")
 
 
-hashlib = larky.struct(
+__hashes = dict(
     md5=MD5.new,
     sha=SHA1.new,
     sha1=SHA1.new,
@@ -63,3 +63,19 @@ hashlib = larky.struct(
     blake2s=BLAKE2s.new,
     shake_128=SHAKE128.new,
 )
+
+def _new(name, data=b'', **kwargs):
+    """new(name, data=b'') - Return a new hashing object using the named algorithm;
+    optionally initialized with data (which must be a bytes-like object).
+    """
+    if name in __hashes:
+        # Prefer our builtin blake2 implementation.
+        return __hashes[name](data, **kwargs)
+
+
+hashlib = larky.struct(
+    __name__='hashlib',
+    new=_new,
+    **__hashes
+)
+

--- a/larky/src/main/resources/vendor/Crypto/Hash/SHA512.star
+++ b/larky/src/main/resources/vendor/Crypto/Hash/SHA512.star
@@ -50,17 +50,17 @@ def SHA512Hash(data=None, truncate=None):
         self_['_truncate'] = truncate
 
         if truncate == None:
-            # self_['oid'] = "2.16.840.1.101.3.4.2.3"
-            # self_['digest_size'] = 64
-             self_['_state'] = _JCrypto.Hash.SHA512("512")
+            self_['oid'] = "2.16.840.1.101.3.4.2.3"
+            self_['digest_size'] = digest_size
+            self_['_state'] = _JCrypto.Hash.SHA512("512")
         elif truncate == "224":
-            # self_['oid'] = "2.16.840.1.101.3.4.2.5"
-            # self_['digest_size'] = 28
-             self_['_state'] = _JCrypto.Hash.SHA512("224")
+            self_['oid'] = "2.16.840.1.101.3.4.2.5"
+            self_['digest_size'] = 28
+            self_['_state'] = _JCrypto.Hash.SHA512("224")
         elif truncate == "256":
-            # self_['oid'] = "2.16.840.1.101.3.4.2.6"
-            # self_['digest_size'] = 32
-             self_['_state'] = _JCrypto.Hash.SHA512("256")
+            self_['oid'] = "2.16.840.1.101.3.4.2.6"
+            self_['digest_size'] = 32
+            self_['_state'] = _JCrypto.Hash.SHA512("256")
         else:
             fail('ValueError: Incorrect truncation length. It must be "224"' +
                  ' or "256".')
@@ -72,7 +72,7 @@ def SHA512Hash(data=None, truncate=None):
     self = __init__(data, truncate)
 
     # The internal block size of the hash algorithm in bytes.
-    self.block_size = 128
+    self.block_size = block_size
 
     def update(data):
         """Continue hashing of a message by consuming the next chunk of data.

--- a/larky/src/main/resources/vendor/Crypto/Hash/__init__.star
+++ b/larky/src/main/resources/vendor/Crypto/Hash/__init__.star
@@ -1,0 +1,27 @@
+load("@stdlib//larky", larky="larky")
+
+load("@vendor//Crypto/Hash/BLAKE2s", BLAKE2s="BLAKE2s")
+load("@vendor//Crypto/Hash/keccak", keccak="keccak")
+load("@vendor//Crypto/Hash/MD5", MD5="MD5")
+load("@vendor//Crypto/Hash/SHA1", SHA1="SHA1")
+load("@vendor//Crypto/Hash/SHA224", SHA224="SHA224")
+load("@vendor//Crypto/Hash/SHA256", SHA256="SHA256")
+load("@vendor//Crypto/Hash/SHA384", SHA384="SHA384")
+load("@vendor//Crypto/Hash/SHA512", SHA512="SHA512")
+load("@vendor//Crypto/Hash/SHAKE128", SHAKE128="SHAKE128")
+load("@vendor//Crypto/Hash/SHA3_256", SHA3_256="SHA3_256")
+
+
+Hash = larky.struct(
+    BLAKE2s=BLAKE2s,
+    MD5=MD5,
+    SHA1=SHA1,
+    SHA224=SHA224,
+    SHA256=SHA256,
+    SHA384=SHA384,
+    SHA512=SHA512,
+    SHAKE128=SHAKE128,
+    keccak=keccak,
+    KECCAK=keccak,
+    SHA3_256=SHA3_256,
+)


### PR DESCRIPTION
**Stack**:
- #225
- #224
- #223
- #222
- #221
- #220
- #219
- #218
- #217
- #216
- #215
- #214
- #213
- #212
- #211
- #210
- #209
- #208
- #207
- #206
- #205
- #204
- #203
- #202
- #201


- feat(compat): SHA512 should support exposing `oid` and `digest_size` as per `Crypto.Hash.SHA512` API