### PR TITLE
fix: expose pss as the module struct

### DIFF
--- a/larky/src/main/resources/stdlib/sets.star
+++ b/larky/src/main/resources/stdlib/sets.star
@@ -318,15 +318,19 @@ def Set(iterable=None):
         return Set([e for e in self._values.keys() if e not in b._values])
     self.difference = difference
 
-    def _length():
+    def _set_length():
         return _length(self)
-    self._length = _length
-    self.__len__ = _length  # alias
+    self._length = _set_length
+    self.__len__ = _set_length  # alias
 
     def __repr__():
         return _repr(self)
     self.__repr__ = __repr__
     self.__str__ = __repr__  # alias
+
+    def __iter__():
+        return iter(self._values)
+    self.__iter__ = __iter__
     return self
 
 

--- a/larky/src/main/resources/vendor/Crypto/Signature/pss.star
+++ b/larky/src/main/resources/vendor/Crypto/Signature/pss.star
@@ -391,3 +391,9 @@ def new(rsa_key, **kwargs):
                      str(kwargs.keys())).unwrap()
     return PSS_SigScheme(rsa_key, mask_func, salt_len, rand_func)
 
+
+pss = larky.struct(
+    __name__='pss',
+    MGF1=MGF1,
+    new=new,
+)

--- a/larky/src/main/resources/vendor/Crypto/Util/number.star
+++ b/larky/src/main/resources/vendor/Crypto/Util/number.star
@@ -340,7 +340,7 @@ def long_to_bytes(n, blocksize=0):
     return bresult
 
 
-def bytes_to_long(s):
+def bytes_to_long(s,  byteorder='big', signed=False):
     r"""Convert a byte string to a long integer (big endian).
 
     In Python 3.2+, use the native method instead::
@@ -354,7 +354,7 @@ def bytes_to_long(s):
 
     This is (essentially) the inverse of :func:`long_to_bytes`.
     """
-    return _JCrypto.Math.int_from_bytes(s, 'big')
+    return _JCrypto.Math.int_from_bytes(s, byteorder)
 
 
 def long2str(n, blocksize=0):

--- a/larky/src/main/resources/vendor/Crypto/Util/py3compat.star
+++ b/larky/src/main/resources/vendor/Crypto/Util/py3compat.star
@@ -102,12 +102,15 @@ def tobytes(s, encoding="ISO-8859-1"):
         return builtins.bytes([s])
 
 
-def tostr(bs):
-    return codecs.decode(bs, encoding="ISO-8859-1")
+def tostr(bs, encoding="ISO-8859-1"):
+    if types.is_string(bs):
+        return bs
+    return codecs.decode(bs, encoding=encoding)
 
 
 def byte_string(s):
     return types.is_bytes(s)
+
 
 is_bytes = byte_string
 

--- a/larky/src/main/resources/vendor/past/__init__.star
+++ b/larky/src/main/resources/vendor/past/__init__.star
@@ -1,0 +1,10 @@
+"""
+This module is to make python<>larky compatibility easier
+"""
+load("@stdlib//larky", larky="larky")
+load("@vendor//past/builtins", builtins=builtins)
+
+
+past = larky.struct(
+    builtins=builtins
+)

--- a/larky/src/main/resources/vendor/past/builtins.star
+++ b/larky/src/main/resources/vendor/past/builtins.star
@@ -1,0 +1,16 @@
+load("@stdlib//larky", larky="larky")
+load("@stdlib//struct", struct="struct")
+load("@stdlib//operator", operator="operator")
+
+
+
+def cmp(a, b):
+    _a = 1 if bool(operator.ge(a, b)) else 0
+    _b = 1 if bool(operator.lt(a, b)) else 0
+    return _a - _b
+
+
+builtins = larky.struct(
+    __name__='builtins',
+    cmp=cmp
+)

--- a/larky/src/main/resources/vendor/six.star
+++ b/larky/src/main/resources/vendor/six.star
@@ -11,9 +11,19 @@ load("@vendor//Crypto/Util/py3compat",
 def _int2byte(x):
     return struct.pack(">B", x)
 
+
+def reraise(tp, value, tb=None):
+    if value == None:
+       value = tp()
+    if tb != None and getattr(value, '__traceback__', None) == tb:
+       fail(value.with_traceback(tb))
+    fail(value)
+
+
 six = larky.struct(
     ensure_binary=tobytes,
     ensure_str=tostr,
     int2byte=_int2byte,
     byte2int=operator.itemgetter(0),
+    reraise=reraise
 )


### PR DESCRIPTION
**Stack**:
- #225
- #224
- #223
- #222
- #221
- #220
- #219
- #218
- #217
- #216
- #215
- #214
- #213
- #212
- #211
- #210
- #209
- #208
- #207
- #206
- #205
- #204
- #203
- #202
- #201


- fix: update __len__() to correctly allow sets `in` for sets.Set() and introduce an iterator
- feat(compat): update Crypto.Util.number.bytes_to_long to match Python3's api
- fix: update Crypto.Util.py3compat to respect an encoding parameter.
- feat: update six.reraise to make porting libraries easier
- feat: introduce `past` vendor library to make porting libraries easier (this particularly allows us to backport the python2 `cmp()` function).