### PR TITLE
feat: Introduce cryptography (https://github.com/pyca/cryptography) as that has superior APIs for handling X509s vs OpenSSL package and will make it much easier to port various packages going forward.

### DIFF
--- a/larky/src/main/resources/stdlib/io/_io.star
+++ b/larky/src/main/resources/stdlib/io/_io.star
@@ -29,6 +29,7 @@ Notes:
 - There's a simple test set (see end of this file).
 """
 # TODO: Port over https://github.com/python/cpython/blob/34bbc87b2ddbaf245fbed6443c3e620f80c6a843/Lib/_pyio.py
+load("@stdlib//codecs", codecs="codecs")
 load("@stdlib//types", types="types")
 load("@stdlib//larky", larky="larky")
 load("@vendor//option/result", Error="Error")
@@ -374,4 +375,11 @@ def BytesIO(buf=b''):
     self.empty_char = b''
     self.zero_char = b'\0'
     self.newline = b'\n'
+
+    self.super_write = self.write
+    def write(s):
+        if not types.is_bytelike(s):
+            s = codecs.encode(s, encoding='utf-8')
+        return self.super_write(s)
+    self.write = write
     return self

--- a/larky/src/main/resources/vendor/cryptography/LICENSE
+++ b/larky/src/main/resources/vendor/cryptography/LICENSE
@@ -1,0 +1,6 @@
+This software is made available under the terms of *either* of the licenses
+found in LICENSE.APACHE or LICENSE.BSD. Contributions to cryptography are made
+under the terms of *both* these licenses.
+
+The code used in the OS random engine is derived from CPython, and is licensed
+under the terms of the PSF License Agreement

--- a/larky/src/main/resources/vendor/cryptography/LICENSE.APACHE
+++ b/larky/src/main/resources/vendor/cryptography/LICENSE.APACHE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        https://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       https://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/larky/src/main/resources/vendor/cryptography/LICENSE.BSD
+++ b/larky/src/main/resources/vendor/cryptography/LICENSE.BSD
@@ -1,0 +1,27 @@
+Copyright (c) Individual contributors.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice,
+       this list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in the
+       documentation and/or other materials provided with the distribution.
+
+    3. Neither the name of PyCA Cryptography nor the names of its contributors
+       may be used to endorse or promote products derived from this software
+       without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/larky/src/main/resources/vendor/cryptography/__init__.star
+++ b/larky/src/main/resources/vendor/cryptography/__init__.star
@@ -1,0 +1,3 @@
+load("@vendor//cryptography/utils", _utils="utils")
+
+utils = _utils

--- a/larky/src/main/resources/vendor/cryptography/hazmat/__init__.star
+++ b/larky/src/main/resources/vendor/cryptography/hazmat/__init__.star
@@ -1,0 +1,10 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+"""
+
+Hazardous Materials
+This is a "Hazardous Materials" module. You should ONLY use it if you're
+100% absolutely sure that you know what you're doing because this module
+is full of land mines, dragons, and dinosaurs with laser guns.
+"""

--- a/larky/src/main/resources/vendor/cryptography/hazmat/_der.star
+++ b/larky/src/main/resources/vendor/cryptography/hazmat/_der.star
@@ -1,0 +1,167 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+# This module contains a lightweight DER encoder and decoder. See X.690 for the
+# specification. This module intentionally does not implement the more complex
+# BER encoding, only DER.
+#
+# Note this implementation treats an element's constructed bit as part of the
+# tag. This is fine for DER, where the bit is always computable from the type.
+load("@stdlib//builtins", builtins="builtins")
+load("@stdlib//larky", larky="larky")
+load("@stdlib//types", types="types")
+load("@vendor//cryptography/utils",
+     int_to_bytes="int_to_bytes",
+     int_from_bytes="int_from_bytes")
+load("@vendor//option/result", Result="Result")
+
+CONSTRUCTED = 0x20
+CONTEXT_SPECIFIC = 0x80
+
+INTEGER = 0x02
+BIT_STRING = 0x03
+OCTET_STRING = 0x04
+NULL = 0x05
+OBJECT_IDENTIFIER = 0x06
+SEQUENCE = 0x10 | CONSTRUCTED
+SET = 0x11 | CONSTRUCTED
+PRINTABLE_STRING = 0x13
+UTC_TIME = 0x17
+GENERALIZED_TIME = 0x18
+
+def DERReader(data):
+    self = larky.mutablestruct(__name__='DERReader', __class__=DERReader)
+
+    def __init__(data):
+        self.data = bytearray(data)
+        return self
+    self = __init__(data)
+
+    def __enter__():
+        return self
+    self.__enter__ = __enter__
+
+    def __exit__(exc_type, exc_value, tb):
+        if exc_value == None:
+            self.check_empty()
+    self.__exit__ = __exit__
+
+    def is_empty():
+        return len(self.data) == 0
+    self.is_empty = is_empty
+
+    def check_empty():
+        if not self.is_empty():
+            fail("ValueError: Invalid DER input: trailing data")
+    self.check_empty = check_empty
+
+    def read_byte():
+        if len(self.data) < 1:
+            fail("ValueError: Invalid DER input: insufficient data")
+        ret = self.data[0]
+        self.data = self.data[1:]
+        return ret
+    self.read_byte = read_byte
+
+    def read_bytes(n):
+        if len(self.data) < n:
+            fail("ValueError: Invalid DER input: insufficient data")
+        ret = self.data[:n]
+        self.data = self.data[n:]
+        return ret
+    self.read_bytes = read_bytes
+
+    def read_any_element():
+        tag = self.read_byte()
+        # Tag numbers 31 or higher are stored in multiple bytes. No supported
+        # ASN.1 types use such tags, so reject these.
+        if tag & 0x1F == 0x1F:
+            fail("ValueError: Invalid DER input: unexpected high tag number")
+        length_byte = self.read_byte()
+        if length_byte & 0x80 == 0:
+            # If the high bit is clear, the first length byte is the length.
+            length = length_byte
+        else:
+            # If the high bit is set, the first length byte encodes the length
+            # of the length.
+            length_byte &= 0x7F
+            if length_byte == 0:
+                fail("ValueError: " + ("Invalid DER input: indefinite length form is not allowed " + "in DER")
+                )
+            length = 0
+            for i in range(length_byte):
+                length <<= 8
+                length |= self.read_byte()
+                if length == 0:
+                    fail("ValueError: Invalid DER input: length was not minimally-encoded"
+                    )
+            if length < 0x80:
+                # If the length could have been encoded in short form, it must
+                # not use long form.
+                fail("ValueError: Invalid DER input: length was not minimally-encoded")
+        body = self.read_bytes(length)
+        return tag, DERReader(body)
+    self.read_any_element = read_any_element
+
+    def read_element(expected_tag):
+        tag, body = self.read_any_element()
+        if tag != expected_tag:
+            fail("ValueError: Invalid DER input: unexpected tag")
+        return body
+    self.read_element = read_element
+
+    def read_single_element(expected_tag):
+        self.__enter__()
+        rval = Result.Ok(self.read_element).map(lambda x: x(expected_tag))
+        if rval.is_ok:
+            self.__exit__(exc_type=None, exc_value=None, tb=None)
+        return rval.unwrap()
+
+    self.read_single_element = read_single_element
+
+    def read_optional_element(expected_tag):
+        if len(self.data) > 0 and self.data[0] == expected_tag:
+            return self.read_element(expected_tag)
+        return None
+    self.read_optional_element = read_optional_element
+
+    def as_integer():
+        if len(self.data) == 0:
+            fail("ValueError: Invalid DER input: empty integer contents")
+        first = self.data[0]
+        if first & 0x80 == 0x80:
+            fail("ValueError: Negative DER integers are not supported")
+        # The first 9 bits must not all be zero or all be ones. Otherwise, the
+        # encoding should have been one byte shorter.
+        if len(self.data) > 1:
+            second = self.data[1]
+            if first == 0 and second & 0x80 == 0:
+                fail("ValueError: Invalid DER input - integer not minimally-encoded")
+        return int_from_bytes(self.data, "big")
+    self.as_integer = as_integer
+    return self
+
+
+def encode_der_integer(x):
+    if not types.is_int(x):
+        fail("ValueError: Value must be an integer")
+    if x < 0:
+        fail("ValueError: Negative integers are not supported")
+    n = x.bit_length() // 8 + 1
+    return int_to_bytes(x, n)
+
+
+def encode_der(tag, *children):
+    length = 0
+    for child in children:
+        length += len(child)
+    chunks = [bytes([tag])]
+    if length < 0x80:
+        chunks.append(bytes([length]))
+    else:
+        length_bytes = int_to_bytes(length)
+        chunks.append(bytes([0x80 | len(length_bytes)]))
+        chunks.append(length_bytes)
+    chunks.extend(children)
+    return b"".join(chunks)
+

--- a/larky/src/main/resources/vendor/cryptography/hazmat/_oid.star
+++ b/larky/src/main/resources/vendor/cryptography/hazmat/_oid.star
@@ -1,0 +1,385 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+load("@stdlib//larky", larky="larky")
+load("@stdlib//types", types="types")
+load("@stdlib//builtins", builtins="builtins")
+load("@vendor//option/result", Result="Result", Ok="Ok", Error="Error", safe="safe")
+load("@vendor//cryptography/hazmat/primitives/hashes", hashes="hashes")
+
+NotImplemented = builtins.NotImplemented
+
+# forward declaration needed for ObjectIdentifier._name()
+_OID_NAMES = {}
+
+
+def ObjectIdentifier(dotted_string):
+    self = larky.mutablestruct(__name__='ObjectIdentifier', __class__=ObjectIdentifier)
+    def __init__(dotted_string):
+        self._dotted_string = dotted_string
+
+        nodes = self._dotted_string.split(".")
+        intnodes = []
+
+        # There must be at least 2 nodes, the first node must be 0..2, and
+        # if less than 2, the second node cannot have a value outside the
+        # range 0..39.  All nodes must be integers.
+        for node in nodes:
+            node_value = (Result.Ok(node)
+                          .map(lambda x: int(x, 10))
+                          .unwrap_or("ValueError: " + "Malformed OID: %s (non-integer nodes)" % (self._dotted_string)))
+            if node_value < 0:
+                return Error("ValueError: " + "Malformed OID: %s (negative-integer nodes)" % (self._dotted_string)
+                ).unwrap()
+            intnodes.append(node_value)
+
+        if len(nodes) < 2:
+            return Error("ValueError: " + "Malformed OID: %s (insufficient number of nodes)"
+                % (self._dotted_string)
+            ).unwrap()
+
+        if intnodes[0] > 2:
+            return Error("ValueError: " + "Malformed OID: %s (first node outside valid range)"
+                % (self._dotted_string)
+            ).unwrap()
+
+        if intnodes[0] < 2 and intnodes[1] >= 40:
+            return Error("ValueError: " + "Malformed OID: %s (second node outside valid range)"
+                % (self._dotted_string)
+            ).unwrap()
+        return self
+    self = __init__(dotted_string)
+
+    def __eq__(other):
+        if not types.is_instance(other, ObjectIdentifier):
+            return NotImplemented
+
+        return self.dotted_string == other.dotted_string
+    self.__eq__ = __eq__
+
+    def __ne__(other):
+        return not self.__eq__(other)
+    self.__ne__ = __ne__
+
+    def __repr__():
+        return "<ObjectIdentifier(oid={}, name={})>".format(
+            self.dotted_string, self._name
+        )
+    self.__repr__ = __repr__
+
+    def __hash__():
+        return hash(self.dotted_string)
+    self.__hash__ = __hash__
+
+    self._hashable = None
+
+    def _name():
+        return _OID_NAMES.get(self._hashable, "Unknown OID")
+
+    def dotted_string():
+        return self._dotted_string
+
+    # hashable
+    self._hashable = larky.struct(
+        _name=larky.property(_name),
+        dotted_string=larky.property(dotted_string),
+        **self.__dict__
+    )
+    return self._hashable
+    # self._name = larky.property(_name)
+    # self.dotted_string = larky.property(dotted_string)
+
+
+ExtensionOID = larky.struct(
+    __name__='ExtensionOID',
+    SUBJECT_DIRECTORY_ATTRIBUTES = ObjectIdentifier("2.5.29.9"),
+    SUBJECT_KEY_IDENTIFIER = ObjectIdentifier("2.5.29.14"),
+    KEY_USAGE = ObjectIdentifier("2.5.29.15"),
+    SUBJECT_ALTERNATIVE_NAME = ObjectIdentifier("2.5.29.17"),
+    ISSUER_ALTERNATIVE_NAME = ObjectIdentifier("2.5.29.18"),
+    BASIC_CONSTRAINTS = ObjectIdentifier("2.5.29.19"),
+    NAME_CONSTRAINTS = ObjectIdentifier("2.5.29.30"),
+    CRL_DISTRIBUTION_POINTS = ObjectIdentifier("2.5.29.31"),
+    CERTIFICATE_POLICIES = ObjectIdentifier("2.5.29.32"),
+    POLICY_MAPPINGS = ObjectIdentifier("2.5.29.33"),
+    AUTHORITY_KEY_IDENTIFIER = ObjectIdentifier("2.5.29.35"),
+    POLICY_CONSTRAINTS = ObjectIdentifier("2.5.29.36"),
+    EXTENDED_KEY_USAGE = ObjectIdentifier("2.5.29.37"),
+    FRESHEST_CRL = ObjectIdentifier("2.5.29.46"),
+    INHIBIT_ANY_POLICY = ObjectIdentifier("2.5.29.54"),
+    ISSUING_DISTRIBUTION_POINT = ObjectIdentifier("2.5.29.28"),
+    AUTHORITY_INFORMATION_ACCESS = ObjectIdentifier("1.3.6.1.5.5.7.1.1"),
+    SUBJECT_INFORMATION_ACCESS = ObjectIdentifier("1.3.6.1.5.5.7.1.11"),
+    OCSP_NO_CHECK = ObjectIdentifier("1.3.6.1.5.5.7.48.1.5"),
+    TLS_FEATURE = ObjectIdentifier("1.3.6.1.5.5.7.1.24"),
+    CRL_NUMBER = ObjectIdentifier("2.5.29.20"),
+    DELTA_CRL_INDICATOR = ObjectIdentifier("2.5.29.27"),
+    PRECERT_SIGNED_CERTIFICATE_TIMESTAMPS = ObjectIdentifier(
+        "1.3.6.1.4.1.11129.2.4.2"
+    ),
+    PRECERT_POISON = ObjectIdentifier("1.3.6.1.4.1.11129.2.4.3"),
+    SIGNED_CERTIFICATE_TIMESTAMPS = ObjectIdentifier("1.3.6.1.4.1.11129.2.4.5"),
+)
+
+
+OCSPExtensionOID = larky.struct(
+    __name__='OCSPExtensionOID',
+    NONCE = ObjectIdentifier("1.3.6.1.5.5.7.48.1.2")
+)
+
+
+CRLEntryExtensionOID = larky.struct(
+    __name__='CRLEntryExtensionOID',
+    CERTIFICATE_ISSUER = ObjectIdentifier("2.5.29.29"),
+    CRL_REASON = ObjectIdentifier("2.5.29.21"),
+    INVALIDITY_DATE = ObjectIdentifier("2.5.29.24"),
+)
+
+
+NameOID = larky.struct(
+    __name__='NameOID',
+    COMMON_NAME = ObjectIdentifier("2.5.4.3"),
+    COUNTRY_NAME = ObjectIdentifier("2.5.4.6"),
+    LOCALITY_NAME = ObjectIdentifier("2.5.4.7"),
+    STATE_OR_PROVINCE_NAME = ObjectIdentifier("2.5.4.8"),
+    STREET_ADDRESS = ObjectIdentifier("2.5.4.9"),
+    ORGANIZATION_NAME = ObjectIdentifier("2.5.4.10"),
+    ORGANIZATIONAL_UNIT_NAME = ObjectIdentifier("2.5.4.11"),
+    SERIAL_NUMBER = ObjectIdentifier("2.5.4.5"),
+    SURNAME = ObjectIdentifier("2.5.4.4"),
+    GIVEN_NAME = ObjectIdentifier("2.5.4.42"),
+    TITLE = ObjectIdentifier("2.5.4.12"),
+    GENERATION_QUALIFIER = ObjectIdentifier("2.5.4.44"),
+    X500_UNIQUE_IDENTIFIER = ObjectIdentifier("2.5.4.45"),
+    DN_QUALIFIER = ObjectIdentifier("2.5.4.46"),
+    PSEUDONYM = ObjectIdentifier("2.5.4.65"),
+    USER_ID = ObjectIdentifier("0.9.2342.19200300.100.1.1"),
+    DOMAIN_COMPONENT = ObjectIdentifier("0.9.2342.19200300.100.1.25"),
+    EMAIL_ADDRESS = ObjectIdentifier("1.2.840.113549.1.9.1"),
+    JURISDICTION_COUNTRY_NAME = ObjectIdentifier("1.3.6.1.4.1.311.60.2.1.3"),
+    JURISDICTION_LOCALITY_NAME = ObjectIdentifier("1.3.6.1.4.1.311.60.2.1.1"),
+    JURISDICTION_STATE_OR_PROVINCE_NAME = ObjectIdentifier("1.3.6.1.4.1.311.60.2.1.2"),
+    BUSINESS_CATEGORY = ObjectIdentifier("2.5.4.15"),
+    POSTAL_ADDRESS = ObjectIdentifier("2.5.4.16"),
+    POSTAL_CODE = ObjectIdentifier("2.5.4.17"),
+    INN = ObjectIdentifier("1.2.643.3.131.1.1"),
+    OGRN = ObjectIdentifier("1.2.643.100.1"),
+    SNILS = ObjectIdentifier("1.2.643.100.3"),
+    UNSTRUCTURED_NAME = ObjectIdentifier("1.2.840.113549.1.9.2"),
+)
+
+
+SignatureAlgorithmOID = larky.struct(
+    __name__='SignatureAlgorithmOID',
+    RSA_WITH_MD5 = ObjectIdentifier("1.2.840.113549.1.1.4"),
+    RSA_WITH_SHA1 = ObjectIdentifier("1.2.840.113549.1.1.5"),
+    # This is an alternate OID for RSA with SHA1 that is occasionally seen
+    _RSA_WITH_SHA1 = ObjectIdentifier("1.3.14.3.2.29"),
+    RSA_WITH_SHA224 = ObjectIdentifier("1.2.840.113549.1.1.14"),
+    RSA_WITH_SHA256 = ObjectIdentifier("1.2.840.113549.1.1.11"),
+    RSA_WITH_SHA384 = ObjectIdentifier("1.2.840.113549.1.1.12"),
+    RSA_WITH_SHA512 = ObjectIdentifier("1.2.840.113549.1.1.13"),
+    RSASSA_PSS = ObjectIdentifier("1.2.840.113549.1.1.10"),
+    ECDSA_WITH_SHA1 = ObjectIdentifier("1.2.840.10045.4.1"),
+    ECDSA_WITH_SHA224 = ObjectIdentifier("1.2.840.10045.4.3.1"),
+    ECDSA_WITH_SHA256 = ObjectIdentifier("1.2.840.10045.4.3.2"),
+    ECDSA_WITH_SHA384 = ObjectIdentifier("1.2.840.10045.4.3.3"),
+    ECDSA_WITH_SHA512 = ObjectIdentifier("1.2.840.10045.4.3.4"),
+    DSA_WITH_SHA1 = ObjectIdentifier("1.2.840.10040.4.3"),
+    DSA_WITH_SHA224 = ObjectIdentifier("2.16.840.1.101.3.4.3.1"),
+    DSA_WITH_SHA256 = ObjectIdentifier("2.16.840.1.101.3.4.3.2"),
+    ED25519 = ObjectIdentifier("1.3.101.112"),
+    ED448 = ObjectIdentifier("1.3.101.113"),
+    GOSTR3411_94_WITH_3410_2001 = ObjectIdentifier("1.2.643.2.2.3"),
+    GOSTR3410_2012_WITH_3411_2012_256 = ObjectIdentifier("1.2.643.7.1.1.3.2"),
+    GOSTR3410_2012_WITH_3411_2012_512 = ObjectIdentifier("1.2.643.7.1.1.3.3"),
+)
+
+
+_SIG_OIDS_TO_HASH = {
+    SignatureAlgorithmOID.RSA_WITH_MD5: hashes.MD5(),
+    SignatureAlgorithmOID.RSA_WITH_SHA1: hashes.SHA1(),
+    SignatureAlgorithmOID._RSA_WITH_SHA1: hashes.SHA1(),
+    SignatureAlgorithmOID.RSA_WITH_SHA224: hashes.SHA224(),
+    SignatureAlgorithmOID.RSA_WITH_SHA256: hashes.SHA256(),
+    SignatureAlgorithmOID.RSA_WITH_SHA384: hashes.SHA384(),
+    SignatureAlgorithmOID.RSA_WITH_SHA512: hashes.SHA512(),
+    SignatureAlgorithmOID.ECDSA_WITH_SHA1: hashes.SHA1(),
+    SignatureAlgorithmOID.ECDSA_WITH_SHA224: hashes.SHA224(),
+    SignatureAlgorithmOID.ECDSA_WITH_SHA256: hashes.SHA256(),
+    SignatureAlgorithmOID.ECDSA_WITH_SHA384: hashes.SHA384(),
+    SignatureAlgorithmOID.ECDSA_WITH_SHA512: hashes.SHA512(),
+    SignatureAlgorithmOID.DSA_WITH_SHA1: hashes.SHA1(),
+    SignatureAlgorithmOID.DSA_WITH_SHA224: hashes.SHA224(),
+    SignatureAlgorithmOID.DSA_WITH_SHA256: hashes.SHA256(),
+    SignatureAlgorithmOID.ED25519: None,
+    SignatureAlgorithmOID.ED448: None,
+    SignatureAlgorithmOID.GOSTR3411_94_WITH_3410_2001: None,
+    SignatureAlgorithmOID.GOSTR3410_2012_WITH_3411_2012_256: None,
+    SignatureAlgorithmOID.GOSTR3410_2012_WITH_3411_2012_512: None,
+}
+
+
+ExtendedKeyUsageOID = larky.struct(
+    __name__='ExtendedKeyUsageOID',
+    SERVER_AUTH = ObjectIdentifier("1.3.6.1.5.5.7.3.1"),
+    CLIENT_AUTH = ObjectIdentifier("1.3.6.1.5.5.7.3.2"),
+    CODE_SIGNING = ObjectIdentifier("1.3.6.1.5.5.7.3.3"),
+    EMAIL_PROTECTION = ObjectIdentifier("1.3.6.1.5.5.7.3.4"),
+    TIME_STAMPING = ObjectIdentifier("1.3.6.1.5.5.7.3.8"),
+    OCSP_SIGNING = ObjectIdentifier("1.3.6.1.5.5.7.3.9"),
+    ANY_EXTENDED_KEY_USAGE = ObjectIdentifier("2.5.29.37.0"),
+    SMARTCARD_LOGON = ObjectIdentifier("1.3.6.1.4.1.311.20.2.2"),
+    KERBEROS_PKINIT_KDC = ObjectIdentifier("1.3.6.1.5.2.3.5"),
+)
+
+AuthorityInformationAccessOID = larky.struct(
+    __name__='AuthorityInformationAccessOID',
+    CA_ISSUERS = ObjectIdentifier("1.3.6.1.5.5.7.48.2"),
+    OCSP = ObjectIdentifier("1.3.6.1.5.5.7.48.1"),
+)
+
+SubjectInformationAccessOID = larky.struct(
+    __name__='SubjectInformationAccessOID',
+    CA_REPOSITORY = ObjectIdentifier("1.3.6.1.5.5.7.48.5")
+)
+
+
+CertificatePoliciesOID = larky.struct(
+    __name__='CertificatePoliciesOID',
+    CPS_QUALIFIER = ObjectIdentifier("1.3.6.1.5.5.7.2.1"),
+    CPS_USER_NOTICE = ObjectIdentifier("1.3.6.1.5.5.7.2.2"),
+    ANY_POLICY = ObjectIdentifier("2.5.29.32.0"),
+)
+
+
+AttributeOID = larky.struct(
+    __name__='AttributeOID',
+    CHALLENGE_PASSWORD = ObjectIdentifier("1.2.840.113549.1.9.7"),
+    UNSTRUCTURED_NAME = ObjectIdentifier("1.2.840.113549.1.9.2"),
+)
+
+
+_OID_NAMES.update({
+    NameOID.COMMON_NAME: "commonName",
+    NameOID.COUNTRY_NAME: "countryName",
+    NameOID.LOCALITY_NAME: "localityName",
+    NameOID.STATE_OR_PROVINCE_NAME: "stateOrProvinceName",
+    NameOID.STREET_ADDRESS: "streetAddress",
+    NameOID.ORGANIZATION_NAME: "organizationName",
+    NameOID.ORGANIZATIONAL_UNIT_NAME: "organizationalUnitName",
+    NameOID.SERIAL_NUMBER: "serialNumber",
+    NameOID.SURNAME: "surname",
+    NameOID.GIVEN_NAME: "givenName",
+    NameOID.TITLE: "title",
+    NameOID.GENERATION_QUALIFIER: "generationQualifier",
+    NameOID.X500_UNIQUE_IDENTIFIER: "x500UniqueIdentifier",
+    NameOID.DN_QUALIFIER: "dnQualifier",
+    NameOID.PSEUDONYM: "pseudonym",
+    NameOID.USER_ID: "userID",
+    NameOID.DOMAIN_COMPONENT: "domainComponent",
+    NameOID.EMAIL_ADDRESS: "emailAddress",
+    NameOID.JURISDICTION_COUNTRY_NAME: "jurisdictionCountryName",
+    NameOID.JURISDICTION_LOCALITY_NAME: "jurisdictionLocalityName",
+    NameOID.JURISDICTION_STATE_OR_PROVINCE_NAME: (
+        "jurisdictionStateOrProvinceName"
+    ),
+    NameOID.BUSINESS_CATEGORY: "businessCategory",
+    NameOID.POSTAL_ADDRESS: "postalAddress",
+    NameOID.POSTAL_CODE: "postalCode",
+    NameOID.INN: "INN",
+    NameOID.OGRN: "OGRN",
+    NameOID.SNILS: "SNILS",
+    NameOID.UNSTRUCTURED_NAME: "unstructuredName",
+    SignatureAlgorithmOID.RSA_WITH_MD5: "md5WithRSAEncryption",
+    SignatureAlgorithmOID.RSA_WITH_SHA1: "sha1WithRSAEncryption",
+    SignatureAlgorithmOID.RSA_WITH_SHA224: "sha224WithRSAEncryption",
+    SignatureAlgorithmOID.RSA_WITH_SHA256: "sha256WithRSAEncryption",
+    SignatureAlgorithmOID.RSA_WITH_SHA384: "sha384WithRSAEncryption",
+    SignatureAlgorithmOID.RSA_WITH_SHA512: "sha512WithRSAEncryption",
+    SignatureAlgorithmOID.RSASSA_PSS: "RSASSA-PSS",
+    SignatureAlgorithmOID.ECDSA_WITH_SHA1: "ecdsa-with-SHA1",
+    SignatureAlgorithmOID.ECDSA_WITH_SHA224: "ecdsa-with-SHA224",
+    SignatureAlgorithmOID.ECDSA_WITH_SHA256: "ecdsa-with-SHA256",
+    SignatureAlgorithmOID.ECDSA_WITH_SHA384: "ecdsa-with-SHA384",
+    SignatureAlgorithmOID.ECDSA_WITH_SHA512: "ecdsa-with-SHA512",
+    SignatureAlgorithmOID.DSA_WITH_SHA1: "dsa-with-sha1",
+    SignatureAlgorithmOID.DSA_WITH_SHA224: "dsa-with-sha224",
+    SignatureAlgorithmOID.DSA_WITH_SHA256: "dsa-with-sha256",
+    SignatureAlgorithmOID.ED25519: "ed25519",
+    SignatureAlgorithmOID.ED448: "ed448",
+    SignatureAlgorithmOID.GOSTR3411_94_WITH_3410_2001: (
+        "GOST R 34.11-94 with GOST R 34.10-2001"
+    ),
+    SignatureAlgorithmOID.GOSTR3410_2012_WITH_3411_2012_256: (
+        "GOST R 34.10-2012 with GOST R 34.11-2012 (256 bit)"
+    ),
+    SignatureAlgorithmOID.GOSTR3410_2012_WITH_3411_2012_512: (
+        "GOST R 34.10-2012 with GOST R 34.11-2012 (512 bit)"
+    ),
+    ExtendedKeyUsageOID.SERVER_AUTH: "serverAuth",
+    ExtendedKeyUsageOID.CLIENT_AUTH: "clientAuth",
+    ExtendedKeyUsageOID.CODE_SIGNING: "codeSigning",
+    ExtendedKeyUsageOID.EMAIL_PROTECTION: "emailProtection",
+    ExtendedKeyUsageOID.TIME_STAMPING: "timeStamping",
+    ExtendedKeyUsageOID.OCSP_SIGNING: "OCSPSigning",
+    ExtendedKeyUsageOID.SMARTCARD_LOGON: "msSmartcardLogin",
+    ExtendedKeyUsageOID.KERBEROS_PKINIT_KDC: "pkInitKDC",
+    ExtensionOID.SUBJECT_DIRECTORY_ATTRIBUTES: "subjectDirectoryAttributes",
+    ExtensionOID.SUBJECT_KEY_IDENTIFIER: "subjectKeyIdentifier",
+    ExtensionOID.KEY_USAGE: "keyUsage",
+    ExtensionOID.SUBJECT_ALTERNATIVE_NAME: "subjectAltName",
+    ExtensionOID.ISSUER_ALTERNATIVE_NAME: "issuerAltName",
+    ExtensionOID.BASIC_CONSTRAINTS: "basicConstraints",
+    ExtensionOID.PRECERT_SIGNED_CERTIFICATE_TIMESTAMPS: (
+        "signedCertificateTimestampList"
+    ),
+    ExtensionOID.SIGNED_CERTIFICATE_TIMESTAMPS: (
+        "signedCertificateTimestampList"
+    ),
+    ExtensionOID.PRECERT_POISON: "ctPoison",
+    CRLEntryExtensionOID.CRL_REASON: "cRLReason",
+    CRLEntryExtensionOID.INVALIDITY_DATE: "invalidityDate",
+    CRLEntryExtensionOID.CERTIFICATE_ISSUER: "certificateIssuer",
+    ExtensionOID.NAME_CONSTRAINTS: "nameConstraints",
+    ExtensionOID.CRL_DISTRIBUTION_POINTS: "cRLDistributionPoints",
+    ExtensionOID.CERTIFICATE_POLICIES: "certificatePolicies",
+    ExtensionOID.POLICY_MAPPINGS: "policyMappings",
+    ExtensionOID.AUTHORITY_KEY_IDENTIFIER: "authorityKeyIdentifier",
+    ExtensionOID.POLICY_CONSTRAINTS: "policyConstraints",
+    ExtensionOID.EXTENDED_KEY_USAGE: "extendedKeyUsage",
+    ExtensionOID.FRESHEST_CRL: "freshestCRL",
+    ExtensionOID.INHIBIT_ANY_POLICY: "inhibitAnyPolicy",
+    ExtensionOID.ISSUING_DISTRIBUTION_POINT: ("issuingDistributionPoint"),
+    ExtensionOID.AUTHORITY_INFORMATION_ACCESS: "authorityInfoAccess",
+    ExtensionOID.SUBJECT_INFORMATION_ACCESS: "subjectInfoAccess",
+    ExtensionOID.OCSP_NO_CHECK: "OCSPNoCheck",
+    ExtensionOID.CRL_NUMBER: "cRLNumber",
+    ExtensionOID.DELTA_CRL_INDICATOR: "deltaCRLIndicator",
+    ExtensionOID.TLS_FEATURE: "TLSFeature",
+    AuthorityInformationAccessOID.OCSP: "OCSP",
+    AuthorityInformationAccessOID.CA_ISSUERS: "caIssuers",
+    SubjectInformationAccessOID.CA_REPOSITORY: "caRepository",
+    CertificatePoliciesOID.CPS_QUALIFIER: "id-qt-cps",
+    CertificatePoliciesOID.CPS_USER_NOTICE: "id-qt-unotice",
+    OCSPExtensionOID.NONCE: "OCSPNonce",
+    AttributeOID.CHALLENGE_PASSWORD: "challengePassword",
+})
+
+
+oid = larky.struct(
+    __name__='_oid',
+    ObjectIdentifier=ObjectIdentifier,
+    ExtensionOID=ExtensionOID,
+    OCSPExtensionOID=OCSPExtensionOID,
+    CRLEntryExtensionOID=CRLEntryExtensionOID,
+    NameOID=NameOID,
+    SignatureAlgorithmOID=SignatureAlgorithmOID,
+    ExtendedKeyUsageOID=ExtendedKeyUsageOID,
+    AuthorityInformationAccessOID=AuthorityInformationAccessOID,
+    SubjectInformationAccessOID=SubjectInformationAccessOID,
+    CertificatePoliciesOID=CertificatePoliciesOID,
+    AttributeOID=AttributeOID,
+    _OID_NAMES=_OID_NAMES,
+    _SIG_OIDS_TO_HASH=_SIG_OIDS_TO_HASH,
+)

--- a/larky/src/main/resources/vendor/cryptography/hazmat/backends/__init__.star
+++ b/larky/src/main/resources/vendor/cryptography/hazmat/backends/__init__.star
@@ -1,0 +1,25 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+load("@stdlib//larky", larky="larky")
+load("@vendor//cryptography/hazmat/backends/pycryptodome", backend="backend")
+
+
+def default_backend():
+    # type: () -> Backend
+    return backend()
+
+
+def _get_backend(backend):
+    # type: (typing.Optional[Backend]) -> Backend
+    if backend == None:
+        return default_backend()
+    else:
+        return backend
+
+
+backends = larky.struct(
+    __name__='backends',
+    _get_backend=_get_backend,
+    default_backend=default_backend,
+)

--- a/larky/src/main/resources/vendor/cryptography/hazmat/backends/interfaces.star
+++ b/larky/src/main/resources/vendor/cryptography/hazmat/backends/interfaces.star
@@ -1,0 +1,27 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+load("@stdlib//larky", larky="larky")
+
+# TODO(mahmoudimus): Implement me
+# https://github.com/pyca/cryptography/blob/main/src/cryptography/hazmat/backends/interfaces.py
+#
+# But honestly, is this even required any more?
+# See:
+# - https://github.com/pyca/cryptography/issues/6499
+# - https://github.com/pyca/cryptography/pull/6518/files#diff-55df9d2f8b8d40391d9d451a1e8155292465d48c52e78dd34655be834cd3dc9fR191-R203
+#
+# What happened to the backend argument?
+# --------------------------------------
+# ``cryptography`` stopped requiring the use of ``backend`` arguments in
+# version 3.1 and deprecated their use in version 36.0. If you are on an older
+# version that requires these arguments please view the appropriate documentation
+# version or upgrade to the latest release.
+#
+# Note that for forward compatibility ``backend`` is still silently accepted by
+# functions that previously required it, but it is ignored and no longer
+# documented.
+
+interfaces = larky.struct(
+    __name__='interfaces'
+)

--- a/larky/src/main/resources/vendor/cryptography/hazmat/backends/pycryptodome.star
+++ b/larky/src/main/resources/vendor/cryptography/hazmat/backends/pycryptodome.star
@@ -1,0 +1,728 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+load("@stdlib//enum", enum="enum")
+load("@stdlib//larky", larky="larky")
+load("@stdlib//types", types="types")
+load("@stdlib//builtins", builtins="builtins")
+load("@stdlib//jopenssl", _JOpenSSL="jopenssl")
+load("@stdlib//jcrypto", _JCrypto="jcrypto")
+load("@vendor//Crypto/Hash", Hash="Hash")
+load("@vendor//Crypto/PublicKey/RSA", RSA="RSA")
+load("@vendor//Crypto/Signature/pkcs1_15", pkcs1_15="pkcs1_15")
+load("@vendor//Crypto/Signature/pss", pss="pss")
+load("@vendor//Crypto/Util/py3compat", tobytes="tobytes")
+load("@vendor//cryptography/hazmat/_oid", oid="oid")
+load("@vendor//cryptography/hazmat/primitives/_serialization", serialization="serialization")
+load("@vendor//cryptography/hazmat/primitives/_hashes", hashes="hashes")
+# load("@vendor//cryptography/hazmat/primitives/asymmetric/utils", asym_utils="utils")
+load("@vendor//cryptography/x509/_base", X509Version="Version")
+load("@vendor//cryptography/utils", utils="utils")
+
+# From: https://github.com/openssl/openssl/blob/master/include/openssl/obj_mac.h
+_OpenSSL_Constants = enum.Enum('OpenSSL_Constant', [
+    ("EVP_PKEY_DH", 28),
+    ("EVP_PKEY_DSA", 116),
+    ("EVP_PKEY_EC", 408),
+    ("EVP_PKEY_RSA", 6),
+    # EVP_PKEY_DHX => NID_dhpublicnumber
+    # https://github.com/openssl/openssl/blob/c6fcd88fa030da8322cf27aff95376512f41faff/include/openssl/evp.h#L68
+    # NID_dhpublicnumber =>
+    # https://github.com/openssl/openssl/blob/a596d38a8cddca4af3416b2664e120028d96e6a9/include/openssl/obj_mac.h#L5011
+    ("EVP_PKEY_DHX", 920),
+    ("RAND_SEED_LENGTH_IN_BYTES", 1024),
+    ("SSL_MODE_HANDSHAKE_CUTTHROUGH", 64),
+    ("SSL_OP_NO_COMPRESSION", 131072),
+    ("SSL_OP_NO_SESSION_RESUMPTION_ON_RENEGOTIATION", 65536),
+    ("SSL_OP_NO_SSLv3", 33554432),
+    ("SSL_OP_NO_TICKET", 16384),
+    ("SSL_OP_NO_TLSv1", 67108864),
+    ("SSL_OP_NO_TLSv1_1", 268435456),
+    ("SSL_OP_NO_TLSv1_2", 134217728),
+    ("SSL_VERIFY_FAIL_IF_NO_PEER_CERT", 2),
+    ("SSL_VERIFY_NONE", 0),
+    ("SSL_VERIFY_PEER", 1),
+])
+
+
+def _register_default_ciphers(self):
+    pass
+
+
+def _register_x509_ext_parsers(self):
+    pass
+
+
+def _register_x509_encoders(self):
+    pass
+
+
+def _rsa_sig_verify(backend, padding, algorithm, public_key, signature, data):
+    # public_key.verify(
+            #     b64decode(signature_value), data, padding.PKCS1v15(), digest()
+            # )
+    pkey_ctx = _rsa_sig_setup(
+        backend,
+        padding,
+        algorithm,
+        public_key,
+        None,
+    )
+
+    hashctx = backend.create_hash_ctx(algorithm)
+    hashctx.update(data)
+    pkey_ctx.new(public_key._evp_pkey).verify(hashctx._ctx, signature)
+
+
+def _rsa_sig_determine_padding(backend, key, padding, algorithm):
+    if type(padding) == 'PKCS1v15':
+        # Hash algorithm is ignored for PKCS1v15-padding, may be None.
+        return pkcs1_15
+    elif type(padding) == 'PSS':
+        if not type(padding._mgf) == 'MGF1':
+            fail("Only MGF1 is supported by this backend.")
+        # PSS padding requires a hash algorithm
+        if not builtins.isinstance(algorithm, hashes.HashAlgorithm):
+            fail("Expected instance of hashes.HashAlgorithm.")
+
+        pkey_size = key.bits
+        # Size of key in bytes - 2 is the maximum
+        # PSS signature length (salt length is checked later)
+        if pkey_size - algorithm.digest_size - 2 < 0:
+            fail(
+                "Digest too large for key size. Use a larger " +
+                "key or different digest."
+            )
+
+        return pss
+    fail("{} is not supported by this backend.".format(padding.name))
+
+
+# Hash algorithm can be absent (None) to initialize the context without setting
+# any message digest algorithm. This is currently only valid for the PKCS1v15
+# padding type, where it means that the signature data is encoded/decoded
+# as provided, without being wrapped in a DigestInfo structure.
+def _rsa_sig_setup(backend, padding, algorithm, key, init_func):
+    padding_cls = _rsa_sig_determine_padding(backend, key, padding, algorithm)
+    if type(padding) != 'PKCS1v15':
+        fail("Unsupported")
+        # TODO(mahmoudimus): support pss
+        # mask_func = kwargs.pop("mask_func", None)
+        # salt_len = kwargs.pop("salt_bytes", None)
+        # rand_func = kwargs.pop("rand_func", None)
+    return padding_cls
+
+
+def _rsa_sig_sign(backend, padding, algorithm, private_key, data):
+    pkey_ctx = _rsa_sig_setup(
+        backend,
+        padding,
+        algorithm,
+        private_key,
+        None
+    )
+    hashctx = backend.create_hash_ctx(algorithm)
+    hashctx.update(data)
+    return (pkey_ctx
+            .new(private_key._evp_pkey)
+            .sign(hashctx._ctx))
+
+
+def _calculate_digest_and_algorithm(backend, data, algorithm):
+    if not type(algorithm) == 'Prehashed':
+        hash_ctx = hashes.Hash(algorithm, backend)
+        hash_ctx.update(data)
+        data = hash_ctx.finalize()
+    else:
+        algorithm = algorithm._algorithm
+
+    if len(data) != algorithm.digest_size:
+        fail(
+            "The provided data must be the same length as the hash " +
+            "algorithm's digest size."
+        )
+
+    return (data, algorithm)
+
+
+def RSAPrivateKey(backend, rsa_cdata, evp_pkey):
+    self = larky.mutablestruct(__name__='RSAPrivateKey',
+                               __class__=RSAPrivateKey)
+
+    def __init__(backend, rsa_cdata, evp_pkey):
+        self._backend = backend
+        self._rsa_cdata = rsa_cdata
+        self._evp_pkey = evp_pkey
+        return self
+    self = __init__(backend, rsa_cdata, evp_pkey)
+
+    def decrypt(ciphertext, padding):
+        """
+        Decrypts the provided ciphertext.
+        """
+    self.decrypt = decrypt
+
+    def key_size():
+        """
+        The bit length of the public modulus.
+        """
+        return self._rsa_cdata.bits
+    self.key_size = key_size
+
+    def public_key():
+        """
+        The RSAPublicKey associated with this private key.
+        """
+        return RSAPublicKey(self._backend, self._evp_pkey.public_key())
+    self.public_key = public_key
+
+    def sign(
+        data,  # type: bytes
+        padding, # type: AsymmetricPadding
+        algorithm,  # type: Union[Prehashed, hashes.HashAlgorithm]
+    ):
+        """
+        Signs the data.
+        """
+        return _rsa_sig_sign(self._backend, padding, algorithm, self, data)
+    self.sign = sign
+
+    def private_numbers():
+        """
+        Returns an RSAPrivateNumbers.
+        """
+    self.private_numbers = private_numbers
+
+    def private_bytes(
+        encoding,
+        format,
+        encryption_algorithm,
+    ):
+        """
+        Returns the key serialized as bytes.
+        """
+    self.private_bytes = private_bytes
+    return self
+
+
+def RSAPublicKey(backend, evp_pkey):
+    self = larky.mutablestruct(__name__='RSAPublicKey', __class__=RSAPublicKey)
+
+    def __init__(backend, evp_pkey):
+        self._backend = backend
+        self._evp_pkey = evp_pkey
+        return self
+    self = __init__(backend, evp_pkey)
+    def encrypt(plaintext, padding):
+        """
+        Encrypts the given plaintext.
+        """
+    self.encrypt = encrypt
+
+    def key_size():
+        """
+        The bit length of the public modulus.
+        """
+    self.key_size = key_size
+
+    def public_numbers():
+        """
+        Returns an RSAPublicNumbers
+        """
+    self.public_numbers = public_numbers
+
+    def public_bytes(
+        encoding,
+        format,
+    ):
+        """
+        Returns the key serialized as bytes.
+        """
+    self.public_bytes = public_bytes
+
+    def verify(
+        signature,
+        data,
+        padding,
+        algorithm,
+    ):
+        """
+        Verifies the signature of the data.
+        """
+        data, algorithm = _calculate_digest_and_algorithm(
+            self._backend, data, algorithm
+        )
+        return _rsa_sig_verify(
+            self._backend, padding, algorithm, self, signature, data
+        )
+    self.verify = verify
+
+    def recover_data_from_signature(
+        signature,
+        padding,
+        algorithm,
+    ):
+        """
+        Recovers the original data from the signature.
+        """
+    self.recover_data_from_signature = recover_data_from_signature
+    return self
+
+
+def RSAPrivateNumbers(p,
+    q,
+    d,
+    dmp1,
+    dmq1,
+    iqmp,
+    public_numbers,
+):
+    self = larky.mutablestruct(__name__='RSAPrivateNumbers', __class__=RSAPrivateNumbers)
+    def __init__(
+        p,
+        q,
+        d,
+        dmp1,
+        dmq1,
+        iqmp,
+        public_numbers,
+    ):
+        if (
+            not types.is_int(p)
+            or not types.is_int(q)
+            or not types.is_int(d)
+            or not types.is_int(dmp1)
+            or not types.is_int(dmq1)
+            or not types.is_int(iqmp)
+        ):
+            fail("TypeError: " + ("RSAPrivateNumbers p, q, d, dmp1, dmq1, iqmp arguments must" +
+                " all be an integers.")
+            )
+
+        if not hasattr(public_numbers, 'public_key'):
+            fail("TypeError: RSAPrivateNumbers public_numbers must be " +
+                 "an RSAPublicNumbers instance.")
+
+        self._p = p
+        self._q = q
+        self._d = d
+        self._dmp1 = dmp1
+        self._dmq1 = dmq1
+        self._iqmp = iqmp
+        self._public_numbers = public_numbers
+        return self
+    self = __init__(p, q, d, dmp1, dmq1, iqmp, public_numbers)
+
+    self.p = larky.property(lambda: self._p)
+    self.q = larky.property(lambda: self._q)
+    self.d = larky.property(lambda: self._d)
+    self.dmp1 = larky.property(lambda: self._dmp1)
+    self.dmq1 = larky.property(lambda: self._dmq1)
+    self.iqmp = larky.property(lambda: self._iqmp)
+    self.public_numbers = larky.property(lambda: self._public_numbers)
+
+    def private_key(backend = None):
+        # backend = _get_backend(backend)
+        return backend.load_rsa_private_numbers(self)
+    self.private_key = private_key
+
+    def __eq__(other):
+        if not builtins.isinstance(other, RSAPrivateNumbers):
+            return builtins.NotImplemented
+
+        return (
+            self.p == other.p
+            and self.q == other.q
+            and self.d == other.d
+            and self.dmp1 == other.dmp1
+            and self.dmq1 == other.dmq1
+            and self.iqmp == other.iqmp
+            and self.public_numbers == other.public_numbers
+        )
+    self.__eq__ = __eq__
+
+    def __ne__(other):
+        return not self.__eq__(other)
+    self.__ne__ = __ne__
+
+    def __hash__():
+        return hash(
+            (
+                self.p,
+                self.q,
+                self.d,
+                self.dmp1,
+                self.dmq1,
+                self.iqmp,
+                self.public_numbers,
+            )
+        )
+    self.__hash__ = __hash__
+    return self
+
+
+
+def RSAPublicNumbers(e, n):
+
+    self = larky.mutablestruct(
+        __name__='RSAPublicNumbers',
+        __class__=RSAPublicNumbers
+    )
+
+    def __init__(e, n):
+        if not types.is_int(e) or not types.is_int(n):
+            fail("TypeError: RSAPublicNumbers arguments must be integers.")
+        self._e = e
+        self._n = n
+        return self
+    self = __init__(e, n)
+
+    self.e = larky.property(lambda: self._e)
+    self.n = larky.property(lambda: self._n)
+
+    def public_key(backend = None):
+        # backend = _get_backend(backend)
+        return pycryptodome().load_rsa_public_numbers(self)
+    self.public_key = public_key
+
+    def __repr__():
+        return "<RSAPublicNumbers(e={}, n={})>".format(self._e, self._n)
+    self.__repr__ = __repr__
+
+    def __eq__(other):
+        if not builtins.isinstance(other, RSAPublicNumbers):
+            return builtins.NotImplemented
+
+        return self.e == other.e and self.n == other.n
+    self.__eq__ = __eq__
+
+    def __ne__(other):
+        return not self == other
+    self.__ne__ = __ne__
+
+    def __hash__():
+        return hash((self.e, self.n,))
+    self.__hash__ = __hash__
+    return self
+
+
+def _HashContext(algorithm, backend, ctx=None):
+    # type: (HashAlgorithm, Backend, _HashContext) -> _HashContext
+    self = hashes.HashContext(algorithm)
+
+    def __init__(algorithm, backend, ctx=None):
+        self._algorithm = algorithm
+        self._backend = backend
+        if not ctx:
+            hash_algo, _, bits = algorithm.name.upper().partition('-')
+            ctx = getattr(Hash, hash_algo, None)
+            if not ctx:
+                fail("{} is not a supported hash on this backend.".format(
+                                        algorithm.name
+                                    ))
+            self._ctx = ctx.new()
+        else:
+            self._ctx = ctx
+        return self
+    self = __init__(algorithm, backend, ctx)
+
+    def update(data):
+        # type: (bytes) -> None
+        self._ctx.update(data)
+    self.update = update
+
+    def finalize():
+        # type: () -> bytes
+        dig = self._ctx.digest()
+        self._ctx = None
+        return dig
+    self.finalize = finalize
+
+    def copy():
+        # type: () -> _HashContext
+        return _HashContext(self._algorithm, self._backend, self._ctx.copy())
+    self.copy = copy
+    return self
+
+
+def _asn1_string_to_bytes(*args):
+    print(*args)
+    return args[1]
+
+
+def _decode_x509_name(*args):
+    print(*args)
+    return args[0]
+
+
+def _Certificate(backend, x509_cert):
+    self = larky.mutablestruct(__name__='Certificate', __class__=_Certificate)
+
+    def __init__(backend, x509_cert):
+        self._backend = backend
+        self._x509 = x509_cert
+        # Keep-alive reference used by OCSP
+        self._ocsp_resp_ref = None
+
+        # version = self._backend.X509_get_version(self._x509)
+        version = self._x509.version()
+        if version == 1:
+            self._version = X509Version.v1
+        elif version == 3:
+            self._version = X509Version.v3
+        else:
+            fail("{} is not a valid X509 version".format(version))
+        return self
+    self = __init__(backend, x509_cert)
+
+    def __repr__():
+        return "<Certificate(subject={}, ...)>".format(self.subject)
+    self.__repr__ = __repr__
+
+    def __eq__(other):
+        if not builtins.isinstance(other, self.__class__):
+            return builtins.NotImplemented
+        return self._x509 == other._x509
+
+    self.__eq__ = __eq__
+
+    def __ne__(other):
+        return not self.__eq__(other)
+    self.__ne__ = __ne__
+#
+    def __hash__():
+        return hash(self.public_bytes(serialization.Encoding.DER))
+    self.__hash__ = __hash__
+
+    def fingerprint(algorithm):
+        return self._x509.fingerprint(algorithm.name)
+        # ctx = self._backend.create_hash_ctx(algorithm)
+        # ctx.update(self.public_bytes(serialization.Encoding.DER))
+        # return ctx.finalize()
+    self.fingerprint = fingerprint
+
+    self.version = larky.property(lambda: self._version)
+
+    # def serial_number():
+    #     return self._x509.serial_number
+    # self.serial_number = serial_number
+    self.serial_number = larky.property(self._x509.serial_number)
+
+    def public_key():
+        # fail("ValueError: Certificate public key is of an unknown type")
+        print(self._x509.public_key())
+        return RSAPublicKey(self, self._x509.public_key())
+        # return self._backend._evp_pkey_to_public_key(self._x509.public_key())
+    self.public_key = public_key
+#
+#     def not_valid_before():
+#         asn1_time = self._backend._lib.X509_get0_notBefore(self._x509)
+#         return _parse_asn1_time(self._backend, asn1_time)
+    self.not_valid_before = larky.property(self._x509.not_valid_before)
+#     not_valid_before = property(not_valid_before)
+#
+#     def not_valid_after():
+#         asn1_time = self._backend._lib.X509_get0_notAfter(self._x509)
+#         return _parse_asn1_time(self._backend, asn1_time)
+#     self.not_valid_after = not_valid_after
+    self.not_valid_after = larky.property(self._x509.not_valid_after)
+    self.issuer = larky.property(lambda: _decode_x509_name(self._x509.issuer()))
+    self.subject = larky.property(lambda: _decode_x509_name(self._x509.subject()))
+
+    def signature_hash_algorithm():
+        oid = self.signature_algorithm_oid
+        roid = oid._SIG_OIDS_TO_HASH.get(oid, None)
+        print(self._x509.signature_hash_algorithm())
+        if roid == None:
+            fail("Signature algorithm OID:{} not recognized".format(oid))
+        return oid
+    self.signature_hash_algorithm = larky.property(signature_hash_algorithm)
+
+    def signature_algorithm_oid():
+        # alg = self._backend._ffi.new("X509_ALGOR **")
+        # self._backend._lib.X509_get0_signature(
+        #     self._backend._ffi.NULL, alg, self._x509
+        # )
+        # self._backend.openssl_assert(alg[0] != self._backend._ffi.NULL)
+        # oid = _obj2txt(self._backend, alg[0].algorithm)
+        return oid.ObjectIdentifier(self._x509.signature_algorithm_oid())
+    self.signature_algorithm_oid = larky.property(signature_algorithm_oid)
+
+    def extensions():
+        return self._x509.extensions()
+    self.extensions = extensions
+
+    def signature():
+        # type: () -> bytes
+        """
+        Returns the signature bytes.
+        """
+        return self._x509.signature()
+    self.signature = larky.property(signature)
+
+    def tbs_certificate_bytes():
+        # type: () -> bytes
+        """
+        Returns the tbsCertificate payload bytes as defined in RFC 5280.
+        """
+        return self._x509.tbs_certificate_bytes()
+    self.tbs_certificate_bytes = larky.property(tbs_certificate_bytes)
+
+    def public_bytes(encoding):
+        return self._x509.public_bytes(encoding)
+    self.public_bytes = public_bytes
+    return self
+
+
+def pycryptodome():
+    """
+    PyCryptodome API interface implementation of `Cryptography`'s
+    `backend/interfaces:Backend`
+    """
+    self = larky.mutablestruct(__name__='pycryptodome', __class__=pycryptodome)
+    self.name = "pycryptodome"
+
+    def __init__():
+        self._cipher_registry = {}
+        _register_default_ciphers(self)
+        _register_x509_ext_parsers(self)
+        _register_x509_encoders(self)
+        # from https://github.com/openssl/openssl/blob/9dddcd90a1350fa63486cbf3226c3eee79f9aff5/crypto/evp/p_lib.c#L907-L925
+        # The EVP_PKEY_DH type is used for dh parameter generation types:
+        #  - named safe prime groups related to ffdhe and modp
+        #  - safe prime generator
+        #
+        # The type EVP_PKEY_DHX is used for dh parameter generation types
+        #  - fips186-4 and fips186-2
+        #  - rfc5114 named groups.
+        #
+        # The EVP_PKEY_DH type is used to save PKCS#3 data than can be stored
+        # without a q value.
+        # The EVP_PKEY_DHX type is used to save X9.42 data that requires the
+        # q value to be stored.
+        self._dh_types = [_OpenSSL_Constants.EVP_PKEY_DH]
+        self._dh_types.append(_OpenSSL_Constants.EVP_PKEY_DHX)
+        return self
+    self = __init__()
+
+    def create_hash_ctx(algorithm):
+        return _HashContext(algorithm, self)
+    self.create_hash_ctx = create_hash_ctx
+
+    def _evp_pkey_to_private_key(evp_pkey):
+        """
+        Return the appropriate type of PrivateKey given an evp_pkey cdata
+        pointer.
+        """
+        key_type = evp_pkey.key_type
+        if key_type == 'RSA':
+            return RSAPrivateKey(self, evp_pkey, RSA.import_key(evp_pkey.private_key()))
+
+        # elif key_type == self._lib.EVP_PKEY_DSA:
+        #     dsa_cdata = self._lib.EVP_PKEY_get1_DSA(evp_pkey)
+        #     self.openssl_assert(dsa_cdata != self._ffi.NULL)
+        #     dsa_cdata = self._ffi.gc(dsa_cdata, self._lib.DSA_free)
+        #     return _DSAPrivateKey(self, dsa_cdata, evp_pkey)
+        # elif key_type == self._lib.EVP_PKEY_EC:
+        #     ec_cdata = self._lib.EVP_PKEY_get1_EC_KEY(evp_pkey)
+        #     self.openssl_assert(ec_cdata != self._ffi.NULL)
+        #     ec_cdata = self._ffi.gc(ec_cdata, self._lib.EC_KEY_free)
+        #     return _EllipticCurvePrivateKey(self, ec_cdata, evp_pkey)
+        # elif key_type in self._dh_types:
+        #     dh_cdata = self._lib.EVP_PKEY_get1_DH(evp_pkey)
+        #     self.openssl_assert(dh_cdata != self._ffi.NULL)
+        #     dh_cdata = self._ffi.gc(dh_cdata, self._lib.DH_free)
+        #     return _DHPrivateKey(self, dh_cdata, evp_pkey)
+        # elif key_type == getattr(self._lib, "EVP_PKEY_ED25519", None):
+        #     # EVP_PKEY_ED25519 is not present in OpenSSL < 1.1.1
+        #     return _Ed25519PrivateKey(self, evp_pkey)
+        # elif key_type == getattr(self._lib, "EVP_PKEY_X448", None):
+        #     # EVP_PKEY_X448 is not present in OpenSSL < 1.1.1
+        #     return _X448PrivateKey(self, evp_pkey)
+        # elif key_type == getattr(self._lib, "EVP_PKEY_X25519", None):
+        #     # EVP_PKEY_X25519 is not present in OpenSSL < 1.1.0
+        #     return _X25519PrivateKey(self, evp_pkey)
+        # elif key_type == getattr(self._lib, "EVP_PKEY_ED448", None):
+        #     # EVP_PKEY_ED448 is not present in OpenSSL < 1.1.1
+        #     return _Ed448PrivateKey(self, evp_pkey)
+        # else:
+        fail("UnsupportedAlgorithm: Unsupported key type: %s" % key_type)
+    self._evp_pkey_to_private_key = _evp_pkey_to_private_key
+
+    def _evp_pkey_to_public_key(pkey):
+        """
+        Return the appropriate type of PublicKey given an pkey cdata
+        """
+
+        key_type = pkey.key_type
+        if key_type == 'RSA':
+            return RSAPublicKey(self, RSA.import_key(pkey.private_key()))
+        fail("UnsupportedAlgorithm: Unsupported key type: %s" % key_type)
+
+        #
+        # if key_type == self._lib.EVP_PKEY_RSA:
+        #     rsa_cdata = self._lib.EVP_PKEY_get1_RSA(evp_pkey)
+        #     self.openssl_assert(rsa_cdata != self._ffi.NULL)
+        #     rsa_cdata = self._ffi.gc(rsa_cdata, self._lib.RSA_free)
+        #     return _RSAPublicKey(self, rsa_cdata, evp_pkey)
+        # elif key_type == self._lib.EVP_PKEY_DSA:
+        #     dsa_cdata = self._lib.EVP_PKEY_get1_DSA(evp_pkey)
+        #     self.openssl_assert(dsa_cdata != self._ffi.NULL)
+        #     dsa_cdata = self._ffi.gc(dsa_cdata, self._lib.DSA_free)
+        #     return _DSAPublicKey(self, dsa_cdata, evp_pkey)
+        # elif key_type == self._lib.EVP_PKEY_EC:
+        #     ec_cdata = self._lib.EVP_PKEY_get1_EC_KEY(evp_pkey)
+        #     self.openssl_assert(ec_cdata != self._ffi.NULL)
+        #     ec_cdata = self._ffi.gc(ec_cdata, self._lib.EC_KEY_free)
+        #     return _EllipticCurvePublicKey(self, ec_cdata, evp_pkey)
+        # elif key_type in self._dh_types:
+        #     dh_cdata = self._lib.EVP_PKEY_get1_DH(evp_pkey)
+        #     self.openssl_assert(dh_cdata != self._ffi.NULL)
+        #     dh_cdata = self._ffi.gc(dh_cdata, self._lib.DH_free)
+        #     return _DHPublicKey(self, dh_cdata, evp_pkey)
+        # elif key_type == getattr(self._lib, "EVP_PKEY_ED25519", None):
+        #     # EVP_PKEY_ED25519 is not present in OpenSSL < 1.1.1
+        #     return _Ed25519PublicKey(self, evp_pkey)
+        # elif key_type == getattr(self._lib, "EVP_PKEY_X448", None):
+        #     # EVP_PKEY_X448 is not present in OpenSSL < 1.1.1
+        #     return _X448PublicKey(self, evp_pkey)
+        # elif key_type == getattr(self._lib, "EVP_PKEY_X25519", None):
+        #     # EVP_PKEY_X25519 is not present in OpenSSL < 1.1.0
+        #     return _X25519PublicKey(self, evp_pkey)
+        # elif key_type == getattr(self._lib, "EVP_PKEY_ED448", None):
+        #     # EVP_PKEY_X25519 is not present in OpenSSL < 1.1.1
+        #     return _Ed448PublicKey(self, evp_pkey)
+        # else:
+        #     raise UnsupportedAlgorithm("Unsupported key type.")
+    self._evp_pkey_to_public_key = _evp_pkey_to_public_key
+
+    def load_key_and_certificates_from_pkcs12(data, password):
+        if password != None:
+            utils._check_byteslike("password", password)
+        # fail("ValueError: Could not deserialize PKCS12 data")
+        # fail("Invalid password or PKCS12 data")
+        # # In OpenSSL < 3.0.0 PKCS12 parsing reverses the order of the
+        # # certificates.
+        # cert = None
+        # key = None
+        # additional_certificates = []
+        key, cert, additional_certificates = _JOpenSSL.OpenSSL.load_key_and_certificates_from_pkcs12(tobytes(data), password)
+        return RSAPrivateKey(self, key, RSA.import_key(key.private_key())), _Certificate(self, cert), [_Certificate(self, c) for c in additional_certificates]
+    self.load_key_and_certificates_from_pkcs12 = load_key_and_certificates_from_pkcs12
+
+    def load_rsa_private_numbers(private_numbers):
+        return
+    self.load_rsa_private_numbers = load_rsa_private_numbers
+
+    def load_pem_private_key(data, password):
+        if password != None:
+            utils._check_byteslike("password", password)
+        # fail("TypeError: Password was not given but private key is encrypted")
+        evp_pkey = _JCrypto.IO.PEM.load_privatekey(data, password)
+        return self._evp_pkey_to_private_key(evp_pkey)
+
+    self.load_pem_private_key = load_pem_private_key
+    return self
+
+
+backend = pycryptodome

--- a/larky/src/main/resources/vendor/cryptography/hazmat/primitives/__init__.star
+++ b/larky/src/main/resources/vendor/cryptography/hazmat/primitives/__init__.star
@@ -1,0 +1,17 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+load("@stdlib//larky", larky="larky")
+load("@vendor//cryptography/hazmat/primitives/hashes", _hashes="hashes")
+load("@vendor//cryptography/hazmat/primitives/serialization",
+     _serialization="serialization")
+
+
+hashes = _hashes
+serialization = _serialization
+
+
+primitives = larky.struct(
+    __name__='primitives',
+    hashes=hashes,
+)

--- a/larky/src/main/resources/vendor/cryptography/hazmat/primitives/_hashes.star
+++ b/larky/src/main/resources/vendor/cryptography/hazmat/primitives/_hashes.star
@@ -1,0 +1,131 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+#
+# This file is non-std to avoid the circular imports that can be handled
+# in python, but cannot be handled in Larky
+#
+# This exists to break an import cycle. These classes are normally accessible
+# from the hashes module.
+load("@stdlib//larky", larky="larky")
+load("@stdlib//builtins", builtins="builtins")
+load("@vendor//cryptography/utils", utils="utils")
+
+
+def _HashAlgorithm(name, digest_size, block_size):
+    # type: (str, int, Optional[int]) -> _HashAlgorithm
+    """
+    :param name: A string naming this algorithm (e.g. "sha256", "md5").
+    :param digest_size: The size of the resulting digest in bytes.
+    :param block_size: The internal block size of the hash function,
+                        or None if the hash function does not use blocks
+                        internally (e.g. SHA3).
+    """
+    return larky.struct(
+        __name__='HashAlgorithm',
+        __class__=HashAlgorithm,
+        name=name,
+        digest_size=digest_size,
+        block_size=block_size,
+    )
+
+
+def HashAlgorithm(**kwargs):
+    # print("HashAlgorithm:", kwargs)
+    return lambda : _HashAlgorithm(kwargs['name'], kwargs['digest_size'], kwargs['block_size'])
+
+
+def HashContext(algorithm):
+    # type: (HashAlgorithm) -> HashAlgorithm
+    """
+    :param algorithm: A HashAlgorithm that will be used by this context.
+    """
+    if not builtins.isinstance(algorithm, HashAlgorithm):
+        fail("Expected instance of hashes.HashAlgorithm.")
+
+    self = larky.mutablestruct(
+        __name__='HashContext',
+        __class__=HashContext,
+        algorithm=larky.property(lambda: algorithm),
+    )
+
+    def update(data):
+        # type: (bytes) -> None
+        """
+        Processes the provided bytes through the hash.
+        """
+    self.update = update
+
+    def finalize():
+        # type: () -> bytes
+        """
+        Finalizes the hash context and returns the hash digest as bytes.
+        """
+    self.finalize = finalize
+
+    def copy():
+        # type: () -> "HashContext"
+        """
+        Return a HashContext that is a copy of the current context.
+        """
+    self.copy = copy
+    return self
+
+
+def Hash(algorithm, backend = None, ctx = None):
+    # type: (HashAlgorithm, Optional[Backend], Optional["HashContext"]) -> Hash
+    self = HashContext(algorithm)
+    self.__name__ = 'Hash'
+    self.__class__ = Hash
+    def __init__(
+        algorithm, # type: HashAlgorithm,
+        backend,   # type: Optional[Backend] = None,
+        ctx        # type: Optional["HashContext"] = None,
+    ):
+        if not backend:
+            fail("Backend not found")
+            # backend = backends._get_backend(backend)
+        self._algorithm = algorithm
+        self._backend = backend
+
+        if ctx == None:
+            self._ctx = self._backend.create_hash_ctx(self.algorithm)
+        else:
+            self._ctx = ctx
+        return self
+    self = __init__(algorithm, backend, ctx)
+
+    def update(data):
+        # type: (bytes) -> None
+        if self._ctx == None:
+            fail("AlreadyFinalized: Context was already finalized.")
+        utils._check_byteslike("data", data)
+        self._ctx.update(data)
+    self.update = update
+
+    def copy():
+        # type: () -> "Hash"
+        if self._ctx == None:
+            fail("AlreadyFinalized: Context was already finalized.")
+        return Hash(
+            self.algorithm, backend=self._backend, ctx=self._ctx.copy()
+        )
+    self.copy = copy
+
+    def finalize():
+        # type: () -> bytes
+        if self._ctx == None:
+            fail("AlreadyFinalized: Context was already finalized.")
+        digest = self._ctx.finalize()
+        self._ctx = None
+        return digest
+    self.finalize = finalize
+    return self
+
+hashes = larky.struct(
+    __name__='_hashes',
+    HashContext=HashContext,
+    Hash=Hash,
+    HashAlgorithm=HashAlgorithm,
+    _HashAlgorithm=_HashAlgorithm
+)

--- a/larky/src/main/resources/vendor/cryptography/hazmat/primitives/_serialization.star
+++ b/larky/src/main/resources/vendor/cryptography/hazmat/primitives/_serialization.star
@@ -1,0 +1,82 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+load("@stdlib//enum", enum="enum")
+load("@stdlib//larky", larky="larky")
+load("@stdlib//types", types="types")
+load("@vendor//option/result", Error="Error")
+
+# This exists to break an import cycle. These classes are normally accessible
+# from the serialization module.
+
+Encoding = enum.Enum('Encoding', dict(
+    PEM = "PEM",
+    DER = "DER",
+    OpenSSH = "OpenSSH",
+    Raw = "Raw",
+    X962 = "ANSI X9.62",
+    SMIME = "S/MIME",
+).items())
+
+
+
+PrivateFormat = enum.Enum('PrivateFormat', dict(
+    PKCS8 = "PKCS8",
+    TraditionalOpenSSL = "TraditionalOpenSSL",
+    Raw = "Raw",
+    OpenSSH = "OpenSSH",
+).items())
+
+
+PublicFormat = enum.Enum('PrivateFormat', dict(
+    SubjectPublicKeyInfo = "X.509 subjectPublicKeyInfo with PKCS#1",
+    PKCS1 = "Raw PKCS#1",
+    OpenSSH = "OpenSSH",
+    Raw = "Raw",
+    CompressedPoint = "X9.62 Compressed Point",
+    UncompressedPoint = "X9.62 Uncompressed Point",
+).items())
+
+
+ParameterFormat = enum.Enum('ParameterFormat', dict(PKCS3="PKCS3",).items())
+
+
+def KeySerializationEncryption():
+    return larky.mutablestruct(
+        __name__="KeySerializationEncryption",
+        __class__=KeySerializationEncryption)
+
+
+def BestAvailableEncryption(password):
+    # type: (bytes) -> "BestAvailableEncryption"
+    self = KeySerializationEncryption()
+    self.__name__ = 'BestAvailableEncryption'
+    self.__class__ = BestAvailableEncryption
+
+    def __init__(password):
+        # type: (bytes) -> Any
+        if not types.is_bytes(password) or len(password) == 0:
+            fail("ValueError: Password must be 1 or more bytes.")
+        self.password = password
+        return self
+    self = __init__(password)
+    return self
+
+
+def NoEncryption():
+    self = KeySerializationEncryption()
+    self.__name__ = 'NoEncryption'
+    self.__class__ = NoEncryption
+    return self
+
+
+serialization = larky.struct(
+    __name__='_serialization',
+    Encoding=Encoding,
+    PrivateFormat=PrivateFormat,
+    PublicFormat=PublicFormat,
+    ParameterFormat=ParameterFormat,
+    KeySerializationEncryption=KeySerializationEncryption,
+    BestAvailableEncryption=BestAvailableEncryption,
+    NoEncryption=NoEncryption,
+)

--- a/larky/src/main/resources/vendor/cryptography/hazmat/primitives/asymmetric/__init__.star
+++ b/larky/src/main/resources/vendor/cryptography/hazmat/primitives/asymmetric/__init__.star
@@ -1,0 +1,10 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+load("@vendor//cryptography/hazmat/primitives/asymmetric/rsa", _rsa="rsa")
+load("@vendor//cryptography/hazmat/primitives/asymmetric/padding", _padding="padding")
+load("@vendor//cryptography/hazmat/primitives/asymmetric/utils", _utils="utils")
+
+rsa = _rsa
+padding = _padding
+utils = _utils

--- a/larky/src/main/resources/vendor/cryptography/hazmat/primitives/asymmetric/padding.star
+++ b/larky/src/main/resources/vendor/cryptography/hazmat/primitives/asymmetric/padding.star
@@ -1,0 +1,102 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+load("@stdlib//builtins", builtins="builtins")
+load("@stdlib//types", types="types")
+load("@stdlib//larky", larky="larky")
+load("@vendor//cryptography/hazmat/primitives", hashes="hashes")
+load("@vendor//cryptography/hazmat/primitives/asymmetric/rsa", rsa="rsa")
+load("@vendor//option/result", Error="Error")
+
+
+def PKCS1v15():
+    self = larky.mutablestruct(__name__='PKCS1v15', __class__=PKCS1v15)
+    self.name = "EMSA-PKCS1-v1_5"
+    return self
+
+
+def PSS(mgf, salt_length):
+    self = larky.mutablestruct(__name__='PSS', __class__=PSS)
+    self.MAX_LENGTH = larky.SENTINEL
+    self.name = "EMSA-PSS"
+
+    def __init__(mgf, salt_length):
+        self._mgf = mgf
+
+        if not types.is_int(salt_length) and salt_length != self.MAX_LENGTH:
+            fail("TypeError: salt_length must be an integer.")
+
+        if salt_length != self.MAX_LENGTH and salt_length < 0:
+            fail("ValueError: salt_length must be zero or greater.")
+
+        self._salt_length = salt_length
+        return self
+
+    self = __init__(mgf, salt_length)
+    return self
+
+
+def OAEP(mgf,
+         algorithm,
+         label,
+         ):
+    self = larky.mutablestruct(__name__='OAEP', __class__=OAEP)
+    self.name = "EME-OAEP"
+
+    def __init__(
+            mgf,
+            algorithm,
+            label,
+    ):
+        if not builtins.isinstance(algorithm, hashes.HashAlgorithm):
+            fail("TypeError: Expected instance of hashes.HashAlgorithm.")
+
+        self._mgf = mgf
+        self._algorithm = algorithm
+        self._label = label
+        return self
+
+    self = __init__(mgf, algorithm, label)
+    return self
+
+
+def MGF1(algorithm):
+    self = larky.mutablestruct(__name__='MGF1', __class__=MGF1)
+    self.MAX_LENGTH = larky.SENTINEL
+
+    def __init__(algorithm):
+        if not builtins.isinstance(algorithm, hashes.HashAlgorithm):
+            fail("TypeError: Expected instance of hashes.HashAlgorithm.")
+
+        self._algorithm = algorithm
+        return self
+
+    self = __init__(algorithm)
+    return self
+
+
+def calculate_max_pss_salt_length(
+        key,
+        hash_algorithm,
+):
+    if not any([
+        builtins.isinstance(key, x)
+        for x in (rsa.RSAPrivateKey, rsa.RSAPublicKey,)
+    ]):
+        fail("TypeError: key must be an RSA public or private key")
+    # bit length - 1 per RFC 3447
+    emlen = (key.key_size + 6) // 8
+    salt_length = emlen - hash_algorithm.digest_size - 2
+    if not (salt_length >= 0):
+        fail("assert salt_length >= 0 failed!")
+    return salt_length
+
+
+padding = larky.struct(
+    __name__='padding',
+    PKCS1v15=PKCS1v15,
+    PSS=PSS,
+    OAEP=OAEP,
+    MGF1=MGF1,
+    calculate_max_pss_salt_length=calculate_max_pss_salt_length,
+)

--- a/larky/src/main/resources/vendor/cryptography/hazmat/primitives/asymmetric/rsa.star
+++ b/larky/src/main/resources/vendor/cryptography/hazmat/primitives/asymmetric/rsa.star
@@ -1,0 +1,473 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+load("@stdlib//builtins", builtins="builtins")
+load("@stdlib//types", types="types")
+load("@stdlib//larky", WHILE_LOOP_EMULATION_ITERATION="WHILE_LOOP_EMULATION_ITERATION", larky="larky")
+load("@stdlib//math", gcd="gcd")
+load("@vendor//cryptography/hazmat/backends", backends="backends")
+load("@vendor//cryptography/hazmat/primitives/hashes", hashes="hashes")
+load("@vendor//option/result", Error="Error")
+
+
+_get_backend = backends._get_backend
+
+
+def RSAPrivateKey():
+    self = larky.mutablestruct(__name__='RSAPrivateKey',
+                               __class__=RSAPrivateKey)
+
+    def signer(
+        padding, algorithm
+    ):
+        """
+        Returns an AsymmetricSignatureContext used for signing data.
+        """
+    self.signer = signer
+
+    def decrypt(ciphertext, padding):
+        """
+        Decrypts the provided ciphertext.
+        """
+    self.decrypt = decrypt
+
+    def key_size():
+        """
+        The bit length of the public modulus.
+        """
+    self.key_size = key_size
+
+    def public_key():
+        """
+        The RSAPublicKey associated with this private key.
+        """
+    self.public_key = public_key
+
+    def sign(
+        data,
+        padding,
+        algorithm,
+    ):
+        """
+        Signs the data.
+        """
+    self.sign = sign
+
+    def private_numbers():
+        """
+        Returns an RSAPrivateNumbers.
+        """
+    self.private_numbers = private_numbers
+
+    def private_bytes(
+        encoding,
+        format,
+        encryption_algorithm,
+    ):
+        """
+        Returns the key serialized as bytes.
+        """
+    self.private_bytes = private_bytes
+    return self
+
+
+RSAPrivateKeyWithSerialization = RSAPrivateKey
+
+
+def RSAPublicKey():
+    self = larky.mutablestruct(__name__='RSAPublicKey', __class__=RSAPublicKey)
+
+    def verifier(
+        signature,
+        padding,
+        algorithm,
+    ):
+        """
+        Returns an AsymmetricVerificationContext used for verifying signatures.
+        """
+    self.verifier = verifier
+
+    def encrypt(plaintext, padding):
+        """
+        Encrypts the given plaintext.
+        """
+    self.encrypt = encrypt
+
+    def key_size():
+        """
+        The bit length of the public modulus.
+        """
+    self.key_size = key_size
+
+    def public_numbers():
+        """
+        Returns an RSAPublicNumbers
+        """
+    self.public_numbers = public_numbers
+
+    def public_bytes(
+        encoding,
+        format,
+    ):
+        """
+        Returns the key serialized as bytes.
+        """
+    self.public_bytes = public_bytes
+
+    def verify(
+        signature,
+        data,
+        padding,
+        algorithm,
+    ):
+        """
+        Verifies the signature of the data.
+        """
+    self.verify = verify
+
+    def recover_data_from_signature(
+        signature,
+        padding,
+        algorithm,
+    ):
+        """
+        Recovers the original data from the signature.
+        """
+    self.recover_data_from_signature = recover_data_from_signature
+    return self
+
+
+RSAPublicKeyWithSerialization = RSAPublicKey
+
+
+def generate_private_key(
+    public_exponent,
+    key_size,
+    backend = None,
+):
+    backend = _get_backend(backend)
+    if not hasattr(backend, 'generate_rsa_private_key'):
+        fail("UnsupportedAlgorithm: Backend object does not implement RSABackend.",
+            )
+
+    _verify_rsa_parameters(public_exponent, key_size)
+    return backend.generate_rsa_private_key(public_exponent, key_size)
+
+
+def _verify_rsa_parameters(public_exponent, key_size):
+    if public_exponent not in (3, 65537):
+        fail("ValueError: " + ("public_exponent must be either 3 (for legacy compatibility) or " +
+            "65537. Almost everyone should choose 65537 here!")
+        )
+
+    if key_size < 512:
+        fail("ValueError: key_size must be at least 512-bits.")
+
+
+def _check_private_key_components(
+    p,
+    q,
+    private_exponent,
+    dmp1,
+    dmq1,
+    iqmp,
+    public_exponent,
+    modulus,
+):
+    if modulus < 3:
+        fail("ValueError: modulus must be >= 3.")
+
+    if p >= modulus:
+        fail("ValueError: p must be < modulus.")
+
+    if q >= modulus:
+        fail("ValueError: q must be < modulus.")
+
+    if dmp1 >= modulus:
+        fail("ValueError: dmp1 must be < modulus.")
+
+    if dmq1 >= modulus:
+        fail("ValueError: dmq1 must be < modulus.")
+
+    if iqmp >= modulus:
+        fail("ValueError: iqmp must be < modulus.")
+
+    if private_exponent >= modulus:
+        fail("ValueError: private_exponent must be < modulus.")
+
+    if public_exponent < 3 or public_exponent >= modulus:
+        fail("ValueError: public_exponent must be >= 3 and < modulus.")
+
+    if public_exponent & 1 == 0:
+        fail("ValueError: public_exponent must be odd.")
+
+    if dmp1 & 1 == 0:
+        fail("ValueError: dmp1 must be odd.")
+
+    if dmq1 & 1 == 0:
+        fail("ValueError: dmq1 must be odd.")
+
+    if p * q != modulus:
+        fail("ValueError: p*q must equal modulus.")
+
+
+def _check_public_key_components(e, n):
+    if n < 3:
+        fail("ValueError: n must be >= 3.")
+
+    if e < 3 or e >= n:
+        fail("ValueError: e must be >= 3 and < n.")
+
+    if e & 1 == 0:
+        fail("ValueError: e must be odd.")
+
+
+def _modinv(e, m):
+    """
+    Modular Multiplicative Inverse. Returns x such that: (x*e) mod m == 1
+    """
+    x1, x2 = 1, 0
+    a, b = e, m
+    for _while_ in range(WHILE_LOOP_EMULATION_ITERATION):
+        if b <= 0:
+            break
+        q, r = divmod(a, b)
+        xn = x1 - q * x2
+        a, b, x1, x2 = b, r, x2, xn
+    return x1 % m
+
+
+def rsa_crt_iqmp(p, q):
+    """
+    Compute the CRT (q ** -1) % p value from RSA primes p and q.
+    """
+    return _modinv(q, p)
+
+
+def rsa_crt_dmp1(private_exponent, p):
+    """
+    Compute the CRT private_exponent % (p - 1) value from the RSA
+    private_exponent (d) and p.
+    """
+    return private_exponent % (p - 1)
+
+
+def rsa_crt_dmq1(private_exponent, q):
+    """
+    Compute the CRT private_exponent % (q - 1) value from the RSA
+    private_exponent (d) and q.
+    """
+    return private_exponent % (q - 1)
+
+
+# Controls the number of iterations rsa_recover_prime_factors will perform
+# to obtain the prime factors. Each iteration increments by 2 so the actual
+# maximum attempts is half this number.
+_MAX_RECOVERY_ATTEMPTS = 1000
+
+
+def rsa_recover_prime_factors(n, e, d):
+    """
+    Compute factors p and q from the private exponent d. We assume that n has
+    no more than two factors. This function is adapted from code in PyCrypto.
+    """
+    # See 8.2.2(i) in Handbook of Applied Cryptography.
+    ktot = d * e - 1
+    # The quantity d*e-1 is a multiple of phi(n), even,
+    # and can be represented as t*2^s.
+    t = ktot
+    for _while_ in range(WHILE_LOOP_EMULATION_ITERATION):
+        if t % 2 != 0:
+            break
+        t = t // 2
+    # Cycle through all multiplicative inverses in Zn.
+    # The algorithm is non-deterministic, but there is a 50% chance
+    # any candidate a leads to successful factoring.
+    # See "Digitalized Signatures and Public Key Functions as Intractable
+    # as Factorization", M. Rabin, 1979
+    spotted = False
+    a = 2
+    for _while_ in range(WHILE_LOOP_EMULATION_ITERATION):
+        # not spotted and a < _MAX_RECOVERY_ATTEMPTS
+        if not (not spotted and a < _MAX_RECOVERY_ATTEMPTS):
+            break
+        k = t
+        for _while_ in range(WHILE_LOOP_EMULATION_ITERATION):
+            if k >= ktot:
+                break
+            cand = pow(a, k, n)
+            # Check if a^k is a non-trivial root of unity (mod n)
+            if cand != 1 and cand != (n - 1) and pow(cand, 2, n) == 1:
+                # We have found a number such that (cand-1)(cand+1)=0 (mod n).
+                # Either of the terms divides n.
+                p = gcd(cand + 1, n)
+                spotted = True
+                break
+            k *= 2
+        # This value was not any good... let's try another!
+        a += 2
+    if not spotted:
+        fail("ValueError: Unable to compute factors p and q from exponent d.")
+    # Found !
+    q, r = divmod(n, p)
+    if not (r == 0):
+        fail("assert r == 0 failed!")
+    p, q = sorted((p, q,), reverse=True)
+    return (p, q)
+
+
+def RSAPrivateNumbers(p,
+    q,
+    d,
+    dmp1,
+    dmq1,
+    iqmp,
+    public_numbers,
+):
+    self = larky.mutablestruct(__name__='RSAPrivateNumbers', __class__=RSAPrivateNumbers)
+    def __init__(
+        p,
+        q,
+        d,
+        dmp1,
+        dmq1,
+        iqmp,
+        public_numbers,
+    ):
+        if (
+            not types.is_int(p)
+            or not types.is_int(q)
+            or not types.is_int(d)
+            or not types.is_int(dmp1)
+            or not types.is_int(dmq1)
+            or not types.is_int(iqmp)
+        ):
+            fail("TypeError: " + ("RSAPrivateNumbers p, q, d, dmp1, dmq1, iqmp arguments must" +
+                " all be an integers.")
+            )
+
+        if not hasattr(public_numbers, 'public_key'):
+            fail("TypeError: RSAPrivateNumbers public_numbers must be " +
+                 "an RSAPublicNumbers instance.")
+
+        self._p = p
+        self._q = q
+        self._d = d
+        self._dmp1 = dmp1
+        self._dmq1 = dmq1
+        self._iqmp = iqmp
+        self._public_numbers = public_numbers
+        return self
+    self = __init__(p, q, d, dmp1, dmq1, iqmp, public_numbers)
+
+    self.p = larky.property(lambda: self._p)
+    self.q = larky.property(lambda: self._q)
+    self.d = larky.property(lambda: self._d)
+    self.dmp1 = larky.property(lambda: self._dmp1)
+    self.dmq1 = larky.property(lambda: self._dmq1)
+    self.iqmp = larky.property(lambda: self._iqmp)
+    self.public_numbers = larky.property(lambda: self._public_numbers)
+
+    def private_key(backend = None):
+        backend = _get_backend(backend)
+        return backend.load_rsa_private_numbers(self)
+    self.private_key = private_key
+
+    def __eq__(other):
+        if not builtins.isinstance(other, RSAPrivateNumbers):
+            return builtins.NotImplemented
+
+        return (
+            self.p == other.p
+            and self.q == other.q
+            and self.d == other.d
+            and self.dmp1 == other.dmp1
+            and self.dmq1 == other.dmq1
+            and self.iqmp == other.iqmp
+            and self.public_numbers == other.public_numbers
+        )
+    self.__eq__ = __eq__
+
+    def __ne__(other):
+        return not self.__eq__(other)
+    self.__ne__ = __ne__
+
+    def __hash__():
+        return hash(
+            (
+                self.p,
+                self.q,
+                self.d,
+                self.dmp1,
+                self.dmq1,
+                self.iqmp,
+                self.public_numbers,
+            )
+        )
+    self.__hash__ = __hash__
+    return self
+
+
+def RSAPublicNumbers(e, n):
+
+    self = larky.mutablestruct(
+        __name__='RSAPublicNumbers',
+        __class__=RSAPublicNumbers
+    )
+
+    def __init__(e, n):
+        if not types.is_int(e) or not types.is_int(n):
+            fail("TypeError: RSAPublicNumbers arguments must be integers.")
+        self._e = e
+        self._n = n
+        return self
+    self = __init__(e, n)
+
+    self.e = larky.property(lambda: self._e)
+    self.n = larky.property(lambda: self._n)
+
+    def public_key(backend = None):
+        backend = _get_backend(backend)
+        return backend.load_rsa_public_numbers(self)
+    self.public_key = public_key
+
+    def __repr__():
+        return "<RSAPublicNumbers(e={}, n={})>".format(self._e, self._n)
+    self.__repr__ = __repr__
+
+    def __eq__(other):
+        if not builtins.isinstance(other, RSAPublicNumbers):
+            return builtins.NotImplemented
+
+        return self.e == other.e and self.n == other.n
+    self.__eq__ = __eq__
+
+    def __ne__(other):
+        return not self == other
+    self.__ne__ = __ne__
+
+    def __hash__():
+        return hash((self.e, self.n,))
+    self.__hash__ = __hash__
+    return self
+
+
+rsa = larky.struct(
+    __name__='rsa',
+    RSAPrivateKey=RSAPrivateKey,
+    RSAPrivateKeyWithSerialization=RSAPrivateKeyWithSerialization,
+    RSAPublicKey=RSAPublicKey,
+    RSAPublicKeyWithSerialization=RSAPublicKeyWithSerialization,
+    generate_private_key=generate_private_key,
+    _verify_rsa_parameters=_verify_rsa_parameters,
+    _check_private_key_components=_check_private_key_components,
+    _check_public_key_components=_check_public_key_components,
+    _modinv=_modinv,
+    rsa_crt_iqmp=rsa_crt_iqmp,
+    rsa_crt_dmp1=rsa_crt_dmp1,
+    rsa_crt_dmq1=rsa_crt_dmq1,
+    _MAX_RECOVERY_ATTEMPTS=_MAX_RECOVERY_ATTEMPTS,
+    rsa_recover_prime_factors=rsa_recover_prime_factors,
+    RSAPrivateNumbers=RSAPrivateNumbers,
+    RSAPublicNumbers=RSAPublicNumbers,
+)

--- a/larky/src/main/resources/vendor/cryptography/hazmat/primitives/asymmetric/utils.star
+++ b/larky/src/main/resources/vendor/cryptography/hazmat/primitives/asymmetric/utils.star
@@ -1,0 +1,49 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+load("@stdlib//builtins", builtins="builtins")
+load("@stdlib//larky", larky="larky")
+load("@vendor//cryptography/hazmat/_der", DERReader="DERReader", INTEGER="INTEGER", SEQUENCE="SEQUENCE", encode_der="encode_der", encode_der_integer="encode_der_integer")
+load("@vendor//cryptography/hazmat/primitives", hashes="hashes")
+load("@vendor//option/result", Error="Error")
+
+
+def decode_dss_signature(signature):
+    reader = DERReader(signature)
+    reader_ctx = reader.__enter__()
+    seq = reader_ctx.read_single_element(SEQUENCE)
+    r = seq.read_element(INTEGER).as_integer()
+    s = seq.read_element(INTEGER).as_integer()
+    reader.__exit__()
+    return r, s
+
+
+def encode_dss_signature(r, s):
+    return encode_der(
+        SEQUENCE,
+        encode_der(INTEGER, encode_der_integer(r)),
+        encode_der(INTEGER, encode_der_integer(s)),
+    )
+
+
+def Prehashed(algorithm):
+    self = larky.mutablestruct(__name__='Prehashed', __class__=Prehashed)
+    def __init__(algorithm):
+        if not builtins.isinstance(algorithm, hashes.HashAlgorithm):
+            fail("TypeError: Expected instance of HashAlgorithm, not %s", type(algorithm))
+
+        self._algorithm = algorithm
+        self._digest_size = algorithm.digest_size
+        return self
+    self = __init__(algorithm)
+
+    self.digest_size = larky.property(lambda: self._digest_size)
+    return self
+
+
+utils = larky.struct(
+    __name__='utils',
+    decode_dss_signature=decode_dss_signature,
+    encode_dss_signature=encode_dss_signature,
+    Prehashed=Prehashed,
+)

--- a/larky/src/main/resources/vendor/cryptography/hazmat/primitives/hashes.star
+++ b/larky/src/main/resources/vendor/cryptography/hazmat/primitives/hashes.star
@@ -1,0 +1,112 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+load("@stdlib//larky", larky="larky")
+load("@stdlib//builtins", builtins="builtins")
+load("@vendor//Crypto/Hash", _Hash="Hash")
+load("@vendor//cryptography", utils="utils")
+load("@vendor//cryptography/hazmat/primitives/_hashes",
+     HashAlgorithm="HashAlgorithm",
+     HashContext="HashContext",
+     Hash="Hash",
+     )
+
+
+SHA1 = HashAlgorithm(
+    name="sha1",
+    digest_size=20,
+    block_size=64,
+)
+
+SHA512_224 = HashAlgorithm(
+    name="sha512-224",
+    digest_size=28,
+    block_size=128,
+)
+
+SHA512_256 = HashAlgorithm(
+    name="sha512-256",
+    digest_size=32,
+    block_size=128,
+)
+
+SHA224 = HashAlgorithm(
+    name="sha224",
+    digest_size=28,
+    block_size=64,
+)
+
+SHA256 = HashAlgorithm(
+    name="sha256",
+    digest_size=32,
+    block_size=64,
+)
+
+SHA384 = HashAlgorithm(
+    name="sha384",
+    digest_size=48,
+    block_size=128,
+)
+
+SHA512 = HashAlgorithm(
+    name="sha512",
+    digest_size=64,
+    block_size=128,
+)
+
+SHA3_224 = HashAlgorithm(
+    name="sha3-224",
+    digest_size=28,
+    block_size=None,
+)
+
+SHA3_256 = HashAlgorithm(
+    name="sha3-256",
+    digest_size=32,
+    block_size=None,
+)
+
+SHA3_384 = HashAlgorithm(
+    name="sha3-384",
+    digest_size=48,
+    block_size=None,
+)
+
+SHA3_512 = HashAlgorithm(
+    name="sha3-512",
+    digest_size=64,
+    block_size=None,
+)
+
+MD5 = HashAlgorithm(
+    name="md5",
+    digest_size=16,
+    block_size=64,
+)
+
+SM3 = HashAlgorithm(
+    name="sm3",
+    digest_size=32,
+    block_size=64,
+)
+
+hashes = larky.struct(
+    __name__='hashes',
+    SHA1=SHA1,
+    SHA512_224=SHA512_224,
+    SHA512_256=SHA512_256,
+    SHA224=SHA224,
+    SHA256=SHA256,
+    SHA384=SHA384,
+    SHA512=SHA512,
+    SHA3_224=SHA3_224,
+    SHA3_256=SHA3_256,
+    SHA3_384=SHA3_384,
+    SHA3_512=SHA3_512,
+    # SHAKE128=SHAKE128,
+    # SHAKE256=SHAKE256,
+    MD5=MD5,
+    # BLAKE2b=BLAKE2b,
+    # BLAKE2s=BLAKE2s,
+    SM3=SM3,
+)

--- a/larky/src/main/resources/vendor/cryptography/hazmat/primitives/serialization/__init__.star
+++ b/larky/src/main/resources/vendor/cryptography/hazmat/primitives/serialization/__init__.star
@@ -1,0 +1,42 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+load("@stdlib//larky", larky="larky")
+load("@vendor//cryptography/hazmat/primitives/_serialization", _Encoding="Encoding")
+load("@vendor//cryptography/hazmat/primitives/serialization/base",
+     # load_der_parameters,
+     # load_der_private_key,
+     # load_der_public_key,
+     # load_pem_parameters,
+     # load_pem_private_key,
+     # load_pem_public_key,
+     "load_der_parameters",
+     "load_der_private_key",
+     "load_der_public_key",
+     "load_pem_parameters",
+     "load_pem_private_key",
+     "load_pem_public_key",
+     )
+
+#
+# load("@vendor//cryptography/hazmat/primitives/serialization/ssh",
+#      # load_ssh_private_key,
+#      # load_ssh_public_key,
+#      "load_ssh_private_key",
+#      "load_ssh_public_key",
+#      )
+
+
+Encoding = _Encoding
+
+
+serialization = larky.struct(
+    __name__='serialization',
+    Encoding=Encoding,
+    load_der_parameters=load_der_parameters,
+    load_der_private_key=load_der_private_key,
+    load_der_public_key=load_der_public_key,
+    load_pem_parameters=load_pem_parameters,
+    load_pem_private_key=load_pem_private_key,
+    load_pem_public_key=load_pem_public_key,
+)

--- a/larky/src/main/resources/vendor/cryptography/hazmat/primitives/serialization/base.star
+++ b/larky/src/main/resources/vendor/cryptography/hazmat/primitives/serialization/base.star
@@ -1,0 +1,64 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+load("@stdlib//larky", larky="larky")
+
+load("@vendor//cryptography/hazmat/backends", backends="backends")
+_get_backend = backends._get_backend
+
+
+def load_pem_private_key(
+    data,
+    password,
+    backend = None,
+):
+    backend = _get_backend(backend)
+    return backend.load_pem_private_key(data, password)
+
+
+def load_pem_public_key(
+    data, backend = None
+):
+    backend = _get_backend(backend)
+    return backend.load_pem_public_key(data)
+
+
+def load_pem_parameters(
+    data, backend = None
+):
+    backend = _get_backend(backend)
+    return backend.load_pem_parameters(data)
+
+
+def load_der_private_key(
+    data,
+    password,
+    backend = None,
+):
+    backend = _get_backend(backend)
+    return backend.load_der_private_key(data, password)
+
+
+def load_der_public_key(
+    data, backend = None
+):
+    backend = _get_backend(backend)
+    return backend.load_der_public_key(data)
+
+
+def load_der_parameters(
+    data, backend = None
+):
+    backend = _get_backend(backend)
+    return backend.load_der_parameters(data)
+
+
+base = larky.struct(
+    __name__='base',
+    load_pem_private_key=load_pem_private_key,
+    load_pem_public_key=load_pem_public_key,
+    load_pem_parameters=load_pem_parameters,
+    load_der_private_key=load_der_private_key,
+    load_der_public_key=load_der_public_key,
+    load_der_parameters=load_der_parameters,
+)

--- a/larky/src/main/resources/vendor/cryptography/hazmat/primitives/serialization/pkcs12.star
+++ b/larky/src/main/resources/vendor/cryptography/hazmat/primitives/serialization/pkcs12.star
@@ -1,0 +1,73 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+load("@stdlib//larky", larky="larky")
+load("@stdlib//types", types="types")
+load("@stdlib//builtins", builtins="builtins")
+load("@vendor//cryptography/x509", x509="x509")
+load("@vendor//cryptography/hazmat/backends", backends="backends")
+load("@vendor//cryptography/hazmat/primitives", serialization="serialization")
+load("@vendor//cryptography/hazmat/primitives/asymmetric",
+     rsa="rsa",
+     # dsa="dsa",
+     # ec="ec",
+     )
+load("@vendor//option/result", Error="Error")
+
+
+_get_backend = backends._get_backend
+
+
+# type: Union[rsa.RSAPrivateKey, dsa.DSAPrivateKey, ec.EllipticCurvePrivateKey]
+
+
+def load_key_and_certificates(
+    data,
+    password,
+    backend = None,
+):
+    backend = _get_backend(backend)
+    return backend.load_key_and_certificates_from_pkcs12(data, password)
+
+
+def serialize_key_and_certificates(
+    name,
+    key,
+    cert,
+    cas,
+    encryption_algorithm,
+):
+    if key != None and not any([
+        builtins.isinstance(key, rsa.RSAPrivateKey),
+        # TODO(mahmoudimus: do this.
+        # builtins.isinstance(key, dsa.DSAPrivateKey),
+        # builtins.isinstance(key, ec.EllipticCurvePrivateKey),
+    ]):
+        fail("TypeError: Key must be RSA, DSA, or EllipticCurve private key.")
+    if cert != None and not builtins.isinstance(cert, x509.Certificate):
+        fail("TypeError: cert must be a certificate")
+
+    if cas != None:
+        cas = list(cas)
+        if not all([builtins.isinstance(val, x509.Certificate) for val in cas]):
+            fail("TypeError: all values in cas must be certificates")
+
+    if not encryption_algorithm:
+        fail("Key encryption algorithm must be a " +
+             "KeySerializationEncryption instance")
+
+    if key == None and cert == None and not cas:
+        fail("ValueError: You must supply at least one of " +
+             "key, cert, or cas")
+
+    backend = _get_backend(None)
+    return backend.serialize_key_and_certificates_to_pkcs12(
+        name, key, cert, cas, encryption_algorithm
+    )
+
+
+pkcs12 = larky.struct(
+    __name__='pkcs12',
+    load_key_and_certificates=load_key_and_certificates,
+    serialize_key_and_certificates=serialize_key_and_certificates,
+)

--- a/larky/src/main/resources/vendor/cryptography/hazmat/primitives/serialization/pkcs7.star
+++ b/larky/src/main/resources/vendor/cryptography/hazmat/primitives/serialization/pkcs7.star
@@ -1,0 +1,174 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+load("@stdlib//enum", Enum="Enum")
+load("@stdlib//types", types="types")
+load("@stdlib//larky", larky="larky")
+load("@stdlib//builtins", builtins="builtins")
+load("@vendor//cryptography/x509", x509="x509")
+load("@vendor//cryptography/utils", utils="utils")
+load("@vendor//cryptography/hazmat/backends", backends="backends")
+load("@vendor//cryptography/hazmat/primitives",
+     hashes="hashes",
+     serialization="serialization")
+load("@vendor//cryptography/hazmat/primitives/asymmetric",
+     rsa="rsa",
+     #ec="ec",
+     )
+load("@vendor//option/result", Error="Error")
+
+
+_get_backend= backends._get_backend
+_check_byteslike = utils._check_byteslike
+
+
+def load_pem_pkcs7_certificates(data):
+    backend = _get_backend(None)
+    return backend.load_pem_pkcs7_certificates(data)
+
+
+def load_der_pkcs7_certificates(data):
+    backend = _get_backend(None)
+    return backend.load_der_pkcs7_certificates(data)
+
+
+# _ALLOWED_PKCS7_HASH_TYPES = typing.Union[
+#     hashes.SHA1,
+#     hashes.SHA224,
+#     hashes.SHA256,
+#     hashes.SHA384,
+#     hashes.SHA512,
+# ]
+
+# _ALLOWED_PRIVATE_KEY_TYPES = typing.Union[rsa.RSAPrivateKey, ec.EllipticCurvePrivateKey]
+
+PKCS7Options = enum.Enum('PKCS7Options', dict(
+    Text="Add text/plain MIME type",
+    Binary="Don't translate input data into canonical MIME format",
+    DetachedSignature="Don't embed data in the PKCS7 structure",
+    NoCapabilities="Don't embed SMIME capabilities",
+    NoAttributes="Don't embed authenticatedAttributes",
+    NoCerts="Don't embed signer certificate",
+).items())
+
+
+def PKCS7SignatureBuilder(data=None, signers=None, additional_certs=None):
+    self = larky.mutablestruct(__name__='PKCS7SignatureBuilder',
+                               __class__=PKCS7SignatureBuilder)
+
+    def __init__(data, signers, additional_certs):
+        self._data = data
+        self._signers = signers or []
+        self._additional_certs = additional_certs or []
+        return self
+    self = __init__(data, signers, additional_certs)
+
+    def set_data(data):
+        _check_byteslike("data", data)
+        if self._data != None:
+            fail("ValueError: data may only be set once")
+
+        return PKCS7SignatureBuilder(data, self._signers)
+    self.set_data = set_data
+
+    def add_signer(
+        certificate,
+        private_key,
+        hash_algorithm,
+    ):
+        if not any(
+                [builtins.isinstance(hash_algorithm, x)
+                 for x in (
+                        hashes.SHA1,
+                        hashes.SHA224,
+                        hashes.SHA256,
+                        hashes.SHA384,
+                        hashes.SHA512,
+                     )
+                 ]
+        ):
+            fail("hash_algorithm must be one of hashes.SHA1, SHA224, " +
+                 "SHA256, SHA384, or SHA512")
+        if not builtins.isinstance(certificate, x509.Certificate):
+            return Error("TypeError: certificate must be a x509.Certificate")
+
+        if not any([
+            builtins.isinstance(private_key, x) for x in
+            (
+                    rsa.RSAPrivateKey,
+                    # ec.EllipticCurvePrivateKey
+            )]):
+            fail("TypeError: Only RSA & EC keys are supported at this time.")
+
+        return PKCS7SignatureBuilder(
+            self._data,
+            self._signers + [(certificate, private_key, hash_algorithm)],
+        )
+    self.add_signer = add_signer
+
+    def add_certificate(certificate):
+        if not builtins.isinstance(certificate, x509.Certificate):
+            fail("TypeError: certificate must be a x509.Certificate")
+
+        return PKCS7SignatureBuilder(
+            self._data, self._signers, self._additional_certs + [certificate]
+        )
+    self.add_certificate = add_certificate
+
+    def sign(
+        encoding,
+        options,
+        backend = None,
+    ):
+        if len(self._signers) == 0:
+            fail("ValueError: Must have at least one signer")
+        if self._data == None:
+            fail("ValueError: You must add data to sign")
+        options = list(options)
+        if not all([builtins.isinstance(x, PKCS7Options) for x in options]):
+            fail("ValueError: options must be from the PKCS7Options enum")
+        if encoding not in (
+            serialization.Encoding.PEM,
+            serialization.Encoding.DER,
+            serialization.Encoding.SMIME,
+        ):
+            fail("ValueError: Must be PEM, DER, or SMIME from the Encoding enum")
+
+        # Text is a meaningless option unless it is accompanied by
+        # DetachedSignature
+        if (
+            PKCS7Options.Text in options
+            and PKCS7Options.DetachedSignature not in options
+        ):
+            fail("When passing the Text option you must also pass " +
+                 "DetachedSignature")
+
+        if PKCS7Options.Text in options and encoding in (
+            serialization.Encoding.DER,
+            serialization.Encoding.PEM,
+        ):
+            fail("ValueError: The Text option is only available " +
+                 "for SMIME serialization")
+
+        # No attributes implies no capabilities so we'll error if you try to
+        # pass both.
+        if (
+            PKCS7Options.NoAttributes in options
+            and PKCS7Options.NoCapabilities in options
+        ):
+            fail("NoAttributes is a superset of NoCapabilities. Do not pass " +
+                 "both values.")
+
+        backend = _get_backend(backend)
+        return backend.pkcs7_sign(self, encoding, options)
+    self.sign = sign
+    return self
+
+
+pkcs7 = larky.struct(
+    __name__='pkcs7',
+    load_pem_pkcs7_certificates=load_pem_pkcs7_certificates,
+    load_der_pkcs7_certificates=load_der_pkcs7_certificates,
+    PKCS7SignatureBuilder=PKCS7SignatureBuilder,
+    PKCS7Options=PKCS7Options
+)

--- a/larky/src/main/resources/vendor/cryptography/hazmat/primitives/serialization/ssh.star
+++ b/larky/src/main/resources/vendor/cryptography/hazmat/primitives/serialization/ssh.star
@@ -1,0 +1,11 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+load("@stdlib//larky", larky="larky")
+
+#      "load_ssh_private_key",
+#      "load_ssh_public_key",
+
+ssh = larky.struct(
+    __name__='ssh',
+)

--- a/larky/src/main/resources/vendor/cryptography/utils.star
+++ b/larky/src/main/resources/vendor/cryptography/utils.star
@@ -1,0 +1,39 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+load("@stdlib//larky", larky="larky")
+load("@stdlib//types", types="types")
+load("@stdlib//builtins", builtins="builtins")
+load("@vendor//Crypto/Util/number", bytes_to_long="bytes_to_long", long_to_bytes="long_to_bytes")
+
+
+def _check_bytes(name, value):
+    # type: (str, bytes) -> None
+    if not types.is_bytes(value):
+        fail("{} must be bytes".format(name))
+
+
+def _check_byteslike(name, value):
+    # type: (str, bytes) -> None
+    if not types.is_bytelike(value):
+        fail("{} must be bytes-like".format(name))
+
+
+int_from_bytes = bytes_to_long
+
+
+int_to_bytes = long_to_bytes
+
+
+def read_only_property(prop):
+    return larky.property(lambda : prop)
+
+
+utils = larky.struct(
+    __name__='utils',
+    _check_bytes=_check_bytes,
+    _check_byteslike=_check_byteslike,
+    int_from_bytes=bytes_to_long,
+    int_to_bytes=long_to_bytes,
+    read_only_property=read_only_property,
+)

--- a/larky/src/main/resources/vendor/cryptography/x509/__init__.star
+++ b/larky/src/main/resources/vendor/cryptography/x509/__init__.star
@@ -1,0 +1,275 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+load("@stdlib//larky", larky="larky")
+load("@vendor//cryptography/x509/certificate_transparency", _certificate_transparency="certificate_transparency")
+load("@vendor//cryptography/x509/base", _base="base")
+load("@vendor//cryptography/x509/extensions", _extensions="extensions")
+load("@vendor//cryptography/x509/general_name", _general_name="general_name")
+load("@vendor//cryptography/x509/name", _name="name")
+load("@vendor//cryptography/x509/oid", _oid="oid")
+
+# imports
+certificate_transparency = _certificate_transparency
+
+# base
+base = _base
+
+# AttributeNotFound = base.AttributeNotFound
+# Certificate = base.Certificate
+# CertificateBuilder = base.CertificateBuilder
+# CertificateRevocationList = base.CertificateRevocationList
+# CertificateRevocationListBuilder = base.CertificateRevocationListBuilder
+# CertificateSigningRequest = base.CertificateSigningRequest
+# CertificateSigningRequestBuilder = base.CertificateSigningRequestBuilder
+# InvalidVersion = base.InvalidVersion
+# RevokedCertificate = base.RevokedCertificate
+# RevokedCertificateBuilder = base.RevokedCertificateBuilder
+Version = base.Version
+load_der_x509_certificate = base.load_der_x509_certificate
+load_der_x509_crl = base.load_der_x509_crl
+load_der_x509_csr = base.load_der_x509_csr
+load_pem_x509_certificate = base.load_pem_x509_certificate
+load_pem_x509_crl = base.load_pem_x509_crl
+load_pem_x509_csr = base.load_pem_x509_csr
+# random_serial_number = base.random_serial_number
+
+# extensions
+extensions = _extensions
+
+# AccessDescription = extensions.AccessDescription
+# AuthorityInformationAccess = extensions.AuthorityInformationAccess
+# AuthorityKeyIdentifier = extensions.AuthorityKeyIdentifier
+# BasicConstraints = extensions.BasicConstraints
+# CRLDistributionPoints = extensions.CRLDistributionPoints
+# CRLNumber = extensions.CRLNumber
+# CRLReason = extensions.CRLReason
+# CertificateIssuer = extensions.CertificateIssuer
+# CertificatePolicies = extensions.CertificatePolicies
+# DeltaCRLIndicator = extensions.DeltaCRLIndicator
+# DistributionPoint = extensions.DistributionPoint
+# DuplicateExtension = extensions.DuplicateExtension
+# ExtendedKeyUsage = extensions.ExtendedKeyUsage
+# Extension = extensions.Extension
+# ExtensionNotFound = extensions.ExtensionNotFound
+# ExtensionType = extensions.ExtensionType
+# Extensions = extensions.Extensions
+# FreshestCRL = extensions.FreshestCRL
+# GeneralNames = extensions.GeneralNames
+# InhibitAnyPolicy = extensions.InhibitAnyPolicy
+# InvalidityDate = extensions.InvalidityDate
+# IssuerAlternativeName = extensions.IssuerAlternativeName
+# IssuingDistributionPoint = extensions.IssuingDistributionPoint
+# KeyUsage = extensions.KeyUsage
+# NameConstraints = extensions.NameConstraints
+# NoticeReference = extensions.NoticeReference
+# OCSPNoCheck = extensions.OCSPNoCheck
+# OCSPNonce = extensions.OCSPNonce
+# PolicyConstraints = extensions.PolicyConstraints
+# PolicyInformation = extensions.PolicyInformation
+# PrecertPoison = extensions.PrecertPoison
+# PrecertificateSignedCertificateTimestamps = extensions.PrecertificateSignedCertificateTimestamps
+# ReasonFlags = extensions.ReasonFlags
+# SignedCertificateTimestamps = extensions.SignedCertificateTimestamps
+# SubjectAlternativeName = extensions.SubjectAlternativeName
+# SubjectInformationAccess = extensions.SubjectInformationAccess
+# SubjectKeyIdentifier = extensions.SubjectKeyIdentifier
+# TLSFeature = extensions.TLSFeature
+# TLSFeatureType = extensions.TLSFeatureType
+# UnrecognizedExtension = extensions.UnrecognizedExtension
+# UserNotice = extensions.UserNotice
+
+
+# general name
+general_name = _general_name
+
+# DNSName = general_name.DNSName
+# DirectoryName = general_name.DirectoryName
+# GeneralName = general_name.GeneralName
+# IPAddress = general_name.IPAddress
+# OtherName = general_name.OtherName
+# RFC822Name = general_name.RFC822Name
+# RegisteredID = general_name.RegisteredID
+# UniformResourceIdentifier = general_name.UniformResourceIdentifier
+# UnsupportedGeneralNameType = general_name.UnsupportedGeneralNameType
+# _GENERAL_NAMES = general_name._GENERAL_NAMES
+
+
+# name
+name = _name
+
+# Name = name.Name
+# NameAttribute = name.NameAttribute
+# RelativeDistinguishedName = name.RelativeDistinguishedName
+
+
+# oid
+oid = _oid
+
+AuthorityInformationAccessOID = oid.AuthorityInformationAccessOID
+CRLEntryExtensionOID = oid.CRLEntryExtensionOID
+CertificatePoliciesOID = oid.CertificatePoliciesOID
+ExtendedKeyUsageOID = oid.ExtendedKeyUsageOID
+ExtensionOID = oid.ExtensionOID
+NameOID = oid.NameOID
+ObjectIdentifier = oid.ObjectIdentifier
+SignatureAlgorithmOID = oid.SignatureAlgorithmOID
+_SIG_OIDS_TO_HASH = oid._SIG_OIDS_TO_HASH
+
+OID_AUTHORITY_INFORMATION_ACCESS = ExtensionOID.AUTHORITY_INFORMATION_ACCESS
+OID_AUTHORITY_KEY_IDENTIFIER = ExtensionOID.AUTHORITY_KEY_IDENTIFIER
+OID_BASIC_CONSTRAINTS = ExtensionOID.BASIC_CONSTRAINTS
+OID_CERTIFICATE_POLICIES = ExtensionOID.CERTIFICATE_POLICIES
+OID_CRL_DISTRIBUTION_POINTS = ExtensionOID.CRL_DISTRIBUTION_POINTS
+OID_EXTENDED_KEY_USAGE = ExtensionOID.EXTENDED_KEY_USAGE
+OID_FRESHEST_CRL = ExtensionOID.FRESHEST_CRL
+OID_INHIBIT_ANY_POLICY = ExtensionOID.INHIBIT_ANY_POLICY
+OID_ISSUER_ALTERNATIVE_NAME = ExtensionOID.ISSUER_ALTERNATIVE_NAME
+OID_KEY_USAGE = ExtensionOID.KEY_USAGE
+OID_NAME_CONSTRAINTS = ExtensionOID.NAME_CONSTRAINTS
+OID_OCSP_NO_CHECK = ExtensionOID.OCSP_NO_CHECK
+OID_POLICY_CONSTRAINTS = ExtensionOID.POLICY_CONSTRAINTS
+OID_POLICY_MAPPINGS = ExtensionOID.POLICY_MAPPINGS
+OID_SUBJECT_ALTERNATIVE_NAME = ExtensionOID.SUBJECT_ALTERNATIVE_NAME
+OID_SUBJECT_DIRECTORY_ATTRIBUTES = ExtensionOID.SUBJECT_DIRECTORY_ATTRIBUTES
+OID_SUBJECT_INFORMATION_ACCESS = ExtensionOID.SUBJECT_INFORMATION_ACCESS
+OID_SUBJECT_KEY_IDENTIFIER = ExtensionOID.SUBJECT_KEY_IDENTIFIER
+
+OID_DSA_WITH_SHA1 = SignatureAlgorithmOID.DSA_WITH_SHA1
+OID_DSA_WITH_SHA224 = SignatureAlgorithmOID.DSA_WITH_SHA224
+OID_DSA_WITH_SHA256 = SignatureAlgorithmOID.DSA_WITH_SHA256
+OID_ECDSA_WITH_SHA1 = SignatureAlgorithmOID.ECDSA_WITH_SHA1
+OID_ECDSA_WITH_SHA224 = SignatureAlgorithmOID.ECDSA_WITH_SHA224
+OID_ECDSA_WITH_SHA256 = SignatureAlgorithmOID.ECDSA_WITH_SHA256
+OID_ECDSA_WITH_SHA384 = SignatureAlgorithmOID.ECDSA_WITH_SHA384
+OID_ECDSA_WITH_SHA512 = SignatureAlgorithmOID.ECDSA_WITH_SHA512
+OID_RSA_WITH_MD5 = SignatureAlgorithmOID.RSA_WITH_MD5
+OID_RSA_WITH_SHA1 = SignatureAlgorithmOID.RSA_WITH_SHA1
+OID_RSA_WITH_SHA224 = SignatureAlgorithmOID.RSA_WITH_SHA224
+OID_RSA_WITH_SHA256 = SignatureAlgorithmOID.RSA_WITH_SHA256
+OID_RSA_WITH_SHA384 = SignatureAlgorithmOID.RSA_WITH_SHA384
+OID_RSA_WITH_SHA512 = SignatureAlgorithmOID.RSA_WITH_SHA512
+OID_RSASSA_PSS = SignatureAlgorithmOID.RSASSA_PSS
+
+OID_COMMON_NAME = NameOID.COMMON_NAME
+OID_COUNTRY_NAME = NameOID.COUNTRY_NAME
+OID_DOMAIN_COMPONENT = NameOID.DOMAIN_COMPONENT
+OID_DN_QUALIFIER = NameOID.DN_QUALIFIER
+OID_EMAIL_ADDRESS = NameOID.EMAIL_ADDRESS
+OID_GENERATION_QUALIFIER = NameOID.GENERATION_QUALIFIER
+OID_GIVEN_NAME = NameOID.GIVEN_NAME
+OID_LOCALITY_NAME = NameOID.LOCALITY_NAME
+OID_ORGANIZATIONAL_UNIT_NAME = NameOID.ORGANIZATIONAL_UNIT_NAME
+OID_ORGANIZATION_NAME = NameOID.ORGANIZATION_NAME
+OID_PSEUDONYM = NameOID.PSEUDONYM
+OID_SERIAL_NUMBER = NameOID.SERIAL_NUMBER
+OID_STATE_OR_PROVINCE_NAME = NameOID.STATE_OR_PROVINCE_NAME
+OID_SURNAME = NameOID.SURNAME
+OID_TITLE = NameOID.TITLE
+
+OID_CLIENT_AUTH = ExtendedKeyUsageOID.CLIENT_AUTH
+OID_CODE_SIGNING = ExtendedKeyUsageOID.CODE_SIGNING
+OID_EMAIL_PROTECTION = ExtendedKeyUsageOID.EMAIL_PROTECTION
+OID_OCSP_SIGNING = ExtendedKeyUsageOID.OCSP_SIGNING
+OID_SERVER_AUTH = ExtendedKeyUsageOID.SERVER_AUTH
+OID_TIME_STAMPING = ExtendedKeyUsageOID.TIME_STAMPING
+
+OID_ANY_POLICY = CertificatePoliciesOID.ANY_POLICY
+OID_CPS_QUALIFIER = CertificatePoliciesOID.CPS_QUALIFIER
+OID_CPS_USER_NOTICE = CertificatePoliciesOID.CPS_USER_NOTICE
+
+OID_CERTIFICATE_ISSUER = CRLEntryExtensionOID.CERTIFICATE_ISSUER
+OID_CRL_REASON = CRLEntryExtensionOID.CRL_REASON
+OID_INVALIDITY_DATE = CRLEntryExtensionOID.INVALIDITY_DATE
+
+OID_CA_ISSUERS = AuthorityInformationAccessOID.CA_ISSUERS
+OID_OCSP = AuthorityInformationAccessOID.OCSP
+
+
+x509 = larky.struct(
+    __name__='x509',
+    certificate_transparency=certificate_transparency,
+    base=base,
+    Version=Version,
+    load_pem_x509_certificate=load_pem_x509_certificate,
+    load_der_x509_certificate=load_der_x509_certificate,
+    load_pem_x509_csr=load_pem_x509_csr,
+    load_der_x509_csr=load_der_x509_csr,
+    load_pem_x509_crl=load_pem_x509_crl,
+    load_der_x509_crl=load_der_x509_crl,
+    extensions=extensions,
+    general_name=general_name,
+    name=name,
+    oid=oid,
+    AuthorityInformationAccessOID=AuthorityInformationAccessOID,
+    CRLEntryExtensionOID=CRLEntryExtensionOID,
+    CertificatePoliciesOID=CertificatePoliciesOID,
+    ExtendedKeyUsageOID=ExtendedKeyUsageOID,
+    ExtensionOID=ExtensionOID,
+    NameOID=NameOID,
+    ObjectIdentifier=ObjectIdentifier,
+    SignatureAlgorithmOID=SignatureAlgorithmOID,
+    _SIG_OIDS_TO_HASH=_SIG_OIDS_TO_HASH,
+    OID_AUTHORITY_INFORMATION_ACCESS=OID_AUTHORITY_INFORMATION_ACCESS,
+    OID_AUTHORITY_KEY_IDENTIFIER=OID_AUTHORITY_KEY_IDENTIFIER,
+    OID_BASIC_CONSTRAINTS=OID_BASIC_CONSTRAINTS,
+    OID_CERTIFICATE_POLICIES=OID_CERTIFICATE_POLICIES,
+    OID_CRL_DISTRIBUTION_POINTS=OID_CRL_DISTRIBUTION_POINTS,
+    OID_EXTENDED_KEY_USAGE=OID_EXTENDED_KEY_USAGE,
+    OID_FRESHEST_CRL=OID_FRESHEST_CRL,
+    OID_INHIBIT_ANY_POLICY=OID_INHIBIT_ANY_POLICY,
+    OID_ISSUER_ALTERNATIVE_NAME=OID_ISSUER_ALTERNATIVE_NAME,
+    OID_KEY_USAGE=OID_KEY_USAGE,
+    OID_NAME_CONSTRAINTS=OID_NAME_CONSTRAINTS,
+    OID_OCSP_NO_CHECK=OID_OCSP_NO_CHECK,
+    OID_POLICY_CONSTRAINTS=OID_POLICY_CONSTRAINTS,
+    OID_POLICY_MAPPINGS=OID_POLICY_MAPPINGS,
+    OID_SUBJECT_ALTERNATIVE_NAME=OID_SUBJECT_ALTERNATIVE_NAME,
+    OID_SUBJECT_DIRECTORY_ATTRIBUTES=OID_SUBJECT_DIRECTORY_ATTRIBUTES,
+    OID_SUBJECT_INFORMATION_ACCESS=OID_SUBJECT_INFORMATION_ACCESS,
+    OID_SUBJECT_KEY_IDENTIFIER=OID_SUBJECT_KEY_IDENTIFIER,
+    OID_DSA_WITH_SHA1=OID_DSA_WITH_SHA1,
+    OID_DSA_WITH_SHA224=OID_DSA_WITH_SHA224,
+    OID_DSA_WITH_SHA256=OID_DSA_WITH_SHA256,
+    OID_ECDSA_WITH_SHA1=OID_ECDSA_WITH_SHA1,
+    OID_ECDSA_WITH_SHA224=OID_ECDSA_WITH_SHA224,
+    OID_ECDSA_WITH_SHA256=OID_ECDSA_WITH_SHA256,
+    OID_ECDSA_WITH_SHA384=OID_ECDSA_WITH_SHA384,
+    OID_ECDSA_WITH_SHA512=OID_ECDSA_WITH_SHA512,
+    OID_RSA_WITH_MD5=OID_RSA_WITH_MD5,
+    OID_RSA_WITH_SHA1=OID_RSA_WITH_SHA1,
+    OID_RSA_WITH_SHA224=OID_RSA_WITH_SHA224,
+    OID_RSA_WITH_SHA256=OID_RSA_WITH_SHA256,
+    OID_RSA_WITH_SHA384=OID_RSA_WITH_SHA384,
+    OID_RSA_WITH_SHA512=OID_RSA_WITH_SHA512,
+    OID_RSASSA_PSS=OID_RSASSA_PSS,
+    OID_COMMON_NAME=OID_COMMON_NAME,
+    OID_COUNTRY_NAME=OID_COUNTRY_NAME,
+    OID_DOMAIN_COMPONENT=OID_DOMAIN_COMPONENT,
+    OID_DN_QUALIFIER=OID_DN_QUALIFIER,
+    OID_EMAIL_ADDRESS=OID_EMAIL_ADDRESS,
+    OID_GENERATION_QUALIFIER=OID_GENERATION_QUALIFIER,
+    OID_GIVEN_NAME=OID_GIVEN_NAME,
+    OID_LOCALITY_NAME=OID_LOCALITY_NAME,
+    OID_ORGANIZATIONAL_UNIT_NAME=OID_ORGANIZATIONAL_UNIT_NAME,
+    OID_ORGANIZATION_NAME=OID_ORGANIZATION_NAME,
+    OID_PSEUDONYM=OID_PSEUDONYM,
+    OID_SERIAL_NUMBER=OID_SERIAL_NUMBER,
+    OID_STATE_OR_PROVINCE_NAME=OID_STATE_OR_PROVINCE_NAME,
+    OID_SURNAME=OID_SURNAME,
+    OID_TITLE=OID_TITLE,
+    OID_CLIENT_AUTH=OID_CLIENT_AUTH,
+    OID_CODE_SIGNING=OID_CODE_SIGNING,
+    OID_EMAIL_PROTECTION=OID_EMAIL_PROTECTION,
+    OID_OCSP_SIGNING=OID_OCSP_SIGNING,
+    OID_SERVER_AUTH=OID_SERVER_AUTH,
+    OID_TIME_STAMPING=OID_TIME_STAMPING,
+    OID_ANY_POLICY=OID_ANY_POLICY,
+    OID_CPS_QUALIFIER=OID_CPS_QUALIFIER,
+    OID_CPS_USER_NOTICE=OID_CPS_USER_NOTICE,
+    OID_CERTIFICATE_ISSUER=OID_CERTIFICATE_ISSUER,
+    OID_CRL_REASON=OID_CRL_REASON,
+    OID_INVALIDITY_DATE=OID_INVALIDITY_DATE,
+    OID_CA_ISSUERS=OID_CA_ISSUERS,
+    OID_OCSP=OID_OCSP,
+)

--- a/larky/src/main/resources/vendor/cryptography/x509/_base.star
+++ b/larky/src/main/resources/vendor/cryptography/x509/_base.star
@@ -1,0 +1,13 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+load("@stdlib//enum", enum="enum")
+load("@stdlib//larky", larky="larky")
+
+# This exists to break an import cycle. These classes are normally accessible
+# from the serialization module.
+
+Version = enum.Enum('Version', [
+    ("v1", 0),
+    ("v3", 2),
+])

--- a/larky/src/main/resources/vendor/cryptography/x509/base.star
+++ b/larky/src/main/resources/vendor/cryptography/x509/base.star
@@ -1,0 +1,54 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+load("@stdlib//enum", enum="enum")
+load("@stdlib//larky", larky="larky")
+load("@vendor//cryptography/x509/_base", _Version="Version")
+load("@vendor//cryptography/hazmat/backends", backends="backends")
+
+load("@vendor//option/result", Error="Error")
+
+_get_backend = backends._get_backend
+Version = _Version
+
+
+def load_pem_x509_certificate(data, backend=None):
+    backend = _get_backend(backend)
+    return backend.load_pem_x509_certificate(data)
+
+
+def load_der_x509_certificate(data, backend=None):
+    backend = _get_backend(backend)
+    return backend.load_der_x509_certificate(data)
+
+
+def load_pem_x509_csr(data, backend=None):
+    backend = _get_backend(backend)
+    return backend.load_pem_x509_csr(data)
+
+
+def load_der_x509_csr(data, backend=None):
+    backend = _get_backend(backend)
+    return backend.load_der_x509_csr(data)
+
+
+def load_pem_x509_crl(data, backend=None):
+    backend = _get_backend(backend)
+    return backend.load_pem_x509_crl(data)
+
+
+def load_der_x509_crl(data, backend=None):
+    backend = _get_backend(backend)
+    return backend.load_der_x509_crl(data)
+
+
+base = larky.struct(
+    __name__='base',
+    Version=Version,
+    load_pem_x509_certificate=load_pem_x509_certificate,
+    load_der_x509_certificate=load_der_x509_certificate,
+    load_pem_x509_csr=load_pem_x509_csr,
+    load_der_x509_csr=load_der_x509_csr,
+    load_pem_x509_crl=load_pem_x509_crl,
+    load_der_x509_crl=load_der_x509_crl,
+)

--- a/larky/src/main/resources/vendor/cryptography/x509/certificate_transparency.star
+++ b/larky/src/main/resources/vendor/cryptography/x509/certificate_transparency.star
@@ -1,0 +1,52 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+load("@stdlib//enum", enum="enum")
+load("@stdlib//larky", larky="larky")
+
+
+LogEntryType = enum.Enum('LogEntryType', dict(
+    X509_CERTIFICATE = 0,
+    PRE_CERTIFICATE = 1
+).items())
+
+
+Version = enum.Enum('Version', [('v1', 0)])
+
+
+def SignedCertificateTimestamp():
+    self = larky.mutablestruct(__name__='SignedCertificateTimestamp',
+                               __class__=SignedCertificateTimestamp)
+
+    def version():
+        """
+        Returns the SCT version.
+        """
+    self.version = version
+
+    def log_id():
+        """
+        Returns an identifier indicating which log this SCT is for.
+        """
+    self.log_id = log_id
+
+    def timestamp():
+        """
+        Returns the timestamp for this SCT.
+        """
+    self.timestamp = timestamp
+
+    def entry_type():
+        """
+        Returns whether this is an SCT for a certificate or pre-certificate.
+        """
+    self.entry_type = entry_type
+    return self
+
+
+certificate_transparency = larky.struct(
+    __name__='certificate_transparency',
+    LogEntryType=LogEntryType,
+    Version=Version,
+    SignedCertificateTimestamp=SignedCertificateTimestamp,
+)

--- a/larky/src/main/resources/vendor/cryptography/x509/extensions.star
+++ b/larky/src/main/resources/vendor/cryptography/x509/extensions.star
@@ -1,0 +1,9 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+load("@stdlib//larky", larky="larky")
+
+
+extensions = larky.struct(
+    __name__='extensions',
+)

--- a/larky/src/main/resources/vendor/cryptography/x509/general_name.star
+++ b/larky/src/main/resources/vendor/cryptography/x509/general_name.star
@@ -1,0 +1,9 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+load("@stdlib//larky", larky="larky")
+
+
+general_name = larky.struct(
+    __name__='general_name',
+)

--- a/larky/src/main/resources/vendor/cryptography/x509/name.star
+++ b/larky/src/main/resources/vendor/cryptography/x509/name.star
@@ -1,0 +1,83 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+load("@stdlib//enum", enum="enum")
+load("@stdlib//larky", larky="larky")
+load("@vendor//cryptography/hazmat/backends", backends="backends")
+load("@vendor//cryptography/x509/oid", NameOID="NameOID", ObjectIdentifier="ObjectIdentifier")
+
+
+_ASN1Type = enum.Enum('_ASN1Type', [
+    ("UTF8String", 12),
+    ("NumericString", 18),
+    ("PrintableString", 19),
+    ("T61String", 20),
+    ("IA5String", 22),
+    ("UTCTime", 23),
+    ("GeneralizedTime", 24),
+    ("VisibleString", 26),
+    ("UniversalString", 28),
+    ("BMPString", 30),
+])
+
+
+_ASN1_TYPE_TO_ENUM = _ASN1Type._value2member_map_
+_SENTINEL = larky.SENTINEL
+_NAMEOID_DEFAULT_TYPE = {
+    NameOID.COUNTRY_NAME: _ASN1Type.PrintableString,
+    NameOID.JURISDICTION_COUNTRY_NAME: _ASN1Type.PrintableString,
+    NameOID.SERIAL_NUMBER: _ASN1Type.PrintableString,
+    NameOID.DN_QUALIFIER: _ASN1Type.PrintableString,
+    NameOID.EMAIL_ADDRESS: _ASN1Type.IA5String,
+    NameOID.DOMAIN_COMPONENT: _ASN1Type.IA5String,
+}
+
+#: Short attribute names from RFC 4514:
+#: https://tools.ietf.org/html/rfc4514#page-7
+_NAMEOID_TO_NAME = {
+    NameOID.COMMON_NAME: "CN",
+    NameOID.LOCALITY_NAME: "L",
+    NameOID.STATE_OR_PROVINCE_NAME: "ST",
+    NameOID.ORGANIZATION_NAME: "O",
+    NameOID.ORGANIZATIONAL_UNIT_NAME: "OU",
+    NameOID.COUNTRY_NAME: "C",
+    NameOID.STREET_ADDRESS: "STREET",
+    NameOID.DOMAIN_COMPONENT: "DC",
+    NameOID.USER_ID: "UID",
+    NameOID.EMAIL_ADDRESS: "E",
+}
+
+
+def _escape_dn_value(val):
+    """Escape special characters in RFC4514 Distinguished Name value."""
+
+    if not val:
+        return ""
+
+    # See https://tools.ietf.org/html/rfc4514#section-2.4
+    val = val.replace("\\", "\\\\")
+    val = val.replace('"', '\\"')
+    val = val.replace("+", "\\+")
+    val = val.replace(",", "\\,")
+    val = val.replace(";", "\\;")
+    val = val.replace("<", "\\<")
+    val = val.replace(">", "\\>")
+    val = val.replace("\0", "\\00")
+
+    if val[0] in ("#", " "):
+        val = "\\" + val
+    if val[-1] == " ":
+        val = val[:-1] + "\\ "
+
+    return val
+
+
+name = larky.struct(
+    __name__='name',
+    _ASN1Type=_ASN1Type,
+    _ASN1_TYPE_TO_ENUM=_ASN1_TYPE_TO_ENUM,
+    _SENTINEL=_SENTINEL,
+    _NAMEOID_DEFAULT_TYPE=_NAMEOID_DEFAULT_TYPE,
+    _NAMEOID_TO_NAME=_NAMEOID_TO_NAME,
+    _escape_dn_value=_escape_dn_value,
+)

--- a/larky/src/main/resources/vendor/cryptography/x509/oid.star
+++ b/larky/src/main/resources/vendor/cryptography/x509/oid.star
@@ -1,0 +1,41 @@
+# This file is dual licensed under the terms of the Apache License, Version
+# 2.0, and the BSD License. See the LICENSE file in the root of this repository
+# for complete details.
+load("@stdlib//larky", larky="larky")
+
+load("@vendor//cryptography/hazmat/_oid", _oid="oid")
+
+
+ObjectIdentifier = _oid.ObjectIdentifier
+ExtensionOID = _oid.ExtensionOID
+OCSPExtensionOID = _oid.OCSPExtensionOID
+CRLEntryExtensionOID = _oid.CRLEntryExtensionOID
+NameOID = _oid.NameOID
+SignatureAlgorithmOID = _oid.SignatureAlgorithmOID
+
+_SIG_OIDS_TO_HASH = _oid._SIG_OIDS_TO_HASH
+
+ExtendedKeyUsageOID = _oid.ExtendedKeyUsageOID
+AuthorityInformationAccessOID = _oid.AuthorityInformationAccessOID
+SubjectInformationAccessOID = _oid.SubjectInformationAccessOID
+CertificatePoliciesOID = _oid.CertificatePoliciesOID
+AttributeOID = _oid.AttributeOID
+_OID_NAMES = _oid._OID_NAMES
+
+
+oid = larky.struct(
+    __name__="oid",
+    ObjectIdentifier=_oid.ObjectIdentifier,
+    ExtensionOID=_oid.ExtensionOID,
+    OCSPExtensionOID=_oid.OCSPExtensionOID,
+    CRLEntryExtensionOID=_oid.CRLEntryExtensionOID,
+    NameOID=_oid.NameOID,
+    SignatureAlgorithmOID=_oid.SignatureAlgorithmOID,
+    _SIG_OIDS_TO_HASH=_SIG_OIDS_TO_HASH,
+    ExtendedKeyUsageOID=_oid.ExtendedKeyUsageOID,
+    AuthorityInformationAccessOID=_oid.AuthorityInformationAccessOID,
+    SubjectInformationAccessOID=_oid.SubjectInformationAccessOID,
+    CertificatePoliciesOID=_oid.CertificatePoliciesOID,
+    AttributeOID=_oid.AttributeOID,
+    _OID_NAMES=_oid._OID_NAMES,
+)


### PR DESCRIPTION
**Stack**:
- #225
- #224
- #223
- #222
- #221
- #220
- #219
- #218
- #217
- #216
- #215
- #214
- #213
- #212
- #211
- #210
- #209
- #208
- #207
- #206
- #205
- #204
- #203
- #202
- #201


- More work getting pycryptodome interface to work with cryptography. It passes the tests.
- feat(compat): Port more files from pyca's cryptography to Larky