### PR TITLE
Update libstarlark to tip bazelbuild/master

### DIFF
--- a/bin/2022-03-30-differences-starlarkbytes.patch
+++ b/bin/2022-03-30-differences-starlarkbytes.patch
@@ -1,0 +1,8351 @@
+diff --git b/libstarlark/src/main/java/net/starlark/java/eval/Eval.java a/libstarlark/src/main/java/net/starlark/java/eval/Eval.java
+index 594afd97..d3eca897 100644
+--- b/libstarlark/src/main/java/net/starlark/java/eval/Eval.java
++++ a/libstarlark/src/main/java/net/starlark/java/eval/Eval.java
+@@ -26,6 +26,7 @@ import net.starlark.java.spelling.SpellChecker;
+ import net.starlark.java.syntax.Argument;
+ import net.starlark.java.syntax.AssignmentStatement;
+ import net.starlark.java.syntax.BinaryOperatorExpression;
++import net.starlark.java.syntax.ByteLiteral;
+ import net.starlark.java.syntax.CallExpression;
+ import net.starlark.java.syntax.Comprehension;
+ import net.starlark.java.syntax.ConditionalExpression;
+@@ -521,6 +522,8 @@ final class Eval {
+         return evalSlice(fr, (SliceExpression) expr);
+       case STRING_LITERAL:
+         return ((StringLiteral) expr).getValue();
++      case BYTE_LITERAL:
++        return evalByteLiteral(fr, (ByteLiteral) expr);
+       case UNARY_OPERATOR:
+         return evalUnaryOperator(fr, (UnaryOperatorExpression) expr);
+     }
+@@ -740,6 +743,11 @@ final class Eval {
+     return expr.isTuple() ? Tuple.wrap(array) : StarlarkList.wrap(fr.thread.mutability(), array);
+   }
+ 
++  private static Object evalByteLiteral(StarlarkThread.Frame fr, ByteLiteral expr)
++      throws EvalException, InterruptedException {
++    return StarlarkBytes.wrap(fr.thread.mutability(), expr.getValue());
++  }
++
+   private static Object evalSlice(StarlarkThread.Frame fr, SliceExpression slice)
+       throws EvalException, InterruptedException {
+     Object x = eval(fr, slice.getObject());
+diff --git b/libstarlark/src/main/java/net/starlark/java/eval/EvalUtils.java a/libstarlark/src/main/java/net/starlark/java/eval/EvalUtils.java
+index 6ef2755c..fd547a6f 100644
+--- b/libstarlark/src/main/java/net/starlark/java/eval/EvalUtils.java
++++ a/libstarlark/src/main/java/net/starlark/java/eval/EvalUtils.java
+@@ -13,6 +13,7 @@
+ // limitations under the License.
+ package net.starlark.java.eval;
+ 
++import com.google.common.base.Strings;
+ import java.util.IllegalFormatException;
+ import net.starlark.java.syntax.TokenKind;
+ 
+@@ -401,7 +402,10 @@ final class EvalUtils {
+       // Would exceed max length of a java String.
+       throw Starlark.errorf("excessive repeat (%d * %d characters)", s.length(), n);
+     } else {
+-      return s.repeat(n);
++      // We currently do not support JDK11 (for now), so we will avoid this:
++      // We can remove this once we are on JDK11.
++      // return s.repeat(n);
++      return Strings.repeat(s, n);
+     }
+   }
+ 
+diff --git b/libstarlark/src/main/java/net/starlark/java/eval/MethodLibrary.java a/libstarlark/src/main/java/net/starlark/java/eval/MethodLibrary.java
+index b23a3bb5..96fdd7e1 100644
+--- b/libstarlark/src/main/java/net/starlark/java/eval/MethodLibrary.java
++++ a/libstarlark/src/main/java/net/starlark/java/eval/MethodLibrary.java
+@@ -290,6 +290,76 @@ class MethodLibrary {
+     return Starlark.str(x);
+   }
+ 
++  @StarlarkMethod(
++      name = "bytes",
++      doc =
++        "<pre class=\"language-python\">bytes(x)</pre> converts its argument to a bytes.\n" +
++          "\n" +
++          "If x is a bytes, the result is x.\n" +
++          "\n" +
++          "If x is a string, the result is a bytes whose elements are the UTF-8 encoding of" +
++          " the string. Each element of the string that is not part of a valid encoding of " +
++          "a code point is replaced by the UTF-8 encoding of the replacement character, " +
++          "U+FFFD.\n" +
++          "\n" +
++          "If x is an iterable sequence of int values, the result is a bytes whose " +
++          "elements are those integers. It is an error if any element is not in the " +
++          "range 0-255.",
++      parameters = {@Param(name = "x", doc = "The object to convert.")})
++  public StarlarkBytes bytes(Object x) throws EvalException {
++    switch(Starlark.type(x)) {
++      case "bytes":
++        return (StarlarkBytes) x;
++      case "string":
++        return StarlarkBytes.immutableOf(((String) x).toCharArray());
++      default:
++        // nothing
++    }
++    if(x instanceof Sequence) {
++      Sequence<StarlarkInt> cast = Sequence.cast(
++        x,
++        StarlarkInt.class,
++        Starlark.str(x));
++      return StarlarkBytes.immutableCopyOf(cast);
++    }
++    throw Starlark.errorf("bytes: got %s, want string, bytes, or iterable of ints", Starlark.type(x));
++  }
++
++
++  @StarlarkMethod(
++       name = "ord",
++       doc = "Given a string representing one Unicode character, return an integer representing" +
++           " the Unicode code point of that character. For example, ord('a') returns the " +
++           "integer 97 and ord('€') (Euro sign) returns 8364. This is the inverse of chr().",
++       parameters = {
++           @Param(
++               name = "c",
++               allowedTypes = {
++                   @ParamType(type = String.class),
++                   @ParamType(type = StarlarkBytes.class),
++               }
++           )
++       }
++   )
++   public StarlarkInt ordinal(Object c) throws EvalException {
++     int containerSize;
++     CharSequence chars;
++     if (String.class.isAssignableFrom(c.getClass())) {
++       containerSize = ((String) c).length();
++       chars = ((String) c);
++     } else {
++       containerSize = ((StarlarkBytes) c).size();
++       chars = ((StarlarkBytes) c);
++     }
++
++     if (containerSize != 1) {
++       throw Starlark.errorf(
++           "ord: %s has length %d, want 1", Starlark.type(c), containerSize);
++     }
++
++    return StarlarkInt.of(Byte.toUnsignedInt((byte) chars.charAt(0)));
++  }
++
+   @StarlarkMethod(
+       name = "repr",
+       doc =
+@@ -528,15 +598,24 @@ class MethodLibrary {
+   @StarlarkMethod(
+       name = "hash",
+       doc =
+-          "Return a hash value for a string. This is computed deterministically using the same "
++          "Return a hash value for a string or bytes." +
++            "For strings, this is computed deterministically using the same "
+               + "algorithm as Java's <code>String.hashCode()</code>, namely: "
+               + "<pre class=\"language-python\">s[0] * (31^(n-1)) + s[1] * (31^(n-2)) + ... + "
+-              + "s[n-1]</pre> Hashing of values besides strings is not currently supported.",
++              + "s[n-1]</pre>.\n" +
++            "For bytes, this is computed using the Fnv32 hash function.\n" +
++            "Hashing of values besides strings or bytes is not currently supported.",
+       // Deterministic hashing is important for the consistency of builds, hence why we
+       // promise a specific algorithm. This is in contrast to Java (Object.hashCode()) and
+       // Python, which promise stable hashing only within a given execution of the program.
+-      parameters = {@Param(name = "value", doc = "String value to hash.")})
+-  public int hash(String value) throws EvalException {
++      parameters = {
++        @Param(name = "value", doc = "String value to hash.",
++        allowedTypes = {
++          @ParamType(type = String.class),
++          @ParamType(type = StarlarkBytes.class),
++        })
++      })
++  public int hash(Object value) throws EvalException {
+     return value.hashCode();
+   }
+ 
+diff --git b/libstarlark/src/main/java/net/starlark/java/eval/Starlark.java a/libstarlark/src/main/java/net/starlark/java/eval/Starlark.java
+index c014a11e..75a62fb9 100644
+--- b/libstarlark/src/main/java/net/starlark/java/eval/Starlark.java
++++ a/libstarlark/src/main/java/net/starlark/java/eval/Starlark.java
+@@ -293,6 +293,8 @@ public final class Starlark {
+     // Check for "direct hits" first to avoid needing to scan for annotations.
+     if (c.equals(String.class)) {
+       return "string";
++    } else if (c.equals(StarlarkBytes.class) || c.equals(StarlarkBytes.StarlarkByte.class)) {
++      return "bytes";
+     } else if (StarlarkInt.class.isAssignableFrom(c)) {
+       return "int";
+     } else if (c.equals(Boolean.class)) {
+@@ -306,6 +308,8 @@ public final class Starlark {
+     // but `getStarlarkBuiltin` is quite expensive.
+     if (c.equals(StarlarkList.class)) {
+       return "list";
++    } else if (c.equals(StarlarkBytes.StarlarkByteArray.class)) {
++      return "bytearray";
+     } else if (c.equals(Tuple.class)) {
+       return "tuple";
+     } else if (c.equals(Dict.class)) {
+diff --git b/libstarlark/src/main/java/net/starlark/java/eval/StarlarkBytes.java a/libstarlark/src/main/java/net/starlark/java/eval/StarlarkBytes.java
+new file mode 100644
+index 00000000..b2527368
+--- /dev/null
++++ a/libstarlark/src/main/java/net/starlark/java/eval/StarlarkBytes.java
+@@ -0,0 +1,1677 @@
++package net.starlark.java.eval;
++
++import com.google.common.base.Strings;
++import com.google.common.collect.Iterables;
++import com.google.common.collect.Range;
++import com.google.common.collect.UnmodifiableListIterator;
++import com.google.common.primitives.UnsignedBytes;
++import java.nio.ByteBuffer;
++import java.nio.CharBuffer;
++import java.nio.charset.CharacterCodingException;
++import java.nio.charset.Charset;
++import java.nio.charset.StandardCharsets;
++import java.util.AbstractList;
++import java.util.ArrayList;
++import java.util.Arrays;
++import java.util.Collection;
++import java.util.Iterator;
++import java.util.List;
++import java.util.ListIterator;
++import java.util.function.UnaryOperator;
++import java.util.stream.Collectors;
++
++import net.starlark.java.annot.Param;
++import net.starlark.java.annot.ParamType;
++import net.starlark.java.annot.StarlarkBuiltin;
++import net.starlark.java.annot.StarlarkMethod;
++import net.starlark.java.ext.ByteList;
++import net.starlark.java.ext.ByteStringModuleApi;
++import net.starlark.java.syntax.TokenKind;
++
++import org.jetbrains.annotations.NotNull;
++import org.jetbrains.annotations.Nullable;
++
++
++public class StarlarkBytes implements ByteStringModuleApi,
++                                        Sequence<StarlarkBytes>,
++                                        Comparable<StarlarkBytes>,
++                                        CharSequence,
++                                        HasBinary,
++                                        StarlarkValue {
++
++  public static class StarlarkByte extends StarlarkBytes implements HasBinary,
++                                                                    StarlarkValue,
++                                                                    Comparable<StarlarkBytes> {
++
++    final byte x;
++    private static final int OFFSET = 128;
++
++    private StarlarkByte(byte x) {
++      super(null, ByteList.wrap(x));
++      this.x = x;
++    } // cannot instantiate publicly.
++
++
++    private static class ByteCache {
++      static final StarlarkByte[] cache = new StarlarkByte[-(-OFFSET) + 127 + 1];
++
++      static {
++        for (int i = 0; i < cache.length; i++)
++          cache[i] = new StarlarkByte((byte) (i - OFFSET));
++      }
++
++      private ByteCache() {
++      }
++    }
++
++    public static StarlarkByte of(byte b) {
++      return ByteCache.cache[(int) b + OFFSET];
++    }
++
++    public static StarlarkByte of(int b) throws EvalException {
++      if(b >> Byte.SIZE != 0) {
++        throw Starlark.errorf("int in bytes: %s out of range", b);
++      }
++      return of((byte)b);
++    }
++
++    public static StarlarkByte of(StarlarkInt b) throws EvalException {
++      return of(b.toInt("StarlarkByte::of"));
++    }
++
++    @Override
++    public int compareTo(@NotNull StarlarkBytes o) {
++      //a negative integer, zero, or a positive integer as this object is less than, equal to, or greater than the specified object.
++      if(o.size() > 1) {
++        return -1; // if size is > 1 then it's bigger
++      }
++      else if (o.size() == 0) {
++        return 1;
++      }
++      byte ob = o.byteAt(0);
++
++      if (this.x == ob) {
++        return 0;
++      } else if (this.x < ob) {
++        return -1;
++      }
++      return 1;
++    }
++
++    public StarlarkInt toStarlarkInt() {
++      return StarlarkInt.of(toUnsigned());
++    }
++
++    public int toUnsigned() {
++      return Byte.toUnsignedInt(this.x);
++    }
++
++    public byte get() {
++      return this.x;
++    }
++
++    @Override
++    public void str(Printer printer) {
++      printer.append((char) x & 0xFF);
++    }
++
++    @Override
++    public void repr(Printer printer) {
++      printer.append(String.format("b\"%s\"", (char) x & 0xFF));
++    }
++
++    @Override
++    public boolean equals(Object o) {
++      // this is probably a hack --> the `StarlarkByte` class is really just a
++      // specialization of a 1-element StarlarkBytes sequence
++      if (!(o instanceof StarlarkBytes || o instanceof StarlarkInt)) {
++        return false;
++      } else if (this == o) {
++        return true;
++      } else if (o instanceof StarlarkByte) {
++        return this.compareTo((StarlarkByte) o) == 0;
++      } else if (o instanceof StarlarkInt) {
++        return ((StarlarkInt)o).compareTo(toStarlarkInt()) == 0;
++      } else {
++        StarlarkBytes sbo = ((StarlarkBytes) o);
++        if (sbo.size() != 1) {
++          return false;
++        }
++        return this.compareTo(StarlarkByte.of(sbo.byteAt(0))) == 0;
++      }
++    }
++
++    @Override
++    public boolean isImmutable() {
++      return true;
++    }
++
++    /**
++     * Returns a hash code for this {@code Byte}; equal to the result of invoking {@code
++     * intValue()}.
++     *
++     * @return a hash code value for this {@code Byte}
++     */
++    @Override
++    public int hashCode() {
++      return Byte.hashCode(x);
++    }
++
++    @Nullable
++    @Override
++    public Object binaryOp(TokenKind op, Object that, boolean thisLeft) throws EvalException {
++      try(Mutability mu = Mutability.create("StarlarkBytesBinaryOp")) {
++        StarlarkThread thread = new StarlarkThread(mu, StarlarkSemantics.DEFAULT);
++        return EvalUtils.binaryOp(op, toStarlarkInt(), that, thread);
++      }
++    }
++
++  }
++
++  public static class StarlarkByteArray extends StarlarkBytes {
++
++    private StarlarkByteArray(StarlarkBytes bytes) {
++      super(bytes.mutability, bytes.delegate);
++    }
++
++    private StarlarkByteArray(@Nullable Mutability mutability, ByteList elems) {
++      super(mutability, elems);
++    }
++
++    static StarlarkByteArray wrap(@Nullable Mutability mutability, ByteList elems) {
++      return new StarlarkByteArray(mutability, elems);
++    }
++
++    public static StarlarkByteArray of(Mutability mutability) {
++      return new StarlarkByteArray(mutability, ByteList.empty());
++    }
++
++    public static StarlarkByteArray of(StarlarkBytes sb) {
++      return new StarlarkByteArray(sb);
++    }
++
++    public static StarlarkByteArray of(@Nullable Mutability mutability, byte... elems) {
++      return StarlarkByteArray.of(StarlarkBytes.of(mutability, elems));
++    }
++    public static StarlarkByteArray of(@Nullable Mutability mutability, StarlarkInt... elems) {
++      return StarlarkByteArray.of(StarlarkBytes.of(mutability, elems));
++    }
++    public static StarlarkByteArray copyOf( @Nullable Mutability mutability, Iterable<StarlarkInt> elems) throws EvalException {
++      return StarlarkByteArray.of(StarlarkBytes.copyOf(mutability, elems));
++    }
++
++    @Override
++    public boolean isImmutable() {  // ByteArray is mutable
++      return false;
++    }
++
++    @Override
++    public StarlarkBytes set(int index, StarlarkBytes element) {
++      if(element.size() != 1) {
++        throw new IllegalArgumentException("Expected starlark element to be of size 1!");
++      }
++      return set(index, element.byteAt(0));
++    }
++
++    public StarlarkBytes set(int index, byte element) {
++     StarlarkBytes oldValue = get(index);
++     final byte oldValuePrimitive = this.delegate.setValue(index, element);
++     assert oldValuePrimitive== oldValue.byteAt(0);
++     return oldValue;
++    }
++
++    @Override
++    public void add(int index, StarlarkBytes element) {
++      this.delegate.addAll(index, element.delegate);
++    }
++
++    @Override
++    public boolean add(StarlarkBytes o) {
++      return this.delegate.extend(o.delegate);
++    }
++
++    @Override
++    public boolean addAll(@NotNull Collection<? extends StarlarkBytes> c) {
++      ensureNotFrozen();
++      boolean modified = false;
++      for (StarlarkBytes e : c) {
++        add(e);
++        modified = true;
++      }
++      return modified;
++    }
++
++    @Override
++    public boolean addAll(int index, @NotNull Collection<? extends StarlarkBytes> c) {
++      ensureNotFrozen();
++      int i = index;
++      for (StarlarkBytes e : c) {
++        add(i, e);
++        i++;
++      }
++      return i != index;
++    }
++
++    public boolean addAll(int index, byte[] c) {
++      ensureNotFrozen();
++      int i = index;
++      for (byte e : c) {
++        this.delegate.addValue(i,e);
++        i++;
++      }
++      return i != index;
++    }
++
++    @Override
++    public void replaceAll(UnaryOperator<StarlarkBytes> operator) {
++      for (int i = 0; i < this.delegate.size(); i++) {
++          this.set(i, operator.apply(this.get(i)));
++      }
++//      final ListIterator<StarlarkBytes> li = this.listIterator();
++//      while (li.hasNext()) {
++//          li.set(operator.apply(li.next()));
++//      }
++    }
++
++    public void replaceAll(StarlarkBytes bl) {
++      this.delegate.clear();
++      this.delegate.extend(bl.delegate);
++//      final ListIterator<StarlarkBytes> li = this.listIterator();
++//      while (li.hasNext()) {
++//          li.set(operator.apply(li.next()));
++//      }
++    }
++
++    @StarlarkMethod(
++         name = "append",
++         doc = "Adds an integer to the end of the byte array.",
++         parameters = {@Param(name = "item", doc = "Item to add at the end.")})
++    public void append(StarlarkInt item) throws EvalException {
++       this.add(StarlarkBytes.immutableOf(toByte(item.toInt("append"))));
++     }
++
++    @StarlarkMethod(name = "copy", doc = "Return a copy of bytearray.")
++    public StarlarkByteArray copy() throws EvalException {
++      return wrap(mutability, delegate);
++    }
++
++     @StarlarkMethod(
++         name = "extend",
++         doc = "Adds all items to the end of the list.",
++         parameters = {@Param(name = "items", doc = "Items to add at the end.")})
++     public void extend(StarlarkBytes items) throws EvalException {
++       this.addAll(items);
++     }
++
++     @StarlarkMethod(
++         name = "insert",
++         doc = "Inserts an item at a given position.",
++         parameters = {
++             @Param(name = "index", doc = "The index of the given position."),
++             @Param(name = "item", doc = "The item.")
++         })
++     public void insert(StarlarkInt index, StarlarkBytes item) throws EvalException {
++       this.addAll(index.toInt("insert"), item);
++     }
++
++    @Override
++    public void clear() {
++      this.delegate.clear();
++    }
++
++    @StarlarkMethod(name = "clear", doc = "Removes all the elements of the list.")
++     public void clearElements() throws EvalException {
++       this.clear();
++     }
++
++    @Override
++    public boolean remove(Object o) {
++      // Overridden for performance to prevent a ton of boxing
++      ensureNotFrozen();
++      if (!(o instanceof StarlarkBytes)) {
++        return false;
++      }
++      return this.delegate.remove(((StarlarkBytes)o).delegate);
++    }
++
++    @Override
++    public StarlarkBytes remove(int index) {
++      ensureNotFrozen();
++      return StarlarkBytes.immutableOf(this.delegate.removeAt(index));
++    }
++
++    @StarlarkMethod(
++         name = "pop",
++         doc =
++             "Removes the item at the given position in the list, and returns it. "
++                 + "If no <code>index</code> is specified, "
++                 + "it removes and returns the last item in the list.",
++         parameters = {
++             @Param(
++                 name = "i",
++                 allowedTypes = {
++                     @ParamType(type = StarlarkInt.class),
++                     @ParamType(type = NoneType.class),
++                 },
++                 defaultValue = "-1",
++                 doc = "The index of the item.")
++         })
++     public StarlarkInt pop(Object i) throws EvalException {
++       int arg = i == Starlark.NONE ? -1 : Starlark.toInt(i, "i");
++       return StarlarkInt.of(this.remove(arg).byteAt(0));
++     }
++
++    @StarlarkMethod(
++        name = "remove",
++        doc ="Remove the first occurrence of a value in the bytearray. ",
++        parameters = {
++            @Param(
++                name = "i",
++                allowedTypes = {
++                    @ParamType(type = StarlarkInt.class),
++                },
++                doc = "The value of the item.")
++        })
++    public void removeItem(Object i) throws EvalException {
++      final int index = this.index(i, 0, this.size());
++      this.remove(index);
++    }
++
++    @Override
++    public @Nullable Object binaryOp(TokenKind op, Object that, boolean thisLeft) throws EvalException {
++      Object rval;
++      if (op == TokenKind.PLUS) {
++        if (that instanceof StarlarkBytes || that instanceof StarlarkList || that instanceof StarlarkByte) {
++          if (thisLeft) {
++            rval = BinaryOperations.add(this, that, this.mutability);
++          } else {
++            rval = BinaryOperations.add(that, this, this.mutability);
++          }
++        }
++      }
++      rval = super.binaryOp(op, that, thisLeft);
++      if (rval == null) {
++        return rval;
++      }
++      // should be starlarkbytearray
++      return StarlarkByteArray.of((StarlarkBytes) rval);
++    }
++  }
++
++  protected final ByteList delegate;
++
++  protected final Mutability mutability;
++
++  private StarlarkBytes(@Nullable Mutability mutability) {
++    this(mutability, ByteList.empty());
++  }
++
++  private StarlarkBytes(@Nullable Mutability mutability, ByteList elems) {
++    this.mutability = mutability == null ? Mutability.IMMUTABLE : mutability;
++    this.delegate = elems;
++  }
++
++  /**
++   * Takes ownership of the supplied ByteList returns a new StarlarkBytes instance that
++   * initially wraps the ByteList. The caller must not subsequently modify the ByteList, but the
++   * StarlarkBytes instance may do so.
++   */
++  static StarlarkBytes wrap(@Nullable Mutability mutability, ByteList elems) {
++    return new StarlarkBytes(mutability, elems);
++  }
++
++  /**
++   * Takes ownership of the supplied byte array and returns a new StarlarkBytes instance that
++   * initially wraps the array. The caller must not subsequently modify the array, but the
++   * StarlarkBytes instance may do so.
++   */
++  static StarlarkBytes wrap(@Nullable Mutability mutability, byte[] elems) {
++    return wrap(mutability, ByteList.wrap(elems));
++  }
++
++  @Override
++  public boolean isImmutable() {
++    return true; // Starlark spec says that Byte is immutable
++  }
++
++  /**
++   * A shared instance for the empty immutable byte array.
++   */
++  private static final StarlarkBytes EMPTY = new StarlarkBytes(Mutability.IMMUTABLE);
++
++  /**
++   * Returns an immutable instance backed by an empty byte array.
++   */
++  public static StarlarkBytes empty() {
++    return EMPTY;
++  }
++
++  /**
++   * Returns a {@code StarlarkBytes} whose items are given by an iterable of StarlarkInt and which
++   * has the given {@link Mutability}.
++   */
++  public static StarlarkBytes copyOf(
++    @Nullable Mutability mutability, Iterable<StarlarkInt> elems) throws EvalException {
++    StarlarkInt[] arr = Iterables.toArray(elems, StarlarkInt.class);
++    byte[] array = new byte[arr.length];
++    for (int i = 0; i < arr.length; i++) {
++      if (arr[i].toIntUnchecked() >> Byte.SIZE != 0) {
++        throw Starlark.errorf("at index %d, %s out of range .want value" +
++                                " in unsigned 8-bit range", i, arr[i]);
++      }
++      array[i] = (byte) arr[i].toIntUnchecked();
++    }
++    return wrap(mutability, array);
++  }
++
++  public static byte toByte(int x) {
++    checkArgument(x >= 0 ? x >> Byte.SIZE == 0: x >= Byte.MIN_VALUE,  x);
++    return (byte) x;
++  }
++
++  private static void checkElemsValid(StarlarkInt[] elems) {
++    for (StarlarkInt elem : elems) {
++      int value = elem.toIntUnchecked();
++      checkArgument(value >> Byte.SIZE == 0, value);
++    }
++  }
++
++  /**
++   * Returns a {@code StarlarkBytes} whose items are given by a {@link ByteBuffer} and which
++   * has the given {@link Mutability}. As the method nmae says, a copy of the data is made.
++   */
++  public static StarlarkBytes copyOf(@Nullable Mutability mutability, ByteBuffer buf) {
++    return wrap(mutability, ByteList.fromByteBuffer(buf));
++  }
++
++  /**
++   * Returns an immutable byte array with the given elements. Equivalent to {@code copyOf(null,
++   * elems)}.
++   */
++  public static StarlarkBytes immutableCopyOf(Iterable<StarlarkInt> elems) throws EvalException {
++    return copyOf(Mutability.IMMUTABLE, elems);
++  }
++
++  /**
++    * Returns an empty {@code StarlarkBytes} with the given {@link Mutability}.
++    */
++   public static StarlarkBytes of(@Nullable Mutability mutability) {
++     return of(mutability, new byte[0]);
++   }
++
++  /**
++   * Returns a {@code StarlarkBytes} with the given items and the {@link Mutability}.
++   */
++  public static StarlarkBytes of(@Nullable Mutability mutability, byte... elems) {
++    if (elems.length == 0 && (mutability == null || mutability.isFrozen())) {
++      return empty();
++    }
++
++    return wrap(mutability, elems);
++  }
++
++  /**
++   * Returns a {@code StarlarkBytes} with the given items and the {@link Mutability}.
++   */
++  public static StarlarkBytes of(@Nullable Mutability mutability, StarlarkInt... elems) {
++    if (elems.length == 0 && (mutability == null || mutability.isFrozen())) {
++      return empty();
++    }
++
++    checkElemsValid(elems);
++    byte[] arr = new byte[elems.length];
++    for (int i = 0; i < elems.length; i++) {
++      arr[i] = UnsignedBytes.checkedCast(elems[i].toIntUnchecked());
++    }
++    return of(mutability, arr);
++  }
++
++  public static StarlarkBytes of(Mutability mutability, int[] out) {
++    byte[] z = null;
++    for (int i = 0, inputLength = out.length; i < inputLength; i++) {
++      if(z == null) {
++        z = new byte[inputLength];
++      }
++      z[i] = toByte(out[i]);
++    }
++    return z != null ? StarlarkBytes.of(mutability, z) : empty();
++  }
++
++  /**
++   * Returns a {@code StarlarkBytes} with the given items and the {@link Mutability}.
++   */
++  public static StarlarkBytes immutableOf(byte... elems) {
++    return of(Mutability.IMMUTABLE, elems);
++  }
++
++  /**
++   * Returns an immutable {@code StarlarkList} with the given items.
++   */
++  public static StarlarkBytes immutableOf(StarlarkInt... elems) {
++    return of(Mutability.IMMUTABLE, elems);
++  }
++
++  /**
++   * Returns a {@code StarlarkBytes} with the given items and the {@link Mutability}.
++   */
++  public static StarlarkBytes immutableOf(char... elems) {
++    byte[] barr = UTF16toUTF8(elems);
++    return immutableOf(barr);
++  }
++
++  public int[] getUnsignedBytes() {
++    return this.delegate.toUnsignedIntArray();
++  }
++
++  protected void ensureNotFrozen() {
++    if (mutability.isFrozen()) {
++      throw new UnsupportedOperationException("frozen");
++    }
++  }
++
++  @Override
++  public StarlarkByte get(int index) {
++    return StarlarkByte.of(this.delegate.get(index)); // can throw OutOfBounds
++  }
++
++  @Override
++  public StarlarkBytes set(int index, StarlarkBytes element) {
++    throw new UnsupportedOperationException("bytes are immutable. use bytearray.");
++  }
++
++  @Override
++  public void add(int index, StarlarkBytes element) {
++    throw new UnsupportedOperationException("bytes are immutable. use bytearray.");
++  }
++
++  @Override
++  public StarlarkBytes remove(int index) {
++    throw new UnsupportedOperationException("bytes are immutable. use bytearray.");
++  }
++
++  @Override
++  public int indexOf(Object o) {
++    // Overridden for performance to prevent a ton of boxing
++    if (!(o instanceof StarlarkBytes)) {
++      return -1;
++    }
++
++    return this.delegate.indexOf(((StarlarkBytes)o).delegate);
++  }
++
++  @Override
++  public int lastIndexOf(Object o) {
++    // Overridden for performance to prevent a ton of boxing
++    if (!(o instanceof StarlarkBytes)) {
++      return -1;
++    }
++
++    return this.delegate.lastIndexOf(((StarlarkBytes)o).delegate, 0,  this.delegate.size());
++  }
++
++  @NotNull
++  @Override
++  public ListIterator<StarlarkBytes> listIterator() {
++    final ByteList.ByteListIterator bListItr = this.delegate.listIterator();
++    return newListIterator(bListItr);
++  }
++
++  @NotNull
++  @Override
++  public ListIterator<StarlarkBytes> listIterator(int index) {
++    final ByteList.ByteListIterator bListItr = this.delegate.listIterator(index);
++    return newListIterator(bListItr);
++  }
++
++  private ListIterator<StarlarkBytes> newListIterator(ByteList.ByteListIterator bListItr) {
++    Mutability mu = this.mutability;
++    return new UnmodifiableListIterator<StarlarkBytes>() {
++      @Override
++      public boolean hasPrevious() {
++        return bListItr.hasPrevious();
++      }
++
++      @Override
++      public StarlarkBytes previous() {
++        return StarlarkBytes.immutableOf(bListItr.previousByte());
++      }
++
++      @Override
++      public int nextIndex() {
++        return bListItr.nextIndex();
++      }
++
++      @Override
++      public int previousIndex() {
++        return bListItr.previousIndex();
++      }
++
++      @Override
++      public boolean hasNext() {
++        return bListItr.hasNext();
++      }
++
++      @Override
++      public StarlarkBytes next() {
++        return StarlarkBytes.immutableOf(bListItr.nextByte());
++      }
++    };
++  }
++
++  @NotNull
++  @Override
++  public List<StarlarkBytes> subList(int fromIndex, int toIndex) {
++    final ByteList substring = this.delegate.substring(fromIndex, toIndex);
++    List<StarlarkBytes> list = new ArrayList<>(substring.size());
++    for (int i = 0, loopLength = substring.size(); i < loopLength; i++) {
++      list.add(i, StarlarkBytes.immutableOf(substring.get(i)));
++    }
++    return list;
++  }
++
++  @Override
++  public int hashCode() {
++    // Fnv32 hash
++    if (this.delegate == null) {
++      return 0;
++    }
++
++    int hash = -2128831035;
++    for (byte b : this.delegate) {
++      hash ^= b;
++      hash *= (long) 16777619;
++    }
++    return hash;
++  }
++
++  @Override
++  public boolean equals(Object o) {
++    if (!(o instanceof StarlarkBytes)) {
++      return false;
++    }
++    if (this == o) {
++      return true;
++    }
++    return this.compareTo((StarlarkBytes) o) == 0;
++  }
++
++  @Override
++  public boolean containsKey(StarlarkSemantics semantics, Object key) throws EvalException {
++    if (key instanceof StarlarkBytes) {
++      return -1 != this.delegate.indexOf(((StarlarkBytes) key).delegate);
++    } else if (key instanceof StarlarkInt) {
++      StarlarkInt _key = ((StarlarkInt) key);
++      if (!Range
++             .closed(0, 255)
++             .contains(_key.toIntUnchecked())) {
++        throw Starlark.errorf("int in bytes: %s out of range", _key);
++      }
++      return -1 != this.delegate.indexOf(_key.toIntUnchecked());
++    }
++    throw new EvalException(
++      String.format("requires bytes or int as left operand, not %s", Starlark.type(key))
++    );
++  }
++
++  @Override
++  public int size() {
++    return this.delegate.size();
++  }
++
++  @Override
++  public boolean isEmpty() {
++    return this.delegate.isEmpty();
++  }
++
++  @Override
++  public boolean contains(Object o) {
++    if (!(o instanceof StarlarkBytes)) {
++      return false;
++    }
++
++    return this.delegate.contains(((StarlarkBytes)o).delegate);
++  }
++
++  @NotNull
++  @Override
++  public Iterator<StarlarkBytes> iterator() {
++    ByteList.OfByte x = this.delegate.iterator();
++    return new Iterator<StarlarkBytes>() {
++
++      @Override
++      public boolean hasNext() {
++        return x.hasNext();
++      }
++
++      @Override
++      public StarlarkBytes next() {
++        return StarlarkBytes.immutableOf(x.next());
++      }
++    };
++  }
++
++  @Override
++  public Object[] toArray() {
++    final int arraySize = size();
++    Object[] r = new Object[arraySize];
++    Arrays.fill(r, this.delegate.toArray());
++    return r;
++  }
++
++  @Override
++  public <T> T[] toArray(T @NotNull [] a) {
++    Arrays.fill(a, this.delegate.toArray());
++    return a;
++  }
++
++  @Override
++  public boolean add(StarlarkBytes o) {
++    throw new UnsupportedOperationException("bytes are immutable. use bytearray.");
++  }
++
++  public byte[] toByteArray() {
++    return this.delegate.toArray();
++  }
++
++  @Override
++  public boolean remove(Object o) {
++    throw new UnsupportedOperationException("bytes are immutable. use bytearray.");
++  }
++
++  @Override
++  public boolean containsAll(@NotNull Collection<?> c) {
++    // Overridden for performance to prevent a ton of boxing
++    for (Object e : c)
++        if (!contains(e))
++            return false;
++    return true;
++  }
++
++  @Override
++  public boolean addAll(@NotNull Collection<? extends StarlarkBytes> c) {
++    throw new UnsupportedOperationException("bytes are immutable. use bytearray.");
++  }
++
++  @Override
++  public boolean addAll(int index, @NotNull Collection<? extends StarlarkBytes> c) {
++    throw new UnsupportedOperationException("bytes are immutable. use bytearray.");
++  }
++
++  @Override
++  public boolean removeAll(@NotNull Collection<?> c) {
++    throw new UnsupportedOperationException("bytes are immutable. use bytearray.");
++  }
++
++  @Override
++  public boolean retainAll(@NotNull Collection<?> c) {
++    throw new UnsupportedOperationException("bytes are immutable. use bytearray.");
++  }
++
++  @Override
++  public void clear() {
++    throw new UnsupportedOperationException("bytes are immutable. use bytearray.");
++  }
++
++  @Override
++  public int compareTo(@NotNull StarlarkBytes o) {
++    return this.delegate.compareTo(o.delegate);
++  }
++
++
++  @Override
++  public void str(Printer printer) {
++    byte[] bytes = this.delegate.copy(); //todo
++    String s;
++    s = UTF8toUTF16(bytes, 0, bytes.length, /*allowMalformed*/false);
++    printer.append(s);
++  }
++
++  @Override
++  public String toString() {
++    return Starlark.repr(this);
++  }
++
++  @Override
++  public void repr(Printer printer) {
++    byte[] bytes = this.delegate.copy(); //todo
++    String s;
++    try {
++      s = UTF8toUTF16(bytes, 0, bytes.length, /*allowMalformed*/true);
++      StringBuilder sb = new StringBuilder();
++      for (int i = 0; i < s.length(); i++) {
++        quote(sb, s.codePointAt(i));
++      }
++      s = sb.toString();
++    } catch(IndexOutOfBoundsException ex) {
++      StringBuilder sb = new StringBuilder();
++      for(byte b : this.delegate) {
++        quote(sb, Byte.toUnsignedInt(b));
++      }
++      s = sb.toString();
++    }
++    printer.append(String.format("b\"%s\"", s));
++  }
++
++  @Override
++  public StarlarkBytes getSlice(Mutability mu, int start, int stop, int step) throws EvalException {
++    RangeList indices = new RangeList(start, stop, step);
++    int n = indices.size();
++    if (step == 1) { // common case
++      final int at = indices.at(0);
++      return wrap(mu, this.delegate.substring(at, at + n));
++    }
++    byte[] res = new byte[n];
++    for (int i = 0; i < n; ++i) {
++      res[i] = this.delegate.get(indices.at(i));
++    }
++    return wrap(mu, res);
++  }
++
++  @StarlarkMethod(
++    name = "elems",
++    doc =
++      "Returns an iterable value containing successive 1-element byte of the underlying bytearray "
++        + "Equivalent to <code>[b[i] for i in range(len(b))]</code>, except that the "
++        + "returned value might not be a list.")
++  public StarlarkByteElems elems() {
++    return new StarlarkByteElems(this);
++  }
++
++  @Override
++  public String hex(Object sepO, StarlarkInt bytesPerSep) throws EvalException {
++    int nbytesPerSep = bytesPerSep.toIntUnchecked();
++    byte sep;
++    if(sepO instanceof CharSequence) {
++      CharSequence sepChr = ((CharSequence) sepO);
++      if(sepChr.length() != 1) {
++        throw new EvalException("sep must be length 1.");
++      }
++      if (sepChr.charAt(0) > 0x7F) {
++        throw new EvalException("sep must be ASCII.");
++      }
++      sep = (byte)(sepChr.charAt(0) & 0xFF);
++    }
++    else {
++      sep = -1; // intentionally set to be less than -1 to avoid allocating an array
++      nbytesPerSep = 0;
++    }
++    return this.delegate.hex(sep, nbytesPerSep);
++  }
++
++  /** Reports whether {@code x} is Java null or Starlark None. */
++  static boolean isNullOrNoneOrUnbound(Object x) {
++    return x == null || x == Starlark.NONE || x == Starlark.UNBOUND;
++  }
++
++  private ByteList starlarkObjectToByteList(Object sub) throws EvalException {
++    if (sub instanceof StarlarkBytes) {
++      return ((StarlarkBytes) sub).delegate;
++    }
++
++    StarlarkInt sub1 = (StarlarkInt) sub;
++    int x;
++    try {
++      x = sub1.toInt("byte must be in range(0, 256)");
++      checkArgument(x >> Byte.SIZE == 0, x);
++    } catch (IllegalArgumentException e) {
++      throw new EvalException(e.getMessage(), e.getCause());
++    }
++    return ByteList.wrap((byte) x);
++  }
++
++  @Override
++  public int count(Object sub, Object start, Object end) throws EvalException {
++    ByteList subarr = starlarkObjectToByteList(sub);
++    return this.delegate.count(
++      subarr,
++      Starlark.isNullOrNone(start) ? 0 : Starlark.toInt(start, "count"),
++      isNullOrNoneOrUnbound(end) ? size() : Starlark.toInt(end, "count"));
++  }
++
++  @Override
++  public StarlarkBytes removeprefix(StarlarkBytes prefix) {
++    final ByteList prefixeRemoved = this.delegate.removeprefix(prefix.delegate);
++    if(prefixeRemoved == this.delegate) {
++      return this;
++    }
++    return wrap(mutability, prefixeRemoved);
++  }
++
++  @Override
++  public StarlarkBytes removesuffix(StarlarkBytes suffix) {
++    final ByteList suffixRemoved = this.delegate.removesuffix(suffix.delegate);
++    if(suffixRemoved == this.delegate) {
++      return this;
++    }
++    return wrap(mutability, suffixRemoved);
++   }
++
++  @Override
++  public String decode(String encoding, String errors) throws EvalException {
++    try {
++      return this.delegate.decode(encoding, errors);
++    } catch (CharacterCodingException e) {
++      throw new EvalException(e.getMessage(), e);
++    }
++  }
++
++  @Override
++  public boolean endsWith(Object suffixO, Object start, Object end) throws EvalException {
++    if(suffixO instanceof StarlarkBytes) {
++      StarlarkBytes suffix = ((StarlarkBytes) suffixO);
++      return this.delegate.endsWith(suffix.delegate.substring(
++          Starlark.isNullOrNone(start) ? 0 : Starlark.toInt(start, "endsWith"),
++          Starlark.isNullOrNone(end) ? suffix.size() : Starlark.toInt(end, "endsWith")
++        ));
++    }
++    Tuple _seq = ((Tuple) suffixO); // we want to throw a class cast exception here if not tuple
++    Sequence<StarlarkBytes> seq = Sequence.cast(_seq, StarlarkBytes.class, "endsWith");
++    //noinspection ForLoopReplaceableByForEach
++    for (int i = 0, seqSize = seq.size(); i < seqSize; i++) { // no allocation loop
++      if(this.delegate.endsWith(
++        seq.get(i) // does not allocate because Tuple returns item @ index
++          .delegate
++          .substring(
++            Starlark.isNullOrNone(start) ? 0 : Starlark.toInt(start, "endsWith"),
++            Starlark.isNullOrNone(end) ? seq.get(i).size() : Starlark.toInt(end, "endsWith")
++          ))) {
++        return true;
++      }
++    }
++    return false;
++  }
++
++  @Override
++  public int find(Object sub, Object start, Object end) throws EvalException {
++    ByteList subarr = starlarkObjectToByteList(sub);
++    return this.delegate.find(
++      subarr,
++      Starlark.isNullOrNone(start) ? 0 : Starlark.toInt(start, "find"),
++      isNullOrNoneOrUnbound(end) ? size() : Starlark.toInt(end, "find"));
++  }
++
++
++  @Override
++  public int index(Object sub, Object start, Object end) throws EvalException {
++    int loc = find(sub, start, end);
++    if(loc == -1) {
++      throw Starlark.errorf("subsection not found");
++    }
++    return loc;
++  }
++
++  @Override
++  public StarlarkBytes join(Sequence<StarlarkBytes> elements) throws EvalException {
++    ByteList[] parts = new ByteList[elements.size()];
++    for (int i = 0, loopLength = elements.size(); i < loopLength; i++) {
++      parts[i] = elements.get(i).delegate;
++    }
++    return wrap(mutability, this.delegate.join(parts));
++  }
++
++  @Override
++  public Tuple partition(StarlarkBytes sep) {
++    final ByteList[] partitioned = this.delegate.partition(sep.delegate);
++    return Tuple.of(
++      wrap(mutability, partitioned[0]),
++      wrap(mutability, partitioned[1]),
++      wrap(mutability, partitioned[2])
++    );
++  }
++
++  @Override
++  public StarlarkBytes replace(StarlarkBytes oldBytes, StarlarkBytes newBytes, StarlarkInt countI, StarlarkThread thread) throws EvalException {
++    int count = Starlark.isNullOrNone(countI)
++                  ? Integer.MAX_VALUE
++                  : Starlark.toInt(countI, "replace");
++    if(count == -1) {
++      count = Integer.MAX_VALUE;
++    }
++    final ByteList replaced = this.delegate.replace(oldBytes.delegate, newBytes.delegate, count);
++    return wrap(mutability, replaced);
++  }
++
++  @Override
++   public int rfind(Object sub, Object start, Object end) throws EvalException {
++    ByteList subarr = starlarkObjectToByteList(sub);
++    return this.delegate.rfind(
++      subarr,
++      Starlark.isNullOrNone(start) ? 0 : Starlark.toInt(start, "rfind"),
++      isNullOrNoneOrUnbound(end) ? size() : Starlark.toInt(end, "rfind"));
++   }
++
++  @Override
++   public int rindex(Object sub, Object start, Object end) throws EvalException {
++    int loc = rfind(sub, start, end);
++    if(loc == -1) {
++      throw Starlark.errorf("subsection not found");
++    }
++    return loc;
++   }
++
++  @Override
++  public Tuple rpartition(StarlarkBytes sep) throws EvalException {
++    final ByteList[] rightPartitioned = this.delegate.rpartition(sep.delegate);
++    return Tuple.of(
++      wrap(mutability, rightPartitioned[0]),
++      wrap(mutability, rightPartitioned[1]),
++      wrap(mutability, rightPartitioned[2])
++    );
++  }
++
++  @Override
++  public boolean startsWith(Object prefixO, Object start, Object end) throws EvalException {
++    if(prefixO instanceof StarlarkBytes) {
++      StarlarkBytes prefix = ((StarlarkBytes) prefixO);
++      return this.delegate.startsWith(prefix.delegate.substring(
++          Starlark.isNullOrNone(start) ? 0 : Starlark.toInt(start, "startsWith"),
++          Starlark.isNullOrNone(end) ? prefix.size() : Starlark.toInt(end, "startsWith")
++        ));
++    }
++    Tuple _seq = ((Tuple) prefixO); // we want to throw a class cast exception here if not tuple
++    Sequence<StarlarkBytes> seq = Sequence.cast(_seq, StarlarkBytes.class, "startsWith");
++    //noinspection ForLoopReplaceableByForEach
++    for (int i = 0, seqSize = seq.size(); i < seqSize; i++) { // no allocation loop
++      if(this.delegate.startsWith(
++        seq.get(i) // does not allocate because Tuple returns item @ index
++          .delegate
++          .substring(
++            Starlark.isNullOrNone(start) ? 0 : Starlark.toInt(start, "startsWith"),
++            Starlark.isNullOrNone(end) ? seq.get(i).size() : Starlark.toInt(end, "startsWith")
++          ))) {
++        return true;
++      }
++    }
++    return false;
++  }
++
++  @Override
++  public StarlarkBytes translate(Object tableO, StarlarkBytes delete) throws EvalException {
++    ByteList table = null;
++    if (!Starlark.isNullOrNone(tableO)) {
++      table = ((StarlarkBytes) tableO).delegate;
++    }
++    try {
++      return wrap(mutability, this.delegate.translate(table, delete.delegate));
++    }catch(IllegalArgumentException ex) {
++      throw new EvalException(ex.getMessage(), ex);
++    }
++  }
++
++  @Override
++  public StarlarkBytes center(StarlarkInt width, StarlarkBytes fillbyte) throws EvalException {
++    return wrap(this.mutability, this.delegate.center(width.toInt("center"),fillbyte.delegate));
++  }
++
++  @Override
++  public StarlarkBytes ljust(StarlarkInt width, StarlarkBytes fillbyte) throws EvalException {
++    return wrap(this.mutability, this.delegate.ljust(width.toInt("ljust"), fillbyte.delegate));
++  }
++
++  @Override
++  public StarlarkBytes lstrip(Object charsO) {
++    ByteList chars = ByteList.empty();
++    if(!Starlark.isNullOrNone(charsO)) {
++      chars = ((StarlarkBytes) charsO).delegate;
++    }
++    return wrap(Mutability.IMMUTABLE, this.delegate.lstrip(chars));
++  }
++
++  @Override
++  public StarlarkBytes rjust(StarlarkInt width, StarlarkBytes fillbyte)  throws EvalException {
++    return wrap(this.mutability, this.delegate.rjust(width.toInt("rjust"), fillbyte.delegate));
++  }
++
++  @Override
++  public StarlarkList<StarlarkBytes> rsplit(Object bytesO, Object maxSplitO, StarlarkThread thread) throws EvalException {
++    int maxSplit = Starlark.isNullOrNone(maxSplitO)
++                  ? Integer.MAX_VALUE
++                  : Starlark.toInt(maxSplitO, "rsplit");
++    if(maxSplit == -1) {
++      maxSplit = Integer.MAX_VALUE;
++    }
++    ByteList splitOn = ByteList.empty();
++    if (!Starlark.isNullOrNone(bytesO)) {
++      splitOn = ((StarlarkBytes)bytesO).delegate;
++    }
++    final ByteList[] rsplited = this.delegate.rsplit(splitOn, maxSplit);
++    StarlarkList<StarlarkBytes> res = StarlarkList.newList(thread.mutability());
++    //noinspection ForLoopReplaceableByForEach
++    for (int i = 0, loopLen = rsplited.length; i < loopLen; i++) {
++      res.addElement(wrap(thread.mutability(), rsplited[i]));
++    }
++    return res;
++  }
++
++  @Override
++  public StarlarkBytes rstrip(Object charsO) {
++    ByteList chars = ByteList.empty();
++    if(!Starlark.isNullOrNone(charsO)) {
++      chars = ((StarlarkBytes) charsO).delegate;
++    }
++    return wrap(Mutability.IMMUTABLE, this.delegate.rstrip(chars));
++  }
++
++  @Override
++  public StarlarkList<StarlarkBytes> split(Object bytesO, Object maxSplitO, StarlarkThread thread) throws EvalException {
++    int maxSplit = Starlark.isNullOrNone(maxSplitO)
++                  ? Integer.MAX_VALUE
++                  : Starlark.toInt(maxSplitO, "split");
++    if(maxSplit == -1) {
++      maxSplit = Integer.MAX_VALUE;
++    }
++    ByteList splitOn = ByteList.empty();
++    if (!Starlark.isNullOrNone(bytesO)) {
++      splitOn = ((StarlarkBytes)bytesO).delegate;
++    }
++    final ByteList[] splitted = this.delegate.split(splitOn, maxSplit);
++    StarlarkList<StarlarkBytes> res = StarlarkList.newList(thread.mutability());
++    //noinspection ForLoopReplaceableByForEach
++    for (int i = 0, loopLen = splitted.length; i < loopLen; i++) {
++      res.addElement(wrap(thread.mutability(), splitted[i]));
++    }
++    return res;
++  }
++
++  @Override
++  public StarlarkBytes strip(Object charsO) {
++    ByteList chars = ByteList.empty();
++    if(!Starlark.isNullOrNone(charsO)) {
++      chars = ((StarlarkBytes) charsO).delegate;
++    }
++    return wrap(Mutability.IMMUTABLE, this.delegate.strip(chars));
++  }
++
++  @Override
++  public StarlarkBytes capitalize() {
++    return wrap(mutability, this.delegate.capitalize());
++  }
++
++  @Override
++  public StarlarkBytes expandTabs(StarlarkInt tabSize) throws EvalException {
++    if(size() == 0) {
++      return empty();
++    }
++    return wrap(mutability, this.delegate.expandtabs(tabSize.toInt("expandTabs")));
++  }
++
++  @Override
++  public boolean isAlnum() {
++    return this.delegate.isalnum();
++  }
++
++  @Override
++  public boolean isAlpha() {
++    return this.delegate.isalpha();
++  }
++
++  @Override
++  public boolean isAscii() {
++    return this.delegate.isascii();
++  }
++
++  @Override
++  public boolean isDigit() {
++    return this.delegate.isdigit();
++  }
++
++  @Override
++  public boolean isLower() {
++    return this.delegate.islower();
++  }
++
++  @Override
++  public boolean isSpace() {
++    return this.delegate.isspace();
++  }
++
++  @Override
++  public boolean isTitle() {
++    return this.delegate.istitle();
++  }
++
++  @Override
++  public boolean isUpper() {
++    return this.delegate.isupper();
++  }
++
++  @Override
++  public StarlarkBytes lower() {
++    return wrap(mutability, this.delegate.lower());
++  }
++
++  @Override
++  public Sequence<StarlarkBytes> splitLines(boolean keepEnds) throws EvalException {
++    final ByteList[] splitted = this.delegate.splitlines(keepEnds);
++    StarlarkList<StarlarkBytes> res = StarlarkList.newList(mutability);
++    //noinspection ForLoopReplaceableByForEach
++    for (int i = 0, loopLen = splitted.length; i < loopLen; i++) {
++      res.addElement(wrap(mutability, splitted[i]));
++    }
++    return res;
++  }
++
++  @Override
++  public StarlarkBytes swapcase() {
++    return wrap(mutability, this.delegate.swapcase());
++  }
++
++  @Override
++  public StarlarkBytes title() {
++    return wrap(mutability, this.delegate.title());
++  }
++
++  @Override
++  public StarlarkBytes upper() {
++    return wrap(mutability, this.delegate.upper());
++  }
++
++  @Override
++  public StarlarkBytes zfill(StarlarkInt width) throws EvalException {
++    return wrap(mutability, this.delegate.zfill(width.toInt("zfill")));
++  }
++
++  /**
++   * Ensures the truth of an expression involving one or more parameters
++   * to the calling method.
++   */
++  static void checkArgument(boolean b, int p1) {
++    if (!b) {
++      throw new IllegalArgumentException(
++        Strings.lenientFormat(
++          "byte must be in range(0, 256). received %s", p1));
++    }
++  }
++
++
++  @Override
++  public int length() {
++    return size();
++  }
++
++  @Override
++  public char charAt(int index) {
++    return this.delegate.charAt(index);
++  }
++
++  public byte byteAt(int index) {
++    return this.delegate.byteAt(index);
++  }
++
++  @Override
++  public CharSequence subSequence(int start, int end) {
++    return this.delegate.subSequence(start,end);
++  }
++
++  public char[] toCharArray(Charset cs) {
++    CharBuffer charBuffer = cs.decode(ByteBuffer.wrap(this.toByteArray()));
++    return Arrays.copyOf(charBuffer.array(), charBuffer.limit());
++  }
++
++  public char[] toCharArray() {
++    // this is the right default charset for char arrays
++    // specially in a password context
++    // see: https://stackoverflow.com/questions/8881291/why-is-char-preferred-over-string-for-passwords
++    // as well as: https://stackoverflow.com/a/9670279/133514
++    return toCharArray(StandardCharsets.ISO_8859_1);
++  }
++
++  @StarlarkBuiltin(name = "bytes.elems")
++  public static class StarlarkByteElems extends AbstractList<StarlarkInt>
++    implements Sequence<StarlarkInt> {
++
++    final private StarlarkBytes bytes;
++
++    public StarlarkByteElems(StarlarkBytes bytes) {
++      this.bytes = bytes;
++    }
++
++    @Override
++    public void repr(Printer printer) {
++      byte[] bytes = this.bytes.delegate.toArray();
++      printer.append(
++        String.format("b\"%s\".elems()",
++          UTF8toUTF16(bytes, 0, bytes.length, /*allowMalformed*/ true)
++        ));
++    }
++
++    @Override
++    public StarlarkInt get(int index) {
++      return StarlarkInt.of(Byte.toUnsignedInt(this.bytes.byteAt(index)));
++//      int[] bytes = this.bytes.get(index).getUnsignedBytes();
++      // guaranteed to be one entry per slice.
++      // an index on a byte array will return 1 byte
++//      return StarlarkInt.of(bytes[0]); // so this is safe.
++    }
++
++    @Override
++    public int size() {
++      return this.bytes.size();
++    }
++
++    @Override
++    public Sequence<StarlarkInt> getSlice(Mutability mu, int start, int stop, int step) throws EvalException {
++      int[] unsignedBytes = this.bytes.getSlice(mu, start, stop, step).getUnsignedBytes();
++      return StarlarkList.copyOf(mu, Arrays
++                                       .stream(unsignedBytes)
++                                       .mapToObj(StarlarkInt::of)
++                                       .collect(Collectors.toList()));
++    }
++
++  }
++
++  /**
++   * Returns a new StarlarkBytes containing n consecutive repeats of this byte array.
++   */
++  public StarlarkBytes repeat(StarlarkInt n, Mutability mutability) throws EvalException {
++    try {
++      return wrap(mutability, this.delegate.repeat(n.toInt("repeat")));
++    } catch(IllegalArgumentException ex) {
++      throw new EvalException(ex.getMessage(), ex);
++    }
++  }
++
++  @Nullable
++  @Override
++  public Object binaryOp(TokenKind op, Object that, boolean thisLeft) throws EvalException {
++    switch (op) {
++      case STAR:
++        /*
++          Attempts to multiply a StarlarkBytes type by an integer. The caller is responsible for casting
++          to the appropriate sub-type.
++         */
++        if (that instanceof StarlarkInt) {
++          return repeat((StarlarkInt) that, this.mutability);
++        }
++      case PLUS:
++        if (thisLeft) {
++          return BinaryOperations.add(this, that, this.mutability);
++        } else {
++          return BinaryOperations.add(that, this, this.mutability);
++        }
++      default:
++        // unsupported binary operation!
++        return null;
++    }
++  }
++
++  static class BinaryOperations {
++
++    /**
++     * Add right to left (i.e. [1] + [2] = [1, 2])
++     */
++    static public StarlarkBytes add(Object left, Object right, Mutability mutability) throws EvalException {
++      StarlarkBytes left_ = toStarlarkByte(left, mutability);
++      StarlarkBytes right_ = toStarlarkByte(right, mutability);
++      return wrap(mutability, ByteList.copy("").join(left_.delegate, right_.delegate));
++    }
++
++    private static StarlarkBytes toStarlarkByte(Object item, Mutability mutability) throws EvalException {
++      if (item instanceof StarlarkList) {
++        Sequence<StarlarkInt> cast = Sequence.cast(
++          item,
++          StarlarkInt.class,
++          "Attempted to add list of non-Integer type to a bytearray");
++        return StarlarkBytes.copyOf(mutability, cast);
++      }
++      return (StarlarkBytes) item;
++    }
++  }
++
++  /**
++   * The Unicode replacement character inserted in place of decoding errors.
++   */
++  private static final char REPLACEMENT_CHAR = '\uFFFD';
++
++  static final int[] TABLE_UTF8_NEEDED = new int[]{
++    //      0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
++    0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 0xc0 - 0xcf
++    1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // 0xd0 - 0xdf
++    2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, // 0xe0 - 0xef
++    3, 3, 3, 3, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // 0xf0 - 0xff
++  };
++
++  /**
++   * Returns a String for the UTF-8 encoded byte sequence in <code>bytes[0..len-1]</code>. The
++   * length of the resulting String will be the exact number of characters encoded by these bytes.
++   * Since UTF-8 is a variable-length encoding, the resulting String may have a length anywhere from
++   * len/3 to len, depending on the contents of the input array.<p>
++   *
++   * In the event of a bad encoding, the UTF-8 replacement character (code point {@code \uFFFD})
++   * is inserted for the bad byte(s), and decoding resumes from the next byte.
++   */
++  static public String UTF8toUTF16(byte[] data, int offset, int byteCount, boolean allowMalformed) {
++    if ((offset | byteCount) < 0 || byteCount > data.length - offset) {
++      throw new RuntimeException("index out of bound: " + data.length + " " + offset + " " + byteCount);
++    }
++    char[] value;
++    int length;
++    char[] v = new char[byteCount];
++
++    int idx = offset;
++    int last = offset + byteCount;
++    int s = 0;
++
++    int codePoint = 0;
++    int utf8BytesSeen = 0;
++    int utf8BytesNeeded = 0;
++    int lowerBound = 0x80;
++    int upperBound = 0xbf;
++    int b;
++    while (idx < last) {
++      b = data[idx++] & 0xff;
++      if (utf8BytesNeeded == 0) {
++        if ((b & 0x80) == 0) { // ASCII char. 0xxxxxxx
++          v[s++] = (char) b;
++          continue;
++        }
++
++        if ((b & 0x40) == 0) { // 10xxxxxx is illegal as first byte
++          v[s++] = REPLACEMENT_CHAR;
++          continue;
++        }
++
++        // 11xxxxxx
++        int tableLookupIndex = b & 0x3f;
++        utf8BytesNeeded = TABLE_UTF8_NEEDED[tableLookupIndex];
++        if (utf8BytesNeeded == 0) {
++          v[s++] = REPLACEMENT_CHAR;
++          continue;
++        }
++
++        // utf8BytesNeeded
++        // 1: b & 0x1f
++        // 2: b & 0x0f
++        // 3: b & 0x07
++        codePoint = b & (0x3f >> utf8BytesNeeded);
++        if (b == 0xe0) {
++          lowerBound = 0xa0;
++        } else if (b == 0xed) {
++          upperBound = 0x9f;
++        } else if (b == 0xf0) {
++          lowerBound = 0x90;
++        } else if (b == 0xf4) {
++          upperBound = 0x8f;
++        }
++      } else {
++        if (b < lowerBound || b > upperBound) {
++          // The bytes seen are ill-formed. Substitute them with U+FFFD
++          v[s++] = REPLACEMENT_CHAR;
++          codePoint = 0;
++          utf8BytesNeeded = 0;
++          utf8BytesSeen = 0;
++          lowerBound = 0x80;
++          upperBound = 0xbf;
++          /*
++           * According to the Unicode Standard,
++           * "a UTF-8 conversion process is required to never consume well-formed
++           * subsequences as part of its error handling for ill-formed subsequences"
++           * The current byte could be part of well-formed subsequences. Reduce the
++           * index by 1 to parse it in next loop.
++           */
++          idx--;
++          continue;
++        }
++
++        lowerBound = 0x80;
++        upperBound = 0xbf;
++        codePoint = (codePoint << 6) | (b & 0x3f);
++        utf8BytesSeen++;
++        if (utf8BytesNeeded != utf8BytesSeen) {
++          continue;
++        }
++
++        // Encode chars from U+10000 up as surrogate pairs
++        if (codePoint < 0x10000) {
++          v[s++] = (char) codePoint;
++        } else {
++          v[s++] = (char) ((codePoint >> 10) + 0xd7c0);
++          v[s++] = (char) ((codePoint & 0x3ff) + 0xdc00);
++        }
++
++        utf8BytesSeen = 0;
++        utf8BytesNeeded = 0;
++        codePoint = 0;
++      }
++    }
++
++    // The bytes seen are ill-formed.
++    if (utf8BytesNeeded != 0) {
++      for (int i = 0; i < utf8BytesNeeded; i++) {
++        if(s + 1 >= v.length) {
++          value = new char[s + (utf8BytesNeeded-i)];
++          System.arraycopy(v, 0, value, 0, s);
++          v = value;
++        }
++        // the total number of utf8BytesNeeded should be replaced by the
++        // actual escaped characters themselves if allowMalformed is true.
++        if (allowMalformed) {
++          // we have to back track utf8BytesNeeded and insert the characters
++          v[s++] = (char) (data[idx - utf8BytesNeeded + i] & 0xff);
++        } else {
++          // Substitute them by U+FFFD
++          v[s++] = REPLACEMENT_CHAR;
++        }
++      }
++    }
++
++    if (s == byteCount) {
++      // We guessed right, so we can use our temporary array as-is.
++      value = v;
++      length = s;
++    } else {
++      // Our temporary array was too big, so reallocate and copy.
++      value = new char[s];
++      length = s;
++      System.arraycopy(v, 0, value, 0, s);
++    }
++    return String.copyValueOf(value, 0, length);
++  }
++
++  /**
++   * The Starlark spec defines text strings as sequences of UTF-k codes that encode Unicode code
++   * points. In this Java implementation, k=16, whereas in a Go implementation, k=8s. For
++   * portability, operations on strings should aim to avoid assumptions about the value of k.
++   */
++  static public byte[] UTF16toUTF8(char[] val) {
++    int dp = 0;
++    int sp = 0;
++    int sl = val.length;
++    byte[] dst = new byte[sl * 3];
++    char c;
++    while (sp < sl && (c = val[sp]) < 0x80) {
++      // ascii fast loop;
++      dst[dp++] = (byte) c;
++      sp++;
++    }
++    while (sp < sl) {
++      c = val[sp++];
++      if (c < 0x80) {
++        dst[dp++] = (byte) c;
++      } else if (c < 0x800) {
++        dst[dp++] = (byte) (0xc0 | (c >> 6));
++        dst[dp++] = (byte) (0x80 | (c & 0x3f));
++      } else if (Character.isSurrogate(c)) {
++        int uc = -1;
++        char c2;
++        if (Character.isHighSurrogate(c) && sp < sl &&
++              Character.isLowSurrogate(c2 = val[sp])) {
++          uc = Character.toCodePoint(c, c2);
++        }
++        if (uc < 0) {
++          dst[dp++] = (byte) 0xEF;
++          dst[dp++] = (byte) 0xBF;
++          dst[dp++] = (byte) 0xBD;
++        } else {
++          dst[dp++] = (byte) (0xf0 | ((uc >> 18)));
++          dst[dp++] = (byte) (0x80 | ((uc >> 12) & 0x3f));
++          dst[dp++] = (byte) (0x80 | ((uc >> 6) & 0x3f));
++          dst[dp++] = (byte) (0x80 | (uc & 0x3f));
++          sp++;  // 2 chars
++        }
++      } else {
++        // 3 bytes, 16 bits
++        dst[dp++] = (byte) (0xe0 | ((c >> 12)));
++        dst[dp++] = (byte) (0x80 | ((c >> 6) & 0x3f));
++        dst[dp++] = (byte) (0x80 | (c & 0x3f));
++      }
++    }
++    if (dp == dst.length) {
++      return dst;
++    }
++    return Arrays.copyOf(dst, dp);
++  }
++
++  public static void quote(StringBuilder sb, int codePoint) {
++    Character.UnicodeBlock of;
++    if (!Character.isISOControl(codePoint)
++          && Character.isValidCodePoint(codePoint)
++          && (of = Character.UnicodeBlock.of(codePoint)) != null
++          && of.equals(Character.UnicodeBlock.BASIC_LATIN)) {
++      sb.append((char) codePoint);
++    } else if (Character.isWhitespace(codePoint) || codePoint <= 0xff) {
++      switch ((char) codePoint) {
++        case '\b':
++          sb.append("\\b");
++          break;
++        case '\t':
++          sb.append("\\t");
++          break;
++        case '\n':
++          sb.append("\\n");
++          break;
++        case '\f':
++          sb.append("\\f");
++          break;
++        case '\r':
++          sb.append("\\r");
++          break;
++        default: {
++          String s = Integer.toHexString(codePoint);
++          if (codePoint < 0x100) {
++            sb.append("\\x");
++            if (s.length() == 1) {
++              sb.append('0');
++            }
++            sb.append(s);
++          } else {
++            sb.append("\\x").append(s);
++          }
++        }
++      }
++    } else {
++      switch (Character.getType(codePoint)) {
++        case Character.CONTROL:     // Cc
++        case Character.FORMAT:      // Cf
++        case Character.PRIVATE_USE: // Co
++        case Character.SURROGATE:   // Cs
++        case Character.UNASSIGNED:  // Cn
++          sb.append(String.format("\\u%04x", codePoint));
++          break;
++        default:
++          sb.append(Character.toChars(codePoint));
++          break;
++      }
++    }
++  }
++}
+diff --git b/libstarlark/src/main/java/net/starlark/java/eval/StarlarkInt.java a/libstarlark/src/main/java/net/starlark/java/eval/StarlarkInt.java
+index 10e9a0bb..d2ae235b 100644
+--- b/libstarlark/src/main/java/net/starlark/java/eval/StarlarkInt.java
++++ a/libstarlark/src/main/java/net/starlark/java/eval/StarlarkInt.java
+@@ -213,7 +213,8 @@ public abstract class StarlarkInt implements StarlarkValue, Comparable<StarlarkI
+     @Override
+     public boolean equals(Object that) {
+       return (that instanceof Int32 && this.v == ((Int32) that).v)
+-          || (that instanceof StarlarkFloat && intEqualsFloat(this, (StarlarkFloat) that));
++       || (that instanceof StarlarkFloat && intEqualsFloat(this, (StarlarkFloat) that))
++       || (that instanceof StarlarkBytes.StarlarkByte && this.v == ((StarlarkBytes.StarlarkByte) that).get());
+     }
+   }
+ 
+diff --git b/libstarlark/src/main/java/net/starlark/java/ext/ByteList.java a/libstarlark/src/main/java/net/starlark/java/ext/ByteList.java
+new file mode 100644
+index 00000000..6563a5ba
+--- /dev/null
++++ a/libstarlark/src/main/java/net/starlark/java/ext/ByteList.java
+@@ -0,0 +1,2374 @@
++package net.starlark.java.ext;
++
++import com.google.common.base.Ascii;
++import java.nio.ByteBuffer;
++import java.nio.CharBuffer;
++import java.nio.charset.CharacterCodingException;
++import java.nio.charset.CharsetDecoder;
++import java.nio.charset.StandardCharsets;
++import java.util.ArrayList;
++import java.util.Arrays;
++import java.util.Collection;
++import java.util.Collections;
++import java.util.Iterator;
++import java.util.List;
++import java.util.ListIterator;
++import java.util.NoSuchElementException;
++import java.util.Objects;
++import java.util.PrimitiveIterator;
++import java.util.RandomAccess;
++import java.util.function.Consumer;
++import java.util.function.IntPredicate;
++
++import org.jetbrains.annotations.NotNull;
++
++public class ByteList implements CharSequence, RandomAccess, Iterable<Byte>, Comparable<ByteList> {
++
++  public static ByteList fromByteBuffer(ByteBuffer buf) {
++    int size;
++    if (buf == null || (size = buf.remaining()) == 0) {
++      return empty();
++    }
++
++    byte[] array = new byte[size];
++    // If buf is a slice, then we must check if it has a backing array
++    // (which can actually be bigger than its capacity) without any way to tell
++    // what the proper offset is.
++    if (buf.hasArray()
++          && (buf.array().length == buf.capacity())) {
++      // it is not a slice, use System.arraycopy
++      System.arraycopy(buf.array(), buf.position(), array, 0, buf.remaining());
++    }
++    else { // _IT IS_ a slice! We must copy manually.
++      int pos = buf.position();
++      buf.get(array, 0, size);
++      buf.position(pos);
++    }
++    return ByteList.wrap(array);
++  }
++
++
++  public String decode(String encoding, String errors) throws CharacterCodingException {
++    CharsetDecoder decoder =
++              CodecHelper
++                .ThreadLocalCoders
++                .decoderFor(encoding)
++                .onMalformedInput(CodecHelper.convertCodingErrorAction(errors))
++                .onUnmappableCharacter(CodecHelper.convertCodingErrorAction(errors));
++
++    return decoder.decode(ByteBuffer.wrap(toArray()))
++             //.compact()
++             .toString();
++  }
++
++  public static class PY_ISSPACE implements IntPredicate {
++    public static final PY_ISSPACE INSTANCE = new PY_ISSPACE();
++
++    // stringlib whitespace =>
++    //   - https://github.com/python/cpython/blob/main/Objects/bytesobject.c#L1720
++    //   - https://github.com/python/cpython/blob/main/Objects/stringlib/stringdefs.h#L16
++    //   - https://github.com/python/cpython/blob/main/Include/cpython/pyctype.h#L27
++    //   - https://github.com/python/cpython/blob/main/Python/pyctype.c#L15-L19 + L38
++    public static final byte[] PY_CTF_SPACE = (
++      "\u0009" + (char) 0x0A + "\u000B" + "\u000C" + (char) 0x0D + "\u0020"
++    ).getBytes(StandardCharsets.US_ASCII);
++
++    @Override
++    public boolean test(int ch) {
++      if (ch > 0x0020) return false;
++      long isspace = 1;
++      for (byte b : PY_CTF_SPACE) {
++        isspace |= (1L << b);
++      }
++      return ((isspace >> ch) & 1L) != 0;
++    }
++  }
++
++  public static class IsLowerCase implements IntPredicate {
++    public static final IsLowerCase INSTANCE = new IsLowerCase();
++
++    @Override
++    public boolean test(int value) {
++      return Ascii.isLowerCase((char) value);
++    }
++  }
++
++  public static class IsUpperCase implements IntPredicate {
++    public static final IsUpperCase INSTANCE = new IsUpperCase();
++
++    @Override
++    public boolean test(int value) {
++      return Ascii.isUpperCase((char) value);
++    }
++  }
++
++  public static class SubByteFinder implements IntPredicate {
++
++    private final ByteList bytes;
++
++    public SubByteFinder(ByteList bytes) {
++      this.bytes = bytes;
++    }
++
++    @Override
++    public boolean test(int value) {
++      return bytes.find((byte) value) != -1;
++    }
++  }
++
++  SubByteFinder FINDER_PREDICATE = new SubByteFinder(this);
++
++  protected static final byte[] EMPTY_BYTE_ARRAY = new byte[0];
++
++  /**
++   * Empty {@code ByteList}.
++   */
++  public static final ByteList EMPTY = new ByteList(EMPTY_BYTE_ARRAY);
++
++  public static ByteList empty() {
++    return ByteList.copy(EMPTY);
++  }
++
++  protected ByteList() {
++    this(EMPTY_BYTE_ARRAY, 0, 0);
++  }
++
++  protected ByteList(int initialCapacity) {
++    this(new byte[initialCapacity], 0, 0);
++    ensureCapacity(initialCapacity);
++  }
++
++  protected ByteList(byte[] array) {
++    this(array, 0, array.length);
++  }
++
++  /**
++   * Construct an empty list with the given initial capacity.
++   *
++   * @throws IllegalArgumentException when <i>initialCapacity</i> is negative
++   */
++  protected ByteList(byte[] array, int offset, int length) {
++    if (length < 0) {
++      throw new IllegalArgumentException(String.format("capacity < 0 (%s)", length));
++    }
++    setArrayUnsafe(array);
++    offset(offset);
++    size(length);
++  }
++
++  /* Constants */
++
++  private static final byte[] HEX_CHAR_LOOKUP_TABLE = "0123456789abcdef".getBytes();
++
++  /**
++   * The largest possible table capacity.  This value must be
++   * exactly 1<<30 to stay within Java array allocation and indexing
++   * bounds for power of two table sizes, and is further required
++   * because the top two bits of 32bit hash fields are used for
++   * control purposes.
++   */
++  private static final int MAXIMUM_CAPACITY = 1 << 30;
++
++  /* Fields */
++
++  private int offset;
++
++  protected int offset() {
++    return offset;
++  }
++
++  protected void offset(final int offset) {
++    this.offset = offset;
++  }
++
++  /**
++   * The current size of the list.
++   *
++   * The size of the list distinct from the length of the array. Think of it as the number of
++   * elements set in the list and as a result, represents the number of actual elements in the
++   * collection.
++   */
++  private int size;
++
++  public int size() {
++    return size;
++  }
++
++  public void size(final int size) {
++    ensureCapacity(size);
++    this.size = size;
++  }
++
++  protected byte[] array;
++
++  /**
++   * Get the array container directly. The array can then be passed directly to the target for use.
++   *
++   * Caller beware: once you use this method, it is recommended not to use this ByteList instance.
++   *
++   * @return the array container directly
++   */
++  public byte[] getArrayUnsafe() {
++    return array;
++  }
++
++  public void setArrayUnsafe(final byte[] array) {
++    if (array.length < size()) {
++      throw new IllegalArgumentException("Array too small");
++    }
++    this.array = array;
++  }
++
++  /**
++   * Returns an array containing all of the elements in this deque in proper sequence (from first to
++   * last element).
++   *
++   * <p>The returned array will be "safe" in that no references to it are
++   * maintained by this ByteList instance.  (In other words, this method must allocate a new array).
++   * The caller is thus free to modify the returned array.
++   *
++   * <p>This method acts as bridge between array-based and collection-based
++   * APIs.
++   *
++   * @return an array containing all of the elements in this ByteList instance
++   */
++  public byte[] toArray() {
++    return toArray(null);
++  }
++
++  public byte[] toArray(byte[] a) {
++    if (a == null || a.length < size()) {
++      a = new byte[size()];
++    }
++    OfByte.unwrap(iterator(), a, 0, a.length);
++    return a;
++  }
++
++  public byte[] toArray(byte[] dest, int sourcePos, int destPos, int len) {
++    if (len == 0) {
++      return dest;             // nothing to copy
++    }
++    OfByte it = iterator();
++    if (sourcePos != 0) {
++      if (sourcePos != it.advance(sourcePos)) {
++        return dest; // cannot copy..
++      }
++    }
++    OfByte.unwrap(it, dest, destPos, len);
++    return dest;
++  }
++
++  public int[] toUnsignedIntArray() {
++    final int arrSize = size();
++    int[] arr = new int[arrSize];
++    for (int i = 0; i < arrSize; ++i) {
++      arr[i] = Byte.toUnsignedInt(byteAt(i));
++    }
++    return arr;
++  }
++
++  public byte byteAt(int index) {
++    // ignoring the potential offset because we need to do range-checking in the
++    // substring case anyway.
++    return array[index];
++  }
++
++
++  // instantiate / copy interface
++
++  /**
++   * Create a {@link ByteList} from the supplied array of byte[] and returns a new ByteList instance
++   * that initially wraps the array. The caller *MUST NOT* subsequently modify the array, but the
++   * ByteList instance may do so.
++   *
++   * @param b the source for new ByteList
++   * @return the new ByteList
++   */
++  public static ByteList wrap(byte... b) {
++    if (b == null || b.length == 0) {
++      return empty();
++    }
++    return new ByteList(b);
++  }
++
++  /**
++   * Create a {@link ByteList} from the provided CharSequence with a default ISO_8859_1 encoding.
++   *
++   * @param s the source for new ByteList
++   * @return the new ByteList
++   */
++  public static ByteList copy(CharSequence s) {
++    return copy(CharBuffer.wrap(s).compact().array());
++  }
++
++  /**
++   * Create a {@link ByteList} from the provided String with a default ISO_8859_1 encoding.
++   *
++   * @param s the source for new ByteList
++   * @return the new ByteList
++   */
++  public static ByteList copy(String s) {
++    return copy(StandardCharsets.ISO_8859_1.encode(CharBuffer.wrap(s)).compact().array());
++  }
++
++  /**
++   * Create a {@link ByteList} from the provided character array with a default ISO_8859_1
++   * encoding.
++   *
++   * @param s the source for new ByteList
++   * @return the new ByteList
++   */
++  public static ByteList copy(char[] s) {
++    byte[] bytes = new byte[s.length];
++    for (int i = 0; i < s.length; i++) {
++      bytes[i] = (byte) s[i];
++    }
++    return copy(bytes);
++  }
++
++  /**
++   * Create a {@link ByteList} from the provided ByteList.
++   *
++   * @param bytes the source for new ByteList
++   * @return the new ByteList
++   */
++  public static ByteList copy(ByteList bytes) {
++    return copy(bytes.copy());
++  }
++
++  public static ByteList copy(byte[] bytes) {
++    return copy(bytes, 0, bytes.length);
++  }
++
++  public static ByteList copy(byte[] bytes, int offset, int size) {
++    byte[] copy = new byte[size];
++    System.arraycopy(bytes, offset, copy, 0, size);
++    return new SubByteList(copy, offset, size);
++  }
++
++  public byte[] copy() {
++    return copy(size());
++  }
++
++  private byte[] copy(final int newLength) {
++    final byte[] copy = new byte[newLength];
++    final byte[] oldArray = getArrayUnsafe();
++    if (oldArray != null) System.arraycopy(oldArray, offset(), copy, 0, size());
++    return copy;
++  }
++
++  /**
++   * Gets the current capacity of the backing array.
++   */
++  public int capacity() {
++    final byte[] array = getArrayUnsafe();
++    return array == null ? 0 : array.length;
++  }
++
++  public void ensureCapacity(final int minCapacity) {
++    final int oldCapacity = capacity();
++    if (minCapacity <= oldCapacity) return; // no need to grow
++
++    // grow the array by up to 50% (plus a small constant)
++    final int growth = Math.min(oldCapacity / 2 + 16, MAXIMUM_CAPACITY);
++    final int newCapacity;
++    if (growth > Integer.MAX_VALUE - oldCapacity) {
++      // growth would push array over the maximum array size
++      newCapacity = Integer.MAX_VALUE;
++    } else newCapacity = oldCapacity + growth;
++    // ensure the array grows by at least the requested minimum capacity
++    final int newLength = Math.max(minCapacity, newCapacity);
++
++    // copy the data into a new array
++    setArrayUnsafe(copy(newLength));
++  }
++
++  /**
++   * Shifts the array to insert space at a specified index.
++   *
++   * @param index the index where the space should be inserted
++   * @param count the number of values to insert
++   */
++  public void insert(final int index, final int count) {
++    int oldSize = size();
++    if (index < 0 || index > oldSize) {
++      throw new ArrayIndexOutOfBoundsException("Invalid index value");
++    }
++    if (count > Integer.MAX_VALUE - oldSize) {
++      // insertion would push array over the maximum size
++      throw new IllegalArgumentException("Too many elements");
++    }
++    if (count <= 0) {
++      throw new IllegalArgumentException("Count must be positive");
++    }
++    size(oldSize + count);
++    if (index < oldSize) {
++      final byte[] array = getArrayUnsafe();
++      System.arraycopy(array, offset() + index, array, index + count, oldSize - index);
++    }
++  }
++
++  private int shiftCapacity(int offset, int additional) {
++    if (size + additional >= capacity()) {
++      byte[] temp = new byte[Math.max(size + additional, size << 1)];
++      if (offset == 0) {
++        System.arraycopy(getArrayUnsafe(), 0, temp, additional, size);
++      } else {
++        System.arraycopy(getArrayUnsafe(), 0, temp, 0, offset);
++        System.arraycopy(getArrayUnsafe(), offset, temp, offset + additional, size - offset);
++      }
++
++      setArrayUnsafe(temp);
++    } else {
++      System.arraycopy(getArrayUnsafe(), offset, array, offset + additional, size - offset);
++    }
++    return additional;
++  }
++
++
++  /**
++   * Shifts the array to delete space starting at a specified index.
++   *
++   * @param index the index where the space should be deleted
++   * @param count the number of values to delete
++   */
++  public void delete(final int index, final int count) {
++    int oldSize = size();
++    if (index < 0 || index > oldSize) {
++      throw new ArrayIndexOutOfBoundsException("Invalid index value");
++    }
++    if (index + count > oldSize) {
++      throw new IllegalArgumentException("Invalid range: index=" + index +
++                                           ", count=" + count + ", size=" + oldSize);
++    }
++    size(oldSize - count);
++    if (index + count < oldSize) {
++      final byte[] array = getArrayUnsafe();
++      System.arraycopy(array, offset() + index + count, array, index, oldSize - index - count);
++    }
++  }
++
++  // collections
++
++  // Overridden for performance to prevent a ton of boxing
++  public boolean contains(final Object o) {
++    if (!(o instanceof Byte)) return false;
++    final byte value = (Byte) o;
++    return contains(value);
++  }
++
++  public boolean contains(final byte value) {
++    return indexOf(value) >= 0;
++  }
++
++  public boolean contains(int value) {
++    return contains((byte) value);
++  }
++
++  // Overridden for performance to prevent a ton of boxing
++  public boolean remove(final Object o) {
++    if (!(o instanceof Byte)) return false;
++    final byte value = (Byte) o;
++    return removeValue(value);
++  }
++
++  public boolean remove(final byte value) {
++    return removeValue(value);
++  }
++
++  /**
++   * Removes and returns the item at the specified index. Note that this is equivalent to {@link
++   * java.util.List#remove(int)}, but can't have that name because we also have {@link
++   * #remove(byte)} that removes a value, rather than an index.
++   *
++   * @param index the index of the item to remove and return
++   * @return the removed item
++   */
++  public byte removeAt(final int index) {
++    final byte removed = get(index);
++    delete(index, 1);
++    return removed;
++  }
++
++  // Overridden for performance to prevent a ton of boxing
++  public boolean containsAll(final Collection<?> c) {
++    for (final Object o : c) {
++      if (!(o instanceof Byte)) return false;
++      final byte value = (Byte) o;
++      if (indexOf(value) < 0) return false;
++    }
++    return true;
++  }
++
++  // Overridden for performance to prevent a ton of boxing
++  public boolean addAll(final int index, final Collection<? extends Byte> c) {
++    if (c.size() == 0) return false;
++    insert(index, c.size());
++    int i = index;
++    for (final byte e : c) {
++      setValue(i++, e);
++    }
++    return true;
++  }
++
++  /**
++   * @param index - where to insert the bytelist
++   * @param b     - the bytelist to insert
++   * @return return the new size (i.e. the index) of the underlying data structure. this can be used
++   * to consecutively add to the list via index
++   */
++  public int addAll(final int index, final ByteList b) {
++    if (b.size() == 0) return size();
++    insert(index, b.size());
++    int i = index;
++    for (final byte e : b) {
++      setValue(i++, e);
++    }
++    return i;
++  }
++
++  // Overridden for performance to prevent a ton of boxing
++  public boolean removeAll(final Collection<?> c) {
++    boolean changed = false;
++    for (final Object o : c) {
++      if (!(o instanceof Byte)) continue;
++      final byte value = (Byte) o;
++      final boolean result = removeValue(value);
++      if (result) changed = true;
++    }
++    return changed;
++  }
++
++  public boolean removeAll(final ByteList c) {
++    boolean changed = false;
++    for (final byte value : c) {
++      final boolean result = removeValue(value);
++      if (result) changed = true;
++    }
++    return changed;
++  }
++
++  public void clear() {
++    size(0);
++  }
++
++  // -- ByteArray methods --
++
++  public void addValue(final byte value) {
++    addValue(size(), value);
++  }
++
++  public void addValue(final int index, final byte value) {
++    insert(index, 1);
++    array[index] = value;
++  }
++
++  public boolean removeValue(final byte value) {
++    final int index = indexOf(offset() + value);
++    if (index < 0) return false;
++    delete(index, 1);
++    return true;
++  }
++
++  /**
++   * Private remove method that skips bounds checking and does not return the value removed.
++   */
++  private void fastRemove(final int index) {
++    final int newSize;
++    final byte[] array = getArrayUnsafe();
++
++    if ((newSize = size - 1) > index) {
++      System.arraycopy(array, offset() + index + 1, array, index, newSize - index);
++    }
++    size(newSize);
++  }
++
++  public byte getValue(final int index) {
++    // delegate offset checking because we do range-checking in the substring case anyway.
++    return this.byteAt(index);
++  }
++
++  public byte setValue(final int index, final byte value) {
++    checkBounds(offset() + index);
++    final byte oldValue = getValue(index);
++    array[offset() + index] = value;
++    return oldValue;
++  }
++
++  public int indexOf(final byte value) {
++    for (int i = 0; i < size(); i++) {
++      if (get(i) == value) return i;
++    }
++    return -1;
++  }
++
++  public int indexOf(final int value) {
++    return indexOf((byte) value);
++  }
++
++  public int indexOf(byte[] target) {
++    return indexOf(ByteList.wrap(target));
++  }
++
++  /**
++   * Returns the start position of the first occurrence of the specified {@code target} within this
++   * ByteList, or {@code -1} if there is no such occurrence.
++   *
++   * @param target the array to search for as a sub-sequence
++   */
++  public int indexOf(ByteList target) {
++    final int targetSize = target.size();
++    if (targetSize == 0) {
++      return 0;
++    }
++
++    outer:
++    for (int i = 0; i < size() - targetSize + 1; i++) {
++      for (int j = 0; j < targetSize; j++) {
++        if (get(i + j) != target.get(j)) {
++          continue outer;
++        }
++      }
++      return i;
++    }
++    return -1;
++  }
++
++  public int lastIndexOf(final byte value) {
++    for (int i = size() - 1; i >= 0; i--) {
++      if (get(i) == value) return i;
++    }
++    return -1;
++  }
++
++  public int lastIndexOf(byte[] sub, int start, int end) {
++    return lastIndexOf(ByteList.wrap(sub), start, end);
++  }
++
++  public int lastIndexOf(ByteList sub, int start, int end) {
++    int subl = sub.size();
++    if (subl == 0) {
++      return end;
++    }
++
++    outer:
++    for (int i = end - 1, blen = size(); i >= start; i--) {
++      for (int j = 0; j < subl; j++) {
++        if (i + j >= blen) {
++          continue outer;
++        }
++        if (get(i + j) != sub.get(j)) {
++          continue outer;
++        }
++      }
++      return i;
++    }
++    return -1;
++  }
++
++  // list
++  public byte get(final int index) {
++    return getValue(index);
++  }
++
++  public byte set(final int index, final Byte element) {
++    return setValue(index, element == null ? defaultValue() : element);
++  }
++
++  public boolean add(final int index, final Byte element) {
++    addValue(index, element);
++    return true;
++  }
++
++  public boolean add(final Byte element) {
++    return add(size(), element);
++  }
++
++  public boolean extend(final ByteList list) {
++    final int i = size();
++    return i != addAll(i, list);
++  }
++
++  /**
++   * Creates a <b>new</b> ByteList and appends the passed list to it.
++   *
++   * @param list - The list to append to the new copy of the list
++   * @return A new list consisting of a copy of this {@link ByteList} appended with list.
++   */
++  public ByteList mergedCopy(final ByteList list) {
++    final ByteList bytes = new ByteList(size() + list.size());
++    int idx = bytes.addAll(0, this);
++    idx = bytes.addAll(idx, list);
++    assert idx == (size() + list.size());
++    return bytes;
++  }
++
++  public byte defaultValue() {
++    return 0;
++  }
++
++  // collection
++  public boolean isEmpty() {
++    return size() == 0;
++  }
++
++  /// internal
++
++  /**
++   * Checks that the index is less than the size of the array.
++   */
++  protected void checkBounds(final int index) {
++    checkBounds(index, size());
++  }
++
++  /**
++   * Checks that the given index falls within the specified array size.
++   *
++   * @param index the index position to be tested
++   * @param size  the length of the array
++   * @throws IndexOutOfBoundsException if the index does not fall within the array.
++   */
++  protected void checkBounds(int index, int size) {
++    if ((index | (size - (index + 1))) < 0) {
++      if (index < 0) {
++        throw new ArrayIndexOutOfBoundsException("Index < 0: " + index);
++      }
++      throw new ArrayIndexOutOfBoundsException("Index > length: " + index + ", " + size);
++    }
++  }
++
++  /**
++   * Checks that the given range falls within the bounds of an array
++   *
++   * @param startIndex the start index of the range (inclusive)
++   * @param endIndex   the end index of the range (exclusive)
++   * @param size       the size of the array.
++   * @return the length of the range.
++   * @throws IndexOutOfBoundsException some or all of the range falls outside of the array.
++   */
++  protected int checkRange(int startIndex, int endIndex, int size) {
++    final int length = endIndex - startIndex;
++    if ((startIndex | endIndex | length | (size - endIndex)) < 0) {
++      if (startIndex < 0) {
++        throw new IndexOutOfBoundsException("Beginning index: " + startIndex + " < 0");
++      }
++      if (endIndex < startIndex) {
++        throw new IndexOutOfBoundsException(
++          "Beginning index larger than ending index: " + startIndex + ", " + endIndex);
++      }
++      // endIndex >= size
++      throw new IndexOutOfBoundsException("End index: " + endIndex + " >= " + size);
++    }
++    return length;
++  }
++
++  // CharSequence
++
++  @Override
++  public int length() {
++    return size();
++  }
++
++  @Override
++  public char charAt(int index) {
++    return (char) byteAt(index);
++  }
++
++  @Override
++  public CharSequence subSequence(int start, int end) {
++    return substring(start, end);
++  }
++
++  @Override
++  public String toString() {
++    return Arrays.toString(Arrays.copyOfRange(array, offset, offset + size));
++  }
++
++  // comparable
++  @Override
++  public int compareTo(@NotNull ByteList o) {
++    final int thisSize = size();
++    final int oSize = o.size();
++    final int minLength = Math.min(thisSize, oSize);
++    for (int i = 0; i < minLength; i++) {
++      int result = Byte.toUnsignedInt(get(i)) - Byte.toUnsignedInt(o.get(i));
++      if (result != 0) {
++        return result;
++      }
++    }
++    return thisSize - oSize;
++  }
++
++  // hashCode()
++  @Override
++  public boolean equals(Object o) {
++    if (!(o instanceof ByteList)) {
++      if (o instanceof Iterable) {
++        return iterator().itemsEqual(((Iterable<?>) o).iterator());
++      }
++      return false;
++    }
++    if (this == o) {
++      return true;
++    }
++    return this.compareTo((ByteList) o) == 0;
++  }
++
++// ByteList python buffer-like methods
++
++  /**
++   * Common implementation for find, rfind, index, rindex.
++   *
++   * @param forward true if we want to return the first matching index.
++   */
++  int find(boolean forward, ByteList sub, int start, int end) {
++    if (sub.size() == 0 && start > end) {
++      return -1;
++    }
++    final int currSize = size();
++    start = toIndex(start, currSize);
++    end = toIndex(end, currSize);
++
++    ByteList subRange = substring(start, end);
++    int subpos = forward
++                   ? subRange.indexOf(sub)
++                   : subRange.lastIndexOf(sub, 0, subRange.size());
++
++    return subpos < 0 ? subpos : subpos + start;
++  }
++
++
++  public String hex() {
++    return hex((byte) -1);
++  }
++
++  public String hex(byte separator) {
++    return hex(separator, -1);
++  }
++
++  public String hex(ByteList separator) {
++    return hex(separator, -1);
++  }
++
++  public String hex(ByteList separator, int bytesPerSep) {
++    if(separator == null || separator.isEmpty()) {
++      throw new IllegalArgumentException("separator cannot be empty");
++    }
++    if(separator.size() != 1) {
++      throw new IllegalArgumentException("separator must be of size 1");
++    }
++    return hex(separator.get(0), bytesPerSep);
++  }
++
++  public String hex(byte separator, int bytesPerSep) {
++    final int srcLength = size();
++    if (srcLength == 0) { // early-exit
++      return "";
++    }
++
++    int absBytesPerSep = Math.abs(bytesPerSep);
++    int resultlen = 0;
++    if (bytesPerSep != 0) {
++      resultlen = (srcLength - 1) / absBytesPerSep;
++    }
++
++    resultlen += srcLength * 2;
++    if (absBytesPerSep >= srcLength) {
++      bytesPerSep = absBytesPerSep = 0;
++    }
++    byte[] retbuf = new byte[resultlen];
++    int i,j;
++    for (i=j=0; i < srcLength; ++i) {
++      int c = get(i) & 0xFF;
++      retbuf[j++] = HEX_CHAR_LOOKUP_TABLE[c >>> 4];
++      retbuf[j++] = HEX_CHAR_LOOKUP_TABLE[c & 0x0f];
++      if ((bytesPerSep != 0) && (i < (srcLength - 1))) {
++          int anchor;
++          anchor = (bytesPerSep > 0) ? (srcLength - 1 - i) : (i + 1);
++          if (anchor % absBytesPerSep == 0 && separator >= 0) {
++              retbuf[j++] = separator;
++          }
++      }
++    }
++    return new String(retbuf, 0, j, StandardCharsets.US_ASCII);
++  }
++
++  public int count(byte[] bytes) {
++    return count(bytes, 0);
++  }
++
++  public int count(byte[] bytes, int i) {
++    return count(bytes, i, size());
++  }
++
++  public int count(byte i) {
++    return count(i, 0);
++  }
++
++  public int count(byte i, int start) {
++    return count(i, start, size());
++  }
++
++  public int count(byte i, int start, int end) {
++    return count(new byte[]{i}, start, end);
++  }
++
++  public int count(byte[] sub, int start, int end) {
++    return count(ByteList.wrap(sub), start, end);
++  }
++
++  public int count(ByteList sub, int start, int end) {
++    if (sub == null) {
++      throw new IllegalArgumentException("argument should be integer or bytes-like object, not 'null'");
++    }
++    final int length = size();
++    final int sublength = sub.size();
++
++    //If the sub string is longer than the value string a match cannot exist
++    if (length < sublength) {
++      return 0;
++    }
++    //Clamp value to negative positive range of indices
++    int istart = Math.max(-length, Math.min(length, start));
++    int iend = Math.max(-length, Math.min(length, end));
++    //Compute wrapped index for negative values(Python modulo operation)
++    if (istart < 0) {
++      istart = ((istart % length) + length) % length;
++    }
++    if (iend < 0) {
++      iend = ((iend % length) + length) % length;
++    }
++
++    int count = 0;
++    boolean found_match;
++    //iend-sub.length+1 accounts for the inner loop comparison to
++    //  end comparisons at (i+j)==iend
++    for (int i = istart; i < ((iend - sublength) + 1); i++) {
++      found_match = true;
++      for (int j = 0; j < sublength; j++) {
++        if (get(i + j) != sub.get(j)) {
++          found_match = false;
++          break;
++        }
++      }
++      if (found_match) {
++        count++;
++        //skip ahead by the length of the sub_array (-1 to account for i++ in outer loop)
++        //this consumes the match from the value array
++        i += sublength - 1;
++      }
++    }
++    return count;
++  }
++
++  public int find(byte[] bytes) {
++    return find(bytes, 0, size());
++  }
++
++  public int find(byte[] bytes, int start) {
++    return find(bytes, start, size());
++  }
++
++  public int find(byte[] bytes, int start, int end) {
++    return find(true, ByteList.wrap(bytes), start, end);
++  }
++  public int find(ByteList bytes, int start, int end) {
++    return find(true, bytes, start, end);
++  }
++
++  public int find(byte i) {
++    return find(i, 0, size());
++  }
++
++  public int find(byte i, int start) {
++    return find(i, start, size());
++  }
++
++  public int find(byte i, int start, int end) {
++    int subpos = substring(start, end).indexOf(i);
++    return subpos < 0 ? subpos : subpos + start;
++  }
++
++  /**
++   * Joins a set of byte arrays into a larger array. The {@code interlude} is placed between each of
++   * the elements, but not at the beginning or end. In the case that the list is empty or {@code
++   * null}, a zero-length byte array will be returned.
++   *
++   * @param parts the pieces to be joined. May be {@code null}, but does not allow for elements in
++   *              the list to be {@code null}.
++   * @return a newly created concatenation of the input
++   */
++  public ByteList join(byte[][] parts) {
++    final int partsLength;
++    if (parts == null || (partsLength = parts.length) == 0) {
++      return empty();
++    }
++
++    if (getArrayUnsafe() == null) {
++      setArrayUnsafe(EMPTY_BYTE_ARRAY);
++    }
++
++    int elementTotals = 0;
++    for (byte[] e : parts) {
++      elementTotals += e.length;
++    }
++
++    int interludeSize = size();
++    byte[] dest = new byte[(interludeSize * (partsLength - 1)) + elementTotals];
++
++    int startByte = 0;
++    int index = 0;
++    for (byte[] part : parts) {
++      final int length = part.length;
++      if (length > 0) {
++        System.arraycopy(part, 0, dest, startByte, length);
++        startByte += length;
++      }
++      if (index < partsLength - 1 && interludeSize > 0) {
++        // If this is not the last element, append the interlude
++        System.arraycopy(getArrayUnsafe(), 0, dest, startByte, interludeSize);
++        startByte += interludeSize;
++      }
++      index++;
++    }
++    return ByteList.wrap(dest);
++  }
++
++  public ByteList join(ByteList... parts) {
++    final int partsLength;
++    if (parts == null || (partsLength = parts.length) == 0) {
++      return empty();
++    }
++    final byte[][] bytes = new byte[partsLength][];
++    for (int i = 0; i < partsLength; i++) {
++      bytes[i] = parts[i].toArray();
++    }
++    return join(bytes);
++  }
++
++  public ByteList[] partition(byte[] separator) {
++    return partition(ByteList.wrap(separator));
++  }
++
++  public ByteList[] partition(ByteList separator) {
++    int i = find(true, separator, 0, size());
++    if (i == -1) {
++      return new ByteList[]{this, empty(), empty()};
++    }
++    return new ByteList[]{
++      substring(0, i),
++      separator,
++      substring(i + separator.size(), size())
++    };
++  }
++
++  public ByteList[] rpartition(byte[] separator) {
++    return rpartition(ByteList.wrap(separator));
++  }
++
++  public ByteList[] rpartition(ByteList separator) {
++    int i = find(false, separator, 0, size());
++    if (i == -1) {
++      return new ByteList[]{empty(), empty(), this};
++    }
++    return new ByteList[]{
++      substring(0, i),
++      separator,
++      substring(i + separator.size(), size())
++    };
++  }
++
++  public ByteList replace(byte[] oldBytes, byte[] newBytes) {
++    return replace(oldBytes, newBytes, Integer.MAX_VALUE);
++  }
++
++  public ByteList replace(byte[] oldBytes, byte[] newBytes, int count) {
++    return replace(ByteList.wrap(oldBytes), ByteList.wrap(newBytes), count);
++  }
++
++  public ByteList replace(ByteList oldBytes, ByteList newBytes, int count) {
++    int i, j, pos, maxcount = count, subLen = oldBytes.size(), repLen = newBytes.size();
++    final ByteList replacement = new ByteList(size() + (repLen * size()));
++    int resultLen = 0;
++    i = 0;
++    while (maxcount-- > 0) {
++      pos = find(true, oldBytes, i, size());
++      if (pos < 0) {
++        break;
++      }
++      j = pos;
++      resultLen = replacement.addAll(resultLen, substring(i, j));
++      resultLen = replacement.addAll(resultLen, newBytes);
++      i = j + subLen;
++    }
++
++    if (i == 0) {
++      return ByteList.copy(substring(0, size()).toArray());
++    }
++
++    resultLen = replacement.addAll(resultLen, substring(i, size()));
++    assert resultLen == replacement.size();
++    return replacement;
++  }
++
++  public boolean startsWith(byte[] prefix) {
++    if (prefix.length > size()) {
++      return false;
++    }
++    for (int i = 0; i < prefix.length; i++) {
++      if (get(i) != prefix[i]) {
++        return false;
++      }
++    }
++    return true;
++  }
++
++  static boolean isdigit(byte ch) {
++    return ch >= '0' && ch <= '9';
++  }
++
++  public boolean isdigit() {
++    if (isEmpty()) {
++      return false;
++    }
++    for (byte ch : this) {
++      if (!isdigit(ch)) {
++        return false;
++      }
++    }
++    return true;
++  }
++
++
++  public boolean isascii() {
++    if (isEmpty()) {
++      return true;
++    }
++    for (byte b : this) {
++      if (b < 0) {  // remember, bytes are -127 to 127 and 0x7F is max ascii
++        return false;
++      }
++    }
++    return true;
++  }
++
++  static boolean isalpha(byte ch) {
++    return Ascii.isUpperCase((char) ch) || Ascii.isLowerCase((char) ch);
++  }
++
++  public boolean isalpha() {
++    if (isEmpty()) {
++      return false;
++    }
++    for (byte ch : this) {
++      if (!isalpha(ch)) {
++        return false;
++      }
++    }
++    return true;
++  }
++
++  static boolean isalnum(byte ch) {
++    return isalpha(ch) || isdigit(ch);
++  }
++
++  public boolean isalnum() {
++    if (isEmpty()) {
++      return false;
++    }
++    for (byte ch : this) {
++      if (!isalnum(ch)) {
++        return false;
++      }
++    }
++    return true;
++  }
++
++  public ByteList swapcase() {
++    byte[] bytes = toArray();
++    for (int idx = 0; idx < size(); ++idx) {
++      char lc = (char) bytes[idx];
++      if (Ascii.isUpperCase(lc)) {
++        bytes[idx] = (byte) Ascii.toLowerCase(lc);
++      } else {
++        bytes[idx] = (byte) Ascii.toUpperCase(lc);
++      }
++    }
++    return ByteList.wrap(bytes);
++  }
++
++  public boolean istitle() {
++    final int inputLength = size();
++    /* Special case for empty strings */
++    if (inputLength == 0) {
++      return false;
++    }
++    boolean isTitleCase = false;
++    boolean previousIsCased = false;
++    for (byte value : this) {
++      char b = (char) value;
++      if (Ascii.isUpperCase(b)) {
++        if (previousIsCased) {
++          return false;
++        }
++        previousIsCased = true;
++        isTitleCase = true;
++      } else if (Ascii.isLowerCase(b)) {
++        if (!previousIsCased) {
++          return false;
++        }
++        previousIsCased = true;
++        isTitleCase = true;
++      } else {
++        previousIsCased = false;
++      }
++    }
++    return isTitleCase;
++  }
++
++  public ByteList zfill(int width) {
++    final int len = size();
++    if (len >= width) {
++      return this;
++    }
++
++    final int fill = width - len;
++    ByteList p = pad(fill, 0, (byte) '0');
++
++    if (len == 0) {
++      return p;
++    }
++
++    if (p.get(fill) == '+' || p.get(fill) == '-') {
++      /* move sign to beginning of string */
++      p.setValue(0, p.get(fill));
++      p.setValue(fill, (byte) '0');
++    }
++    return p;
++  }
++
++  private ByteList pad(int left, int right, byte padChar) {
++    final int len = size();
++
++    left = Math.max(left, 0);
++    right = Math.max(right, 0);
++    if (left == 0 && right == 0) {
++      return this;
++    }
++
++    byte[] u = new byte[left + len + right];
++
++    if (left > 0) {
++      Arrays.fill(u, 0, left, padChar);
++    }
++
++    for (int i = left, j = 0; i < (left + len); j++, i++) {
++      u[i] = get(j);
++    }
++
++    if (right > 0) {
++      Arrays.fill(u, left + len, u.length, padChar);
++    }
++    return ByteList.wrap(u);
++  }
++
++  public ByteList title() {
++    final int len = size();
++    boolean capitalizeNext = true;
++    final ByteList titleCased = ByteList.wrap(copy());
++    for (int idx = 0; idx < len; ++idx) {
++      byte lc = get(idx);
++      if (!isalpha(lc)) {
++        titleCased.setValue(idx, lc);
++        capitalizeNext = true;
++      } else if (capitalizeNext) {
++        titleCased.setValue(idx, (byte) Ascii.toUpperCase((char) lc));
++        capitalizeNext = false;
++      } else {
++        titleCased.setValue(idx, (byte) Ascii.toLowerCase((char) lc));
++      }
++    }
++    return titleCased;
++  }
++
++  public ByteList lower() {
++    final ByteList lowerCased = ByteList.copy(this);
++    final int length = lowerCased.size();
++    for (int i = 0; i < length; i++) {
++      byte b = (byte) Ascii.toLowerCase((char) lowerCased.get(i));
++      lowerCased.setValue(i, b);
++    }
++    return lowerCased;
++  }
++
++  public ByteList upper() {
++    final ByteList upperCased = ByteList.copy(this);
++    final int length = upperCased.size();
++    for (int i = 0; i < length; i++) {
++      byte b = (byte) Ascii.toUpperCase((char) upperCased.get(i));
++      upperCased.setValue(i, b);
++    }
++    return upperCased;
++  }
++
++  public ByteList capitalize() {
++    final ByteList capitalized = ByteList.copy(this);
++    final int length = capitalized.size();
++    for (int i = 0; i < length; i++) {
++      byte b = capitalized.get(i);
++      if (b < 127 && b > 32) {
++        char c = (char) b;
++        if (i == 0) {
++          c = Ascii.toUpperCase(c);
++        } else {
++          c = Ascii.toLowerCase(c);
++        }
++        capitalized.setValue(i, (byte) c);
++      } else {
++        capitalized.setValue(i, b);
++      }
++    }
++    return capitalized;
++  }
++
++  private static final byte[] SPACE = new byte[]{(byte) ' '};
++
++  public ByteList center(int width) {
++    return center(width, SPACE);
++  }
++
++  public ByteList center(int width, byte[] fillChar) {
++    return center(width, ByteList.wrap(fillChar));
++  }
++
++  public ByteList center(int width, ByteList fillChar) {
++    int marg = width - size();
++    int left = marg / 2 + (marg & width & 1);
++    return pad(left, marg - left, fillChar.get(0));
++  }
++
++  public ByteList rjust(int width) {
++    return rjust(width, SPACE);
++  }
++
++  public ByteList rjust(int width, byte[] fillChar) {
++    return rjust(width, ByteList.wrap(fillChar));
++  }
++
++  public ByteList rjust(int width, ByteList fillChar) {
++    if (fillChar.isEmpty() || (width - size() <= 0)) {
++      return this;
++    }
++    int l = width - size();
++    int resLen = l + size();
++    byte[] res = new byte[resLen];
++    Arrays.fill(res, 0, l, fillChar.byteAt(0));
++    for (int i = l, j = 0; i < (size() + l); j++, i++) {
++      res[i] = this.byteAt(j);
++    }
++    return ByteList.wrap(res);
++  }
++
++  public ByteList ljust(int width) {
++    return ljust(width, SPACE);
++  }
++
++  public ByteList ljust(int width, byte[] fillChar) {
++    return ljust(width, ByteList.wrap(fillChar));
++  }
++
++  public ByteList ljust(int width, ByteList fillChar) {
++    if (fillChar.isEmpty() || (width - size() <= 0)) {
++      return this;
++    }
++    int l = width - size();
++    int resLen = l + size();
++    byte[] res = new byte[resLen];
++    System.arraycopy(array, 0, res, 0, size());
++    Arrays.fill(res, size(), resLen, fillChar.byteAt(0));
++    return ByteList.wrap(res);
++  }
++
++  public ByteList[] splitlines() {
++    return splitlines(false);
++  }
++
++  public ByteList[] splitlines(boolean keepEnds) {
++    final int length = size();
++    int start = 0;
++    // Escape analysis should only allocate this on the heap
++    List<ByteList> bl = new ArrayList<>();
++    for (int i = 0; i < length; i++) {
++      if (get(i) == '\n' || get(i) == '\r') {
++        int end = i;
++        if (get(i) == '\r' && i + 1 != length && get(i + 1) == '\n') {
++          i++;
++        }
++        if (keepEnds) {
++          end = i + 1;
++        }
++        bl.add(substring(start, start + (end - start)));
++        start = i + 1;
++      }
++    }
++    if (start == length) {
++      return bl.toArray(new ByteList[0]);
++    }
++    // We have remaining parts, so let's process it.
++    bl.add(substring(start, start + (length - start)));
++    return bl.toArray(new ByteList[0]);
++  }
++
++  public ByteList translate(byte[] table) {
++    return translate(ByteList.wrap(table), empty());
++  }
++
++  public ByteList translate(byte[] table, byte[] delete) {
++    return translate(ByteList.wrap(table), ByteList.wrap(delete));
++  }
++
++  public ByteList translate(byte[] table, ByteList delete) {
++    return translate(ByteList.wrap(table), delete);
++  }
++
++  public ByteList translate(ByteList table, ByteList delete) {
++    int dellen = delete.size();
++    boolean changed = false;
++
++    if (table != null && !table.isEmpty()) {
++      if (table.size() != 256) {
++        throw new IllegalArgumentException(
++          String.format(
++            "translation table must be 256 characters long. length of table was %d",
++            table.size()));
++      }
++    }
++
++    final int totalSize = size();
++
++    if (dellen == 0 && table != null && !table.isEmpty()) {
++      byte[] result = new byte[totalSize];
++      /* If no deletions are required, use faster code */
++      for (int i = 0; i < totalSize; i++) {
++        byte c = byteAt(i);
++        byte v = table.get(c);
++        if (!changed && c != v) {
++          changed = true;
++        }
++        result[i] = v;
++      }
++      if (!changed) {
++        return this;
++      }
++      return ByteList.wrap(result);
++    }
++
++    boolean[] toDelete = new boolean[256];
++    for (int i = 0; i < 256; i++) {
++      toDelete[i] = false;
++    }
++    for (byte b : delete) {
++      toDelete[b] = true;
++    }
++
++    int resultLen = 0;
++    byte[] result = new byte[totalSize];
++
++    for (int i = 0; i < totalSize; i++) {
++      byte c = byteAt(i);
++      if (!toDelete[c]) {
++        byte v = (table != null && !table.isEmpty()) ? table.get(c) : c;
++        if (!changed && c != v) {
++          changed = true;
++        }
++        result[resultLen] = v;
++        resultLen++;
++      }
++    }
++    if (!changed && resultLen == totalSize) {
++      return this;
++    }
++    // optimize for pre-allocated if resultLen = 0
++    if (resultLen == 0) {
++      return empty();
++    }
++    return ByteList.wrap(result).substring(0, resultLen);
++  }
++
++  public ByteList expandtabs() {
++    return expandtabs(8);
++  }
++
++  public ByteList expandtabs(int tabsize) {
++    if (size() == 0) {
++      return empty();
++    }
++    final int length = size();
++    final int max = Integer.MAX_VALUE;
++    int i = 0, j = 0;
++    for (int i1 = 0; i1 < length; i1++) {
++      byte p = get(i1);
++      if (p == (byte) '\t') {
++        if (tabsize > 0) {
++          int incr = tabsize - (j % tabsize);
++          if (j > max - incr) {
++            throw new ArrayIndexOutOfBoundsException("result too long");
++          }
++          j += incr;
++        }
++      } else {
++        if (j > max - 1) {
++          throw new ArrayIndexOutOfBoundsException("result too long");
++        }
++        j++;
++        if (p == (byte) '\n' || p == (byte) '\r') {
++          if (i > max - j) {
++            throw new ArrayIndexOutOfBoundsException("result too long");
++          }
++          i += j;
++          j = 0;
++        }
++      }
++    }
++    if (i > max - j) {
++      throw new ArrayIndexOutOfBoundsException("result too long");
++    }
++
++    byte[] q = new byte[i + j];
++    j = 0;
++    int idx = 0;
++    for (int i1 = 0; i1 < length; i1++) {
++      byte p = get(i1);
++      if (p == (byte) '\t') {
++        if (tabsize > 0) {
++          i = tabsize - (j % tabsize);
++          j += i;
++          while (i-- > 0) {
++            q[idx++] = (byte) ' ';
++          }
++        }
++      } else {
++        j++;
++        q[idx++] = p;
++        if (p == (byte) '\n' || p == (byte) '\r') {
++          j = 0;
++        }
++      }
++
++    }
++    return ByteList.wrap(q);
++  }
++
++  public ByteList[] split() {
++    return split(empty());
++  }
++
++  public ByteList[] split(ByteList sep) {
++    return split(sep, Integer.MAX_VALUE);
++  }
++
++  public ByteList[] split(ByteList sep, int maxSplit) {
++    if (maxSplit == -1) {
++      maxSplit = Integer.MAX_VALUE;
++    }
++    List<ByteList> split;
++    if (sep == null || sep.isEmpty()) {
++      // on whitespace
++      split = splitOnWhitespace(maxSplit);
++    } else {
++      split = splitOnSep(sep, maxSplit);
++    }
++    return split.toArray(new ByteList[0]);
++  }
++
++  public ByteList[] rsplit() {
++    return rsplit(empty());
++  }
++
++  public ByteList[] rsplit(ByteList sep) {
++    return rsplit(sep, Integer.MAX_VALUE);
++  }
++
++  public ByteList[] rsplit(ByteList sep, int maxSplit) {
++    if (maxSplit == -1) {
++      maxSplit = Integer.MAX_VALUE;
++    }
++    List<ByteList> rightSplit;
++    if (sep == null || sep.isEmpty()) {
++      // on whitespace
++      rightSplit = rightSplitOnWhitespace(maxSplit);
++    } else {
++      rightSplit = rightSplitOnSep(sep, maxSplit);
++    }
++    return rightSplit.toArray(new ByteList[0]);
++  }
++
++  List<ByteList> rightSplitOnWhitespace(int maxCount) {
++    List<ByteList> list = new ArrayList<>();
++    final int srcLength = size();
++    int i, j;
++    i = srcLength - 1;
++    while (maxCount-- > 0) {
++      while (i >= 0 && PY_ISSPACE.INSTANCE.test(charAt(i)))
++        i--;
++      if (i < 0) break;
++      j = i;
++      i--;
++      while (i >= 0 && !PY_ISSPACE.INSTANCE.test(charAt(i)))
++        i--;
++      if (j == srcLength - i && i < 0) {
++        /* No whitespace in str_obj, so just use it as list[0] */
++        list.add(substring(0));
++        break;
++      }
++      list.add(substring(i + 1, j + 1));
++    }
++    if (i >= 0) {
++      /* Only occurs when maxCount was reached */
++      /* Skip any remaining whitespace and copy to end of string */
++      while (i >= 0 && PY_ISSPACE.INSTANCE.test(charAt(i)))
++        i--;
++      if (i >= 0) {
++        list.add(substring(0, i + 1));
++      }
++    }
++    Collections.reverse(list);
++    return list;
++  }
++
++  List<ByteList> rightSplitOnSep(ByteList sep, int maxCount) {
++    if (sep.isEmpty()) {
++      throw new UnsupportedOperationException("empty separator not supported");
++    }
++    int pos, end, sepLen = sep.size();
++    final int srcLength = size();
++    List<ByteList> list = new ArrayList<>();
++    if (sepLen == 1) {
++      pos = end = srcLength - 1;
++      while ((pos >= 0) && (maxCount-- > 0)) {
++        for (; pos >= 0; pos--) {
++          if (get(pos) == sep.get(0)) {
++            list.add(substring(pos + 1, end + 1));
++            end = pos = pos - 1;
++            break;
++          }
++        }
++      }
++      if (end >= -1) {
++        list.add(substring(0, end + 1));
++      }
++      Collections.reverse(list);
++      return list;
++    }
++    end = srcLength;
++    while (true) {
++      pos = lastIndexOf(sep, 0, end - 1);
++      if (pos < 0 || maxCount-- == 0) {
++        list.add(substring(0, end));
++        break;
++      }
++      // if we're going to copy beyond the end of the array, copy to the end
++      // and just return
++      if (pos + sepLen > end) {
++        list.add(substring(pos, end));
++        break;
++      }
++      list.add(substring(pos + sepLen, end));
++      end = pos;
++    }
++    Collections.reverse(list);
++    return list;
++  }
++
++  List<ByteList> splitOnWhitespace(int maxCount) {
++    List<ByteList> list = new ArrayList<>();
++    final int srcLength = size();
++    int i = 0, j;
++    while ((maxCount--) > 0) {
++      while (i < srcLength && PY_ISSPACE.INSTANCE.test(charAt(i)))
++        i++;
++      if (i == srcLength) break;
++      j = i;
++      i++;
++      while (i < srcLength && !PY_ISSPACE.INSTANCE.test(charAt(i)))
++        i++;
++      if (j == 0 && i == srcLength) {
++        /* No whitespace in str_obj, so just use it as list[0] */
++        list.add(substring(0));
++        break;
++      }
++      list.add(substring(j, i));
++    }
++    if (i < srcLength) {
++      /* Only occurs when maxCount was reached */
++      /* Skip any remaining whitespace and copy to end of string */
++      while (i < srcLength && PY_ISSPACE.INSTANCE.test(charAt(i)))
++        i++;
++      if (i != srcLength) {
++        list.add(substring(i, srcLength));
++      }
++    }
++    return list;
++  }
++
++  List<ByteList> splitOnSep(ByteList sep, int maxsplit) {
++    int i, j, pos, maxCount = maxsplit, sepLen = sep.size();
++    List<ByteList> list = new ArrayList<>();
++    i = 0;
++    while ((maxCount--) > 0) {
++      pos = find(true, sep, i, size());
++      if (pos < 0) {
++        break;
++      }
++      j = pos;
++      list.add(substring(i, j));
++      i = j + sepLen;
++    }
++    list.add(substring(i));
++    return list;
++  }
++
++  public ByteList strip() {
++    return strip(null);
++  }
++
++  enum StripDirection {
++    LEFTSTRIP, RIGHTSTRIP, BOTHSTRIP
++  }
++
++  ByteList strip(StripDirection striptype, IntPredicate sepobj) {
++    if (isEmpty()) {
++      return empty();
++    }
++    int len = size();
++    int i = 0, j;
++    if (striptype != StripDirection.RIGHTSTRIP) {
++      while (i < len && sepobj.test(get(i))) {
++        i++;
++      }
++    }
++
++    j = len;
++    if (striptype != StripDirection.LEFTSTRIP) {
++      do {
++        j--;
++      } while (j >= i && sepobj.test(get(j)));
++      j++;
++    }
++
++    if (i == 0 && j == len) {
++      return this;
++    }
++    return substring(i, i + (j - i));
++  }
++
++  public ByteList strip(ByteList chars) {
++    IntPredicate finder = PY_ISSPACE.INSTANCE;
++    if (chars != null && !chars.isEmpty()) {
++      finder = chars.FINDER_PREDICATE;
++    }
++    return strip(StripDirection.BOTHSTRIP, finder);
++  }
++
++  public ByteList lstrip() {
++    return lstrip(null);
++  }
++
++  public ByteList lstrip(ByteList chars) {
++    IntPredicate finder = PY_ISSPACE.INSTANCE;
++    if (chars != null && !chars.isEmpty()) {
++      finder = chars.FINDER_PREDICATE;
++    }
++    return strip(StripDirection.LEFTSTRIP, finder);
++  }
++
++  public ByteList rstrip() {
++    return rstrip(null);
++  }
++
++  public ByteList rstrip(ByteList chars) {
++    IntPredicate finder = PY_ISSPACE.INSTANCE;
++    if (chars != null && !chars.isEmpty()) {
++      finder = chars.FINDER_PREDICATE;
++    }
++    return strip(StripDirection.RIGHTSTRIP, finder);
++  }
++
++  public int rfind(ByteList bytes) {
++    return rfind(bytes, 0, size());
++  }
++
++  public int rfind(ByteList bytes, int start) {
++    return rfind(bytes, start, size());
++  }
++
++  public int rfind(ByteList bytes, int start, int end) {
++    return find(false, bytes, start, end);
++  }
++
++  public int rfind(byte i) {
++    return rfind(i, 0, size());
++  }
++
++  public int rfind(byte i, int start) {
++    return rfind(i, start, size());
++  }
++
++  public int rfind(byte i, int start, int end) {
++    int subpos = substring(start, end).lastIndexOf(i);
++    return subpos < 0 ? subpos : subpos + start;
++  }
++
++  public ByteList removeprefix(ByteList prefix) {
++    final int self_len = size();
++    final int prefix_len = prefix.size();
++    if (self_len >= prefix_len && prefix_len > 0 && startsWith(prefix)) {
++      return ByteList.wrap(substring(prefix_len, prefix_len + (self_len - prefix_len)).toArray());
++    }
++    return this;
++  }
++
++  public ByteList removesuffix(ByteList suffix) {
++    final int self_len = size();
++    final int suffix_len = suffix.size();
++    if (self_len >= suffix_len && suffix_len > 0 && endsWith(suffix)) {
++      return ByteList.wrap(substring(0, self_len - suffix_len).toArray());
++    }
++    return this;
++  }
++
++  private boolean sequenceSatisfies(IntPredicate falsePredicate, IntPredicate truePredicate) {
++    final int inputLength = size();
++    if (inputLength == 0) {
++      return false;
++    }
++    boolean result = false;
++
++    for (byte ch : this) {
++      if (falsePredicate.test(ch)) {
++        return false;
++      } else if (!result && truePredicate.test(ch)) {
++        result = true;
++      }
++    }
++    return result;
++  }
++
++  public boolean isupper() {
++    return sequenceSatisfies(IsLowerCase.INSTANCE, IsUpperCase.INSTANCE);
++  }
++
++  public boolean islower() {
++    return sequenceSatisfies(IsUpperCase.INSTANCE, IsLowerCase.INSTANCE);
++  }
++
++  public boolean isspace() {
++    return isspace(PY_ISSPACE.INSTANCE);
++  }
++
++  public boolean isspace(IntPredicate checker) {
++    final int inputLength = size();
++    /* Shortcut for single character strings */
++    if (inputLength == 1 && checker.test(get(0))) {
++      return true;
++    }
++
++    /* Special case for empty strings */
++    if (inputLength == 0) {
++      return false;
++    }
++
++    for (byte b : this) {
++      if (!checker.test(b)) {
++        return false;
++      }
++    }
++    return true;
++  }
++
++  // iterable
++
++  /**
++   * Represents an operation that accepts a single {@code byte}-valued argument and returns no
++   * result. This is the primitive type specialization of {@code Consumer} for {@code byte}.
++   *
++   * Unlike most other functional interfaces, {@code ByteConsumer} is expected to operate via
++   * side-effects. This is a functional interface whose functional method is {@link #accept(byte)}.
++   */
++  @FunctionalInterface
++  public interface ByteConsumer {
++    /**
++     * Performs this operation on the given argument.
++     *
++     * @param value the input argument
++     */
++    void accept(final byte value);
++
++    /**
++     * Returns a composed {@code ByteConsumer} that performs, in sequence, this operation followed
++     * by the {@code after} operation.
++     * <p>
++     * If {@code after} is {@code null}, a {@code NullPointerException} will be thrown.
++     * <p>
++     * If performing either operation throws an exception, it is relayed to the caller of the
++     * composed operation.
++     * <p>
++     * If performing this operation throws an exception, the {@code after} operation will not be
++     * performed.
++     *
++     * @param after the operation to perform after this operation
++     * @return a composed {@code ByteConsumer} that performs, in sequence, this operation followed
++     * by the {@code after} operation
++     * @throws NullPointerException thrown if, and only if, {@code after} is {@code null}
++     */
++    default ByteConsumer andThen(final ByteConsumer after) {
++      Objects.requireNonNull(after, "after == null");
++
++      return (byte t) -> {
++        accept(t);
++
++        after.accept(t);
++      };
++    }
++  }
++
++  /**
++   * An {@code Iterator} specialized for {@code byte} values.
++   *
++   * This interface extends {@code PrimitiveIterator<T, T_CONS>}, so that we can return an unboxed
++   * {@code byte}.
++   */
++  public interface OfByte extends PrimitiveIterator<Byte, ByteConsumer> {
++
++    /**
++     * Returns the next {@code byte} element in the iteration.
++     *
++     * If the iteration has no more elements, a {@code NoSuchElementException} will be thrown.
++     *
++     * @return the next {@code byte} element in the iteration
++     * @throws NoSuchElementException thrown if, and only if, the iteration has no more elements
++     */
++    byte nextByte();
++
++    /**
++     * {@inheritDoc}
++     */
++    @Override
++    default Byte next() {
++      // Boxing calls Byte.valueOf(byte), which does not instantiate.
++      return nextByte();
++    }
++
++    /**
++     * {@inheritDoc}
++     */
++    @Override
++    default void forEachRemaining(final Consumer<? super Byte> action) {
++      if (action instanceof ByteConsumer) {
++        forEachRemaining((ByteConsumer) (action));
++      } else {
++        Objects.requireNonNull(action);
++        forEachRemaining((ByteConsumer) (action::accept));
++      }
++    }
++
++    /**
++     * {@inheritDoc}
++     */
++    @Override
++    default void forEachRemaining(final ByteConsumer action) {
++      Objects.requireNonNull(action);
++
++      while (hasNext()) {
++        action.accept(nextByte());
++      }
++    }
++
++    /**
++     * Unwraps an iterator into an array starting at a given offset for a given number of elements.
++     *
++     * <p>This method iterates over the given {@link ByteList.OfByte} iterator and stores the
++     * elements
++     * returned, up to a maximum of {@code length}, in the given array starting at {@code offset}.
++     * The number of actually unwrapped elements is returned (it may be less than {@code max} if the
++     * iterator emits less than {@code max} elements).
++     *
++     * @param i      a {@link ByteList.OfByte} iterator iterator.
++     * @param array  an array to contain the output of the iterator.
++     * @param offset the first element of the array to be returned.
++     * @param max    the maximum number of elements to unwrap.
++     * @return the number of elements unwrapped.
++     */
++    static int unwrap(final OfByte i, final byte[] array, int offset, final int max) {
++      if (max < 0)
++        throw new IllegalArgumentException("The maximum number of elements (" + max + ") is negative");
++      if (offset < 0 || offset + max > array.length) throw new IllegalArgumentException();
++      int j = max;
++      while (j-- != 0 && i.hasNext()) array[offset++] = i.nextByte();
++      return max - j - 1;
++    }
++
++    /**
++     * Determines whether this iterator is equal to another iterator's elements in the same order.
++     * More specifically, this method returns {@code true} if this iterator and {@code o} contain
++     * the same number of elements and every element of this iterator is equal to the corresponding
++     * element of {@code o}.
++     *
++     * <p>Note that this will modify the supplied iterators, since they will have been advanced
++     * some
++     * number of elements forward.
++     */
++    default boolean itemsEqual(@NotNull Iterator<?> o) {
++      return itemsEqual(this, o);
++    }
++
++    /**
++     * Determines whether iterator1 is equal to iterator2's elements in the same order. More
++     * specifically, this method returns {@code true} if {@code iterator1} and {@code iterator2}
++     * contain the same number of elements and every element of {@code iterator1} is equal to the
++     * corresponding element of {@code iterator2}.
++     *
++     * <p>Note that this will modify the supplied iterators, since they will have been advanced
++     * some
++     * number of elements forward.
++     */
++    static boolean itemsEqual(@NotNull Iterator<?> iterator1, @NotNull Iterator<?> iterator2) {
++      while (iterator1.hasNext()) {
++        if (!iterator2.hasNext()) {
++          return false;
++        }
++        Object o1 = iterator1.next();
++        Object o2 = iterator2.next();
++        if (!Objects.equals(o1, o2)) {
++          return false;
++        }
++      }
++      return !iterator2.hasNext();
++    }
++
++    /**
++     * Calls {@code next()} on this iterator, either {@code numberToAdvance} times or until {@code
++     * hasNext()} returns {@code false}, whichever comes first.
++     */
++    default int advance(int numberToAdvance) {
++      if (numberToAdvance < 0)
++        throw new IllegalArgumentException("numberToAdvance (" + numberToAdvance + ") is negative!");
++      int i = 0;
++      while (i < numberToAdvance && hasNext()) {
++        next();
++        i++;
++      }
++      return i;
++    }
++
++  }
++
++  /**
++   * Return a {@link OfByte} over the bytes in the ByteString. To avoid auto-boxing, you may get the
++   * iterator manually and call {@link OfByte#nextByte()}.
++   *
++   * @return the iterator
++   */
++  @Override
++  public OfByte iterator() {
++    return new OfByte() {
++      private int position = 0;
++      private final int limit = size();
++
++      @Override
++      public byte nextByte() {
++        int currentPos = position;
++        if (currentPos >= limit) {
++          throw new NoSuchElementException();
++        }
++        position = currentPos + 1;
++        return byteAt(currentPos);
++      }
++
++      @Override
++      public boolean hasNext() {
++        return position < limit;
++      }
++    };
++  }
++
++  /**
++   * This class is used to represent the substring of a {@link ByteList} over a single byte array.
++   * In terms of the public API of {@link ByteList}, you end up here by calling {@link
++   * ByteList#copy(byte[])} followed by {@link ByteList#substring(int, int)}.
++   *
++   * <p>This class contains most of the overhead involved in creating a substring from a {@link
++   * ByteList}. The overhead involves some range-checking and two extra fields.
++   */
++  private static final class SubByteList extends ByteList {
++    /**
++     * Creates a {@code BoundedByteString} backed by the sub-range of given array, without copying.
++     *
++     * @param bytes  array to wrap
++     * @param offset index to first byte to use in bytes
++     * @param length number of bytes to use from bytes
++     * @throws IllegalArgumentException if {@code offset < 0}, {@code length < 0}, or if {@code
++     *                                  offset + length > bytes.length}.
++     */
++    SubByteList(byte[] bytes, int offset, int length) {
++      super(bytes);
++      checkRange(offset, offset + length, bytes.length);
++      this.offset(offset);
++      this.size(length);
++    }
++
++    /**
++     * Gets the byte at the given index. Throws {@link ArrayIndexOutOfBoundsException} for
++     * backwards-compatibility reasons although it would more properly be {@link
++     * IndexOutOfBoundsException}.
++     *
++     * @param index index of byte
++     * @return the value
++     * @throws ArrayIndexOutOfBoundsException {@code index} is < 0 or >= size
++     */
++    @Override
++    public byte byteAt(int index) {
++      // We must check the index ourselves as we cannot rely on Java array index
++      // checking for substrings.
++      checkBounds(index, size());
++      return array[offset() + index];
++    }
++  }
++
++  // ByteList java.lang.String method equivalents
++
++  /**
++   * @see String#contentEquals(CharSequence)
++   */
++  public boolean contentEquals(ByteList that) {
++    if (size() != that.size()) {
++      return false;
++    }
++    OfByte thisBytes = iterator();
++    OfByte thatBytes = that.iterator();
++    while (thisBytes.hasNext()) {
++      if (!thatBytes.hasNext()) {
++        return false;
++      } else if (thisBytes.nextByte() != thatBytes.nextByte()) {
++        return false;
++      }
++    }
++    return true;
++  }
++
++  /**
++   * Tests for the presence of a specific sequence of bytes in a larger array at a specific
++   * location.<br/> If {@code this} is {@code null} there is a case for a match. First, if {@code
++   * start} is non-zero, an {@code IllegalArgumentException} will be thrown. If {@code start} is
++   * {@code 0}, will evaluate to {@code true} if {@code pattern} is {@code null}; {@code false}
++   * otherwise.<br/> In all other cases, a {@code null} pattern will never match.
++   *
++   * @param start   the index at which to look for a match. The length of {@code pattern} added to
++   *                this index must not pass the end of {@code src.}
++   * @param pattern the series of {@code byte}s to match. If {@code null}, will only match a {@code
++   *                null} {@code src} at position {@code 0}.
++   * @return {@code true} if {@code pattern} is found in {@code src} at {@code start}.
++   */
++  public boolean constantTimeEquals(int start, byte[] pattern) {
++    if (isEmpty()) {
++      if (start == 0) {
++        return pattern == null;
++      }
++      throw new IllegalArgumentException("start index after end of src");
++    }
++    if (pattern == null) {
++      return false;
++    }
++    final int srcLength = size();
++    // At this point neither src or pattern are null...
++    if (start >= srcLength) {
++      throw new IllegalArgumentException("start index after end of src");
++    }
++    if (srcLength < start + pattern.length) {
++      return false;
++    }
++    int result = 0;
++    // time-constant comparison
++    for (int i = 0; i < pattern.length; i++) {
++      result |= pattern[i] ^ get(start + i);
++    }
++    return result == 0;
++  }
++
++  /**
++   * Given an integer, will return a new list with n consecutive repeats of the underlying value.
++   *
++   * @param value The number of times to repeat the entire list
++   * @return a new ByteList with n consecutive repeats of the underlying value.
++   */
++  public ByteList repeat(int value) {
++    int newSize = value * size();
++    if (newSize > MAXIMUM_CAPACITY) {
++      // TODO: avoid allocation
++      throw new IllegalArgumentException(String.format("excessive repeat (%d * %d elements)", size(), value));
++    }
++    byte[] res = new byte[newSize];
++    for (int i = 0; i < value; i++) {
++      System.arraycopy(array, 0, res, i * size(), size());
++    }
++    return wrap(res);
++  }
++
++  /**
++   * Tests if this bytestring starts with the specified prefix. Similar to {@link
++   * String#startsWith(String)}
++   *
++   * @param prefix the prefix.
++   * @return <code>true</code> if the byte sequence represented by the argument is a prefix of the
++   * byte sequence represented by this string; <code>false</code> otherwise.
++   */
++  public final boolean startsWith(ByteList prefix) {
++    return size() >= prefix.size() && substring(0, prefix.size()).equals(prefix);
++  }
++
++  /**
++   * Tests if this bytestring ends with the specified suffix. Similar to {@link
++   * String#endsWith(String)}
++   *
++   * @param suffix the suffix.
++   * @return <code>true</code> if the byte sequence represented by the argument is a suffix of the
++   * byte sequence represented by this string; <code>false</code> otherwise.
++   */
++  public final boolean endsWith(ByteList suffix) {
++    return size() >= suffix.size() && substring(size() - suffix.size()).equals(suffix);
++  }
++
++  public final boolean endsWith(byte[] suffix) {
++    return endsWith(ByteList.wrap(suffix));
++  }
++
++  /**
++   * Return the substring from {@code beginIndex}, inclusive, to the end of the string.
++   *
++   * @param beginIndex start at this index
++   * @return substring sharing underlying data
++   * @throws IndexOutOfBoundsException if {@code beginIndex < 0} or {@code beginIndex > size()}.
++   */
++  public final ByteList substring(int beginIndex) {
++    return substring(beginIndex, size());
++  }
++
++  /**
++   * Return the substring from {@code beginIndex}, inclusive, to {@code endIndex}, exclusive.
++   *
++   * @param beginIndex start at this index
++   * @param endIndex   the last character is the one before this index
++   * @return substring sharing underlying data
++   * @throws IndexOutOfBoundsException if {@code beginIndex < 0}, {@code endIndex > size()}, or
++   *                                   {@code beginIndex > endIndex}.
++   */
++  public final ByteList substring(int beginIndex, int endIndex) {
++    beginIndex = toIndex(beginIndex, size());
++    endIndex = toIndex(endIndex, size());
++
++    final int length = checkRange(beginIndex, endIndex, size());
++
++    if (length == 0) {
++      return EMPTY;
++    }
++
++    return new SubByteList(array, offset() + beginIndex, length);
++  }
++
++  /**
++     * Returns the effective index denoted by a user-supplied integer. First, if the integer is
++     * negative, the length of the sequence is added to it, so an index of -1 represents the last
++     * element of the sequence. Then, the integer is "clamped" into the inclusive interval [0,
++     * length].
++     */
++    static int toIndex(int index, int length) {
++      if (index < 0) {
++        index += length;
++      }
++
++      if (index < 0) {
++        return 0;
++      } else {
++        return Math.min(index, length);
++      }
++    }
++
++  public ByteListIterator listIterator() {
++    return new ByteListIterator(0);
++  }
++
++  public ByteListIterator listIterator(int index) {
++    return new ByteListIterator(index);
++  }
++
++  public class ByteListIterator implements ListIterator<Byte>, OfByte {
++
++    private int pos;
++    private int last;
++
++    ByteListIterator(int index) {
++      pos = index;
++      last = -1;
++    }
++
++    @Override
++    public boolean hasNext() {
++      return pos < size();
++    }
++
++    @Override
++    public byte nextByte() {
++      if (! hasNext()) throw new NoSuchElementException(); return get(last = pos++);
++    }
++
++    public byte previousByte() { if (!hasPrevious()) throw new NoSuchElementException(); return get(last = --pos); }
++
++    @Override
++    public Byte next() {
++      return nextByte();
++    }
++
++    @Override
++    public boolean hasPrevious() {
++      return pos > 0;
++    }
++
++    @Override
++    public Byte previous() {
++      return previousByte();
++    }
++
++    @Override
++    public int nextIndex() {
++      return pos;
++    }
++
++    @Override
++    public int previousIndex() {
++      return pos - 1;
++    }
++
++    @Override
++    public void remove() {
++      if (last == -1) throw new IllegalStateException();
++      ByteList.this.remove(last);
++      /* If the last operation was a next(), we are removing an element *before* us, and we must
++         decrease pos correspondingly. */
++      if (last < pos) pos--;
++      last = -1;
++    }
++
++    @Override
++    public void set(Byte k) {
++      if (last == -1) throw new IllegalStateException();
++      ByteList.this.set(last, k);
++    }
++
++    @Override
++    public void add(Byte k) {
++      ByteList.this.add(pos++, k);
++      last = -1;
++    }
++  }
++
++}
+diff --git b/libstarlark/src/main/java/net/starlark/java/ext/ByteStringModuleApi.java a/libstarlark/src/main/java/net/starlark/java/ext/ByteStringModuleApi.java
+new file mode 100644
+index 00000000..161ee157
+--- /dev/null
++++ a/libstarlark/src/main/java/net/starlark/java/ext/ByteStringModuleApi.java
+@@ -0,0 +1,874 @@
++package net.starlark.java.ext;
++
++import net.starlark.java.annot.Param;
++import net.starlark.java.annot.ParamType;
++import net.starlark.java.annot.StarlarkMethod;
++import net.starlark.java.eval.EvalException;
++import net.starlark.java.eval.NoneType;
++import net.starlark.java.eval.Sequence;
++import net.starlark.java.eval.StarlarkBytes;
++import net.starlark.java.eval.StarlarkInt;
++import net.starlark.java.eval.StarlarkList;
++import net.starlark.java.eval.StarlarkThread;
++import net.starlark.java.eval.Tuple;
++
++public interface ByteStringModuleApi {
++
++  @StarlarkMethod(
++      name = "hex",
++      doc =
++        "Return a string object containing two hexadecimal digits for each byte in " +
++          "the instance.\n" +
++          "\n" +
++        ">>> b'\\xf0\\xf1\\xf2'.hex()\n" +
++        "'f0f1f2'" +
++        "\n" +
++        "If you want to make the hex string easier to read, you can specify a single character " +
++          "separator sep parameter to include in the output. By default between each byte. " +
++          "A second optional bytes_per_sep parameter controls the spacing. Positive values " +
++          "calculate the separator position from the right, negative values from the left.\n" +
++        "\n" +
++        ">>> value = b'\\xf0\\xf1\\xf2'\n" +
++        ">>> value.hex('-')\n" +
++        "'f0-f1-f2'" + "\n" +
++        ">>> value.hex('_', 2)\n" +
++        "'f0_f1f2'" + "\n" +
++        ">>> b'UUDDLRLRAB'.hex(' ', -4)\n" +
++        "'55554444 4c524c52 4142'",
++      parameters = {
++        @Param(name = "sep", allowedTypes = {
++          @ParamType(type = String.class),
++          @ParamType(type = StarlarkBytes.class),
++        },defaultValue = "unbound"),
++        @Param(
++          name = "bytes_per_sep",
++          allowedTypes = {
++            @ParamType(type = StarlarkInt.class)
++          },
++          defaultValue = "-1"
++        )
++      })
++    String hex(Object sepO, StarlarkInt bytesPerSep) throws EvalException;
++
++
++  @StarlarkMethod(
++    name = "count",
++    doc =
++      "Return the number of non-overlapping occurrences of subsequence sub in the range " +
++        "[start, end]. Optional arguments start and end are interpreted as in slice " +
++        "notation." +
++        "\n" +
++        "The subsequence to search for may be any bytes-like object or an integer in the " +
++        "range 0 to 255.",
++    parameters = {
++      @Param(name = "sub", allowedTypes = {
++        @ParamType(type = StarlarkInt.class),
++        @ParamType(type = StarlarkBytes.class),
++      }),
++      @Param(
++        name = "start",
++        allowedTypes = {
++          @ParamType(type = StarlarkInt.class),
++          @ParamType(type = NoneType.class),
++        },
++        defaultValue = "0",
++        doc = "Restrict to search from this position."),
++      @Param(
++        name = "end",
++        allowedTypes = {
++          @ParamType(type = StarlarkInt.class),
++          @ParamType(type = NoneType.class),
++        },
++        defaultValue = "unbound",
++        doc = "optional position before which to restrict to search.")
++    })
++  int count(Object sub, Object start, Object end) throws EvalException;
++
++  @StarlarkMethod(
++    name = "removeprefix",
++    doc =
++      "If the binary data starts with the prefix string, return bytes[len(prefix):]. " +
++        "Otherwise, return a copy of the original binary data:" +
++        "",
++    parameters = {
++      @Param(name = "prefix", allowedTypes = {
++        @ParamType(type = StarlarkBytes.class),
++      },
++        doc = "The prefix may be any bytes-like object.")})
++  StarlarkBytes removeprefix(StarlarkBytes prefix) throws EvalException;
++
++  @StarlarkMethod(
++    name = "removesuffix",
++    doc =
++      "If the binary data ends with the suffix string and that suffix is not empty, " +
++        "return bytes[:-len(suffix)]. Otherwise, return a copy of the original binary" +
++        " data:\n" +
++        ">>> b'MiscTests'.removesuffix(b'Tests')\n" +
++        "b'Misc'\n" +
++        ">>> b'TmpDirMixin'.removesuffix(b'Tests')\n" +
++        "b'TmpDirMixin'\n" +
++        "The suffix may be any bytes-like object.",
++    parameters = {
++      @Param(name = "suffix", allowedTypes = {
++        @ParamType(type = StarlarkBytes.class),
++      },
++        doc = "The suffix may be any bytes-like object.")})
++  StarlarkBytes removesuffix(StarlarkBytes suffix) throws EvalException;
++
++    @StarlarkMethod(
++        name = "decode",
++        parameters = {
++            @Param(name = "encoding", defaultValue = "'utf-8'"),
++            @Param(name ="errors", defaultValue = "'strict'")
++        })
++  String decode(String encoding, String errors) throws EvalException;
++
++  @StarlarkMethod(
++    name = "endswith",
++    doc = "B.endswith(suffix[, start[, end]]) -> bool\n" +
++            "\n" +
++            "Return True if B ends with the specified suffix, False otherwise.\n" +
++            "With optional start, test B beginning at that position.\n" +
++            "With optional end, stop comparing B at that position.\n" +
++            "suffix can also be a tuple of bytes to try.\n.",
++    parameters = {
++      @Param(
++        name = "suffix",
++        allowedTypes = {
++          @ParamType(type = StarlarkBytes.class),
++          @ParamType(type = Tuple.class, generic1 = StarlarkBytes.class),
++        },
++        doc = "The suffix (or tuple of alternative suffixes) to match."),
++      @Param(
++        name = "start",
++        allowedTypes = {
++          @ParamType(type = StarlarkInt.class),
++          @ParamType(type = NoneType.class),
++        },
++        defaultValue = "0",
++        doc = "Test beginning at this position."),
++      @Param(
++        name = "end",
++        allowedTypes = {
++          @ParamType(type = StarlarkInt.class),
++          @ParamType(type = NoneType.class),
++        },
++        defaultValue = "None",
++        doc = "optional position at which to stop comparing.")
++    })
++  boolean endsWith(Object suffix, Object start, Object end) throws EvalException;
++
++  @StarlarkMethod(
++    name = "find",
++    doc =
++      "Return the lowest index in the data where the subsequence sub is found, such that sub is contained in the slice s[start:end]. Optional arguments start and end are interpreted as in slice notation. Return -1 if sub is not found.\n" +
++        "\n" +
++        "The subsequence to search for may be any bytes-like object or an integer in the range 0 to 255.\n" +
++        "\n" +
++        "Note The find() method should be used only if you need to know the position of sub. To check if sub is a substring or not, use the in operator:\n" +
++        ">>>\n" +
++        ">>> b'Py' in b'Python'\n" +
++        "True",
++    parameters = {
++      @Param(name = "sub", allowedTypes = {
++        @ParamType(type = StarlarkInt.class),
++        @ParamType(type = StarlarkBytes.class),
++      }),
++      @Param(
++        name = "start",
++        allowedTypes = {
++          @ParamType(type = StarlarkInt.class),
++          @ParamType(type = NoneType.class),
++        },
++        defaultValue = "0",
++        doc = "Restrict to search from this position."),
++      @Param(
++        name = "end",
++        allowedTypes = {
++          @ParamType(type = StarlarkInt.class),
++          @ParamType(type = NoneType.class),
++        },
++        defaultValue = "unbound",
++        doc = "optional position before which to restrict to search.")
++    })
++  int find(Object sub, Object start, Object end) throws EvalException;
++
++  @StarlarkMethod(
++    name = "index",
++    doc =
++      "Like find(), but raise ValueError when the subsequence is not found.\n" +
++        "\n" +
++        "The subsequence to search for may be any bytes-like object or an integer in the range 0 to 255.",
++    parameters = {
++      @Param(name = "sub", allowedTypes = {
++        @ParamType(type = StarlarkInt.class),
++        @ParamType(type = StarlarkBytes.class),
++      }),
++      @Param(
++        name = "start",
++        allowedTypes = {
++          @ParamType(type = StarlarkInt.class),
++          @ParamType(type = NoneType.class),
++        },
++        defaultValue = "0",
++        doc = "Restrict to search from this position."),
++      @Param(
++        name = "end",
++        allowedTypes = {
++          @ParamType(type = StarlarkInt.class),
++          @ParamType(type = NoneType.class),
++        },
++        defaultValue = "unbound",
++        doc = "optional position before which to restrict to search.")
++    })
++  int index(Object sub, Object start, Object end) throws EvalException;
++
++
++  @StarlarkMethod(
++    name = "join",
++    doc = "Concatenate any number of bytes objects.\n" +
++            "\n" +
++            "The bytes whose method is called is inserted in between each pair.\n" +
++            "\n" +
++            "The result is returned as a new bytes object.\n" +
++            "\n" +
++            "Example: b'.'.join([b'ab', b'pq', b'rs']) -> b'ab.pq.rs'.\n",
++    parameters = {
++      @Param(name = "iterable_of_bytes", doc = "The bytes to join,",
++        allowedTypes = {
++          @ParamType(type = Sequence.class, generic1 = StarlarkBytes.class)
++        })
++  })
++  StarlarkBytes join(Sequence<StarlarkBytes> elements) throws EvalException;
++
++  @StarlarkMethod(
++    name = "partition",
++    doc =
++      "Split the sequence at the first occurrence of sep, and return a 3-tuple containing the" +
++        " part before the separator, the separator itself or its bytearray copy, and the part" +
++        " after the separator. If the separator is not found, return a 3-tuple containing a " +
++        "copy of the original sequence, followed by two empty bytes or bytearray objects." +
++        "\n" +
++        "The separator to search for may be any bytes-like object.",
++    parameters = {@Param(name = "sep", doc = "The bytes-like object separator to search for")})
++  Tuple partition(StarlarkBytes sep) throws EvalException;
++
++  @StarlarkMethod(
++    name = "replace",
++    doc =
++      "Return a copy of the sequence with all occurrences of subsequence old replaced " +
++        "by new. If the optional argument count is given, only the first count " +
++        "occurrences are replaced." +
++        "\n" +
++        "The subsequence to search for and its replacement may be any bytes-like" +
++        " object.",
++    parameters = {
++      @Param(name = "old", doc = "The bytes-like object to be replaced."),
++      @Param(name = "new", doc = "The bytes-like object to replace with."),
++      @Param(
++        name = "count",
++        defaultValue = "-1",
++        doc =
++          "The maximum number of replacements. If omitted, or if the value is negative, "
++            + "there is no limit.")
++    },
++    useStarlarkThread = true)
++  StarlarkBytes replace(StarlarkBytes oldBytes, StarlarkBytes newBytes, StarlarkInt countI, StarlarkThread thread)
++    throws EvalException;
++
++  @StarlarkMethod(
++    name = "rfind",
++    doc =
++      "Return the highest index in the sequence where the subsequence sub is found, " +
++        "such that sub is contained within s[start:end]. " +
++        "Optional arguments start and end are interpreted as in slice notation. " +
++        "Return -1 on failure.\n" +
++        "\n" +
++        "The subsequence to search for may be any bytes-like object or an integer in " +
++        "the range 0 to 255.",
++    parameters = {
++      @Param(name = "sub", allowedTypes = {
++        @ParamType(type = StarlarkInt.class),
++        @ParamType(type = StarlarkBytes.class),
++      }),
++      @Param(
++        name = "start",
++        allowedTypes = {
++          @ParamType(type = StarlarkInt.class),
++          @ParamType(type = NoneType.class),
++        },
++        defaultValue = "0",
++        doc = "Restrict to search from this position."),
++      @Param(
++        name = "end",
++        allowedTypes = {
++          @ParamType(type = StarlarkInt.class),
++          @ParamType(type = NoneType.class),
++        },
++        defaultValue = "None",
++        doc = "optional position before which to restrict to search.")
++    })
++  int rfind(Object sub, Object start, Object end) throws EvalException;
++
++  @StarlarkMethod(
++    name = "rindex",
++    doc =
++      "Like rfind(), but raise ValueError when the subsequence sub is not found.\n" +
++        "\n" +
++        "The subsequence to search for may be any bytes-like object or an integer in the range 0 to 255.",
++    parameters = {
++      @Param(name = "sub", allowedTypes = {
++        @ParamType(type = StarlarkInt.class),
++        @ParamType(type = StarlarkBytes.class),
++      }),
++      @Param(
++        name = "start",
++        allowedTypes = {
++          @ParamType(type = StarlarkInt.class),
++          @ParamType(type = NoneType.class),
++        },
++        defaultValue = "0",
++        doc = "Restrict to search from this position."),
++      @Param(
++        name = "end",
++        allowedTypes = {
++          @ParamType(type = StarlarkInt.class),
++          @ParamType(type = NoneType.class),
++        },
++        defaultValue = "None",
++        doc = "optional position before which to restrict to search.")
++    })
++  int rindex(Object sub, Object start, Object end) throws EvalException;
++
++  @StarlarkMethod(
++    name = "rpartition",
++    doc =
++      "Split the sequence at the last occurrence of sep, and return a 3-tuple containing " +
++        "the part before the separator, the separator itself or its bytearray copy, and the" +
++        " part after the separator. If the separator is not found, return a 3-tuple " +
++        "containing two empty bytes or bytearray objects, followed by a copy of the " +
++        "original sequence." +
++        "\n" +
++        "The separator to search for may be any bytes-like object.",
++    parameters = {@Param(name = "sep", doc = "The bytes-like object separator to search for")})
++  Tuple rpartition(StarlarkBytes sep) throws EvalException;
++
++  @StarlarkMethod(
++    name = "startswith",
++    doc = "B.startswith(prefix[, start[, end]]) -> bool\n" +
++            "\n" +
++            "Return True if B starts with the specified prefix, False otherwise.\n" +
++            "With optional start, test B beginning at that position.\n" +
++            "With optional end, stop comparing B at that position.\n" +
++            "prefix can also be a tuple of bytes to try.\n",
++    parameters = {
++      @Param(
++        name = "prefix",
++        allowedTypes = {
++          @ParamType(type = StarlarkBytes.class),
++          @ParamType(type = Tuple.class, generic1 = StarlarkBytes.class),
++        },
++        doc = "The prefix (or tuple of alternative prefixes) to match."),
++      @Param(
++        name = "start",
++        allowedTypes = {
++          @ParamType(type = StarlarkInt.class),
++          @ParamType(type = NoneType.class),
++        },
++        defaultValue = "0",
++        doc = "Test beginning at this position."),
++      @Param(
++        name = "end",
++        allowedTypes = {
++          @ParamType(type = StarlarkInt.class),
++          @ParamType(type = NoneType.class),
++        },
++        defaultValue = "None",
++        doc = "Stop comparing at this position.")
++    })
++  boolean startsWith(Object prefix, Object start, Object end)
++    throws EvalException;
++
++  @StarlarkMethod(
++    name = "translate",
++    doc = "Return a copy of the bytes or bytearray object where all bytes occurring in the " +
++            "optional argument delete are removed, and the remaining bytes have been mapped through the given translation table, which must be a bytes object of length 256.\n" +
++            "\n" +
++            "You can use the bytes.maketrans() method to create a translation table.\n" +
++            "\n" +
++            "Set the table argument to None for translations that only delete characters:\n" +
++            "\n" +
++            ">>>\n" +
++            ">>> b'read this short text'.translate(None, b'aeiou')\n" +
++            "b'rd ths shrt txt'",
++    parameters = {
++      @Param(
++        name = "table",
++        allowedTypes = {
++          @ParamType(type = StarlarkBytes.class),
++          @ParamType(type = NoneType.class),
++        },
++        doc = "Translation table, which must be a bytes object of length 256."),
++      @Param(
++        name = "delete",
++        allowedTypes = {
++          @ParamType(type = StarlarkBytes.class)
++        },
++        named = true,
++        defaultValue = "b''",
++        doc = "All characters occurring in the argument delete are removed.")
++    })
++  StarlarkBytes translate(Object tableO, StarlarkBytes delete)
++    throws EvalException;
++
++  //  The following methods on bytes and bytearray objects have default
++  //  behaviours that assume the use of ASCII compatible binary formats,
++  //  but can still be used with arbitrary binary data by passing
++  //  appropriate arguments.
++  //
++  //  Note that all of the bytearray methods in this section do not
++  //  operate in place, and instead produce new objects
++
++  @StarlarkMethod(
++    name = "center",
++    doc = "Return a copy of the object centered in a sequence of length width. Padding is done using the specified fillbyte (default is an ASCII space). For bytes objects, the original sequence is returned if width is less than or equal to len(s).",
++    parameters = {
++      @Param(
++        name = "width",
++        allowedTypes = {
++          @ParamType(type = StarlarkInt.class)
++        }), @Param(
++      name = "fillbyte",
++      allowedTypes = {
++        @ParamType(type = StarlarkBytes.class),
++      }, defaultValue = "b' '")
++    })
++  StarlarkBytes center(StarlarkInt width, StarlarkBytes fillbyte) throws EvalException;
++
++  @StarlarkMethod(
++    name = "ljust",
++    doc = "Return a copy of the object left justified in a sequence of length width. Padding is done using the specified fillbyte (default is an ASCII space). For bytes objects, the original sequence is returned if width is less than or equal to len(s).",
++    parameters = {
++      @Param(
++        name = "width",
++        allowedTypes = {
++          @ParamType(type = StarlarkInt.class)
++        }), @Param(
++      name = "fillbyte",
++      allowedTypes = {
++        @ParamType(type = StarlarkBytes.class),
++      }, defaultValue = "b' '")
++    })
++  StarlarkBytes ljust(StarlarkInt width, StarlarkBytes fillbyte) throws EvalException;
++
++  @StarlarkMethod(
++    name = "lstrip",
++    doc = "" +
++            "Return a copy of the sequence with specified leading bytes removed. The chars argument is a binary sequence specifying the set of byte values to be removed - the name refers to the fact this method is usually used with ASCII characters. If omitted or None, the chars argument defaults to removing ASCII whitespace. The chars argument is not a prefix; rather, all combinations of its values are stripped:\n" +
++            "\n" +
++            ">>>\n" +
++            ">>> b'   spacious   '.lstrip()\n" +
++            "b'spacious   '\n" +
++            ">>> b'www.example.com'.lstrip(b'cmowz.')\n" +
++            "b'example.com'\n" +
++            "The binary sequence of byte values to remove may be any bytes-like object. See removeprefix() for a method that will remove a single prefix string rather than all of a set of characters. For example:\n" +
++            "\n" +
++            ">>>\n" +
++            ">>> b'Arthur: three!'.lstrip(b'Arthur: ')\n" +
++            "b'ee!'\n" +
++            ">>> b'Arthur: three!'.removeprefix(b'Arthur: ')\n" +
++            "b'three!'",
++    parameters = {
++      @Param(
++        name = "chars",
++        allowedTypes = {
++          @ParamType(type = StarlarkBytes.class),
++          @ParamType(type = NoneType.class),
++        },
++        defaultValue = "None")
++    })
++  StarlarkBytes lstrip(Object charsO);
++
++  @StarlarkMethod(
++    name = "rjust",
++    doc = "Return a copy of the object right justified in a sequence of length width. Padding is done using the specified fillbyte (default is an ASCII space). For bytes objects, the original sequence is returned if width is less than or equal to len(s).",
++    parameters = {
++      @Param(
++        name = "width",
++        allowedTypes = {
++          @ParamType(type = StarlarkInt.class)
++        }), @Param(
++      name = "fillbyte",
++      allowedTypes = {
++        @ParamType(type = StarlarkBytes.class),
++      }, defaultValue = "b' '")
++    })
++  StarlarkBytes rjust(StarlarkInt width, StarlarkBytes fillbyte) throws EvalException;
++
++  @StarlarkMethod(
++    name = "rsplit",
++    doc = "" +
++            "Split the binary sequence into subsequences of the same type, using sep as the" +
++            " delimiter string. If maxsplit is given, at most maxsplit splits are done, the" +
++            " rightmost ones. If sep is not specified or None, any subsequence consisting " +
++            "solely of ASCII whitespace is a separator. Except for splitting from the " +
++            "right, rsplit() behaves like split() which is described in detail below.\n" +
++            "\n",
++    parameters = {
++      @Param(name = "sep", doc = "The delimiter to split on.", named=true,
++        allowedTypes = {
++        @ParamType(type = StarlarkBytes.class),
++        @ParamType(type = NoneType.class)
++      }, defaultValue = "None"),
++      @Param(
++        name = "maxsplit", named=true,
++        allowedTypes = {
++          @ParamType(type = StarlarkInt.class),
++          @ParamType(type = NoneType.class),
++        },
++        defaultValue = "-1",
++        doc = "The maximum number of splits.")
++    },
++    useStarlarkThread = true)
++  StarlarkList<StarlarkBytes> rsplit(Object bytesO, Object maxSplitO, StarlarkThread thread) throws EvalException;
++
++  @StarlarkMethod(
++    name = "rstrip",
++    doc = "Return a copy of the sequence with specified trailing bytes removed. The chars argument is a binary sequence specifying the set of byte values to be removed - the name refers to the fact this method is usually used with ASCII characters. If omitted or None, the chars argument defaults to removing ASCII whitespace. The chars argument is not a suffix; rather, all combinations of its values are stripped:\n" +
++            "\n" +
++            ">>>\n" +
++            ">>> b'   spacious   '.rstrip()\n" +
++            "b'   spacious'\n" +
++            ">>> b'mississippi'.rstrip(b'ipz')\n" +
++            "b'mississ'\n" +
++            "The binary sequence of byte values to remove may be any bytes-like object. See removesuffix() for a method that will remove a single suffix string rather than all of a set of characters. For example:\n" +
++            "\n" +
++            ">>>\n" +
++            ">>> b'Monty Python'.rstrip(b' Python')\n" +
++            "b'M'\n" +
++            ">>> b'Monty Python'.removesuffix(b' Python')\n" +
++            "b'Monty'\n",
++    parameters = {
++      @Param(
++        name = "chars",
++        allowedTypes = {
++          @ParamType(type = StarlarkBytes.class),
++          @ParamType(type = NoneType.class),
++        },
++        defaultValue = "None")
++    })
++  StarlarkBytes rstrip(Object charsO);
++
++  @StarlarkMethod(
++    name = "split",
++    doc = "" +
++      "Return a list of the sections in the bytes, using sep as the delimiter.\n" +
++      "\n" +
++      "sep\n" +
++      "  The delimiter according which to split the bytes.\n" +
++      "  None (the default value) means split on ASCII whitespace characters\n" +
++      "  (space, tab, return, newline, formfeed, vertical tab).\n" +
++      "maxsplit\n" +
++      "  Maximum number of splits to do.\n" +
++      "  -1 (the default value) means no limit.",
++    parameters = {
++      @Param(name = "sep", doc = "The delimiter to split on.", named = true, allowedTypes = {
++        @ParamType(type = StarlarkBytes.class),
++        @ParamType(type = NoneType.class)
++      }, defaultValue = "None"),
++      @Param(
++        name = "maxsplit", named = true,
++        allowedTypes = {
++          @ParamType(type = StarlarkInt.class),
++          @ParamType(type = NoneType.class),
++        },
++        defaultValue = "-1",
++        doc = "The maximum number of splits.")
++    },
++    useStarlarkThread = true)
++  StarlarkList<StarlarkBytes> split(Object bytesO, Object maxSplitO, StarlarkThread thread) throws EvalException;
++
++  @StarlarkMethod(
++    name = "strip",
++    doc = "Return a copy of the sequence with specified leading and trailing bytes removed. The " +
++            "chars argument is a binary sequence specifying the set of byte values to be" +
++            " removed - the name refers to the fact this method is usually used with ASCII " +
++            "characters. " +
++            "If omitted or None, the chars argument defaults to removing ASCII whitespace. " +
++            "" +
++            "The chars argument is not a prefix or suffix; rather, all combinations of its " +
++            "values are stripped:" +
++            "\n" +
++            ">>> b'   spacious   '.strip()\n" +
++            "b'spacious'\n" +
++            ">>> b'www.example.com'.strip(b'cmowz.')\n" +
++            "b'example'\n" +
++            "The binary sequence of byte values to remove may be any bytes-like object.\n" +
++            "\n",
++    parameters = {
++      @Param(
++        name = "chars",
++        doc = "binary sequence of byte values to remove may be any bytes-like object.",
++        allowedTypes = {
++          @ParamType(type = StarlarkBytes.class),
++          @ParamType(type = NoneType.class),
++        },
++        defaultValue = "None")
++    })
++  StarlarkBytes strip(Object charsO);
++
++  //
++  //  The following methods on bytes and bytearray objects assume the use of ASCII compatible
++  //  binary formats and should not be applied to arbitrary binary data.
++  //
++  //  Note that all of the bytearray methods in this section do not operate in place, and
++  //  instead produce new objects.
++  //
++
++  @StarlarkMethod(
++    name = "capitalize",
++    doc =
++      "Return a copy of the sequence with each byte interpreted as an ASCII character, and the first byte capitalized and the rest lowercased. Non-ASCII byte values are passed through unchanged."
++  )
++  StarlarkBytes capitalize();
++
++  @StarlarkMethod(
++    name = "expandtabs",
++    doc = "Return a copy of the sequence where all ASCII tab characters are replaced by one or more ASCII spaces, depending on the current column and the given tab size. Tab positions occur every tabsize bytes (default is 8, giving tab positions at columns 0, 8, 16 and so on). To expand the sequence, the current column is set to zero and the sequence is examined byte by byte. If the byte is an ASCII tab character (b'\\t'), one or more space characters are inserted in the result until the current column is equal to the next tab position. (The tab character itself is not copied.) If the current byte is an ASCII newline (b'\\n') or carriage return (b'\\r'), it is copied and the current column is reset to zero. Any other byte value is copied unchanged and the current column is incremented by one regardless of how the byte value is represented when printed:\n" +
++            "\n" +
++            ">>>\n" +
++            ">>> b'01\\t012\\t0123\\t01234'.expandtabs()\n" +
++            "b'01      012     0123    01234'\n" +
++            ">>> b'01\\t012\\t0123\\t01234'.expandtabs(4)\n" +
++            "b'01  012 0123    01234'" +
++            "\n",
++    parameters = {@Param(
++      name = "tabsize", named = true,
++      allowedTypes = {@ParamType(type = StarlarkInt.class)},
++      defaultValue = "8"
++  )})
++  StarlarkBytes expandTabs(StarlarkInt tabSize) throws EvalException;
++
++  @StarlarkMethod(
++    name = "isalnum",
++    doc =
++      "Return True if all bytes in the sequence are alphabetical ASCII characters or ASCII decimal digits and the sequence is not empty, False otherwise. Alphabetic ASCII characters are those byte values in the sequence b'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'. ASCII decimal digits are those byte values in the sequence b'0123456789'.\n" +
++        "\n" +
++        "For example:\n" +
++        "\n" +
++        ">>>\n" +
++        ">>> b'ABCabc1'.isalnum()\n" +
++        "True\n" +
++        ">>> b'ABC abc1'.isalnum()\n" +
++        "False"
++  )
++  boolean isAlnum() throws EvalException;
++
++  @StarlarkMethod(
++    name = "isalpha",
++    doc =
++      "Return True if all bytes in the sequence are alphabetic ASCII characters and the sequence is not empty, False otherwise. Alphabetic ASCII characters are those byte values in the sequence b'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'.\n" +
++        "\n" +
++        "For example:\n" +
++        "\n" +
++        ">>>\n" +
++        ">>> b'ABCabc'.isalpha()\n" +
++        "True\n" +
++        ">>> b'ABCabc1'.isalpha()\n" +
++        "False\n"
++  )
++  boolean isAlpha() throws EvalException;
++
++  @StarlarkMethod(
++    name = "isascii",
++    doc =
++      "Return True if the sequence is empty or all bytes in the sequence are ASCII, False otherwise. ASCII bytes are in the range 0-0x7F."
++  )
++  boolean isAscii() throws EvalException;
++
++  @StarlarkMethod(
++    name = "isdigit",
++    doc =
++      "Return True if all bytes in the sequence are ASCII decimal digits and the sequence is not empty, False otherwise. ASCII decimal digits are those byte values in the sequence b'0123456789'.\n" +
++        "\n" +
++        "For example:\n" +
++        "\n" +
++        ">>>\n" +
++        ">>> b'1234'.isdigit()\n" +
++        "True\n" +
++        ">>> b'1.23'.isdigit()\n" +
++        "False"
++  )
++  boolean isDigit();
++
++  @StarlarkMethod(
++    name = "islower",
++    doc =
++      "Return True if there is at least one lowercase ASCII character in the sequence and no uppercase ASCII characters, False otherwise.\n" +
++        "\n" +
++        "For example:\n" +
++        "\n" +
++        ">>>\n" +
++        ">>> b'hello world'.islower()\n" +
++        "True\n" +
++        ">>> b'Hello world'.islower()\n" +
++        "False\n" +
++        "Lowercase ASCII characters are those byte values in the sequence b'abcdefghijklmnopqrstuvwxyz'. Uppercase ASCII characters are those byte values in the sequence b'ABCDEFGHIJKLMNOPQRSTUVWXYZ'."
++  )
++  boolean isLower();
++
++  @StarlarkMethod(
++    name = "isspace",
++    doc =
++      "Return True if all bytes in the sequence are ASCII whitespace and the sequence is not empty, False otherwise. ASCII whitespace characters are those byte values in the sequence b' \\t\\n\\r\\x0b\\f' (space, tab, newline, carriage return, vertical tab, form feed)."
++  )
++  boolean isSpace() throws EvalException;
++
++  @StarlarkMethod(
++    name = "istitle",
++    doc =
++      "Return True if the sequence is ASCII titlecase and the sequence is not empty, False otherwise. See bytes.title() for more details on the definition of “titlecase”.\n" +
++        "\n" +
++        "For example:\n" +
++        "\n" +
++        ">>>\n" +
++        ">>> b'Hello World'.istitle()\n" +
++        "True\n" +
++        ">>> b'Hello world'.istitle()\n" +
++        "False"
++  )
++  boolean isTitle() throws EvalException;
++
++  @StarlarkMethod(
++    name = "isupper",
++    doc =
++      "Return True if there is at least one uppercase alphabetic ASCII character in the sequence and no lowercase ASCII characters, False otherwise.\n" +
++        "\n" +
++        "For example:\n" +
++        "\n" +
++        ">>>\n" +
++        ">>> b'HELLO WORLD'.isupper()\n" +
++        "True\n" +
++        ">>> b'Hello world'.isupper()\n" +
++        "False\n" +
++        "Lowercase ASCII characters are those byte values in the sequence b'abcdefghijklmnopqrstuvwxyz'. Uppercase ASCII characters are those byte values in the sequence b'ABCDEFGHIJKLMNOPQRSTUVWXYZ'."
++  )
++  boolean isUpper();
++
++  @StarlarkMethod(
++    name = "lower",
++    doc = "B.lower() -> copy of B\n" +
++            "\n" +
++            "Return a copy of B with all ASCII characters converted to lowercase.")
++  StarlarkBytes lower();
++
++  @StarlarkMethod(
++    name = "splitlines",
++    doc =
++      "Return a list of the lines in the binary sequence, breaking at ASCII " +
++        "line boundaries. This method uses the universal newlines approach " +
++        "to splitting lines. Line breaks are not included in the resulting " +
++        "list unless keepends is given and true." +
++        "\n" +
++        "For example:\n" +
++        "\n" +
++        ">>>\n" +
++        ">>> b'ab c\\n\\nde fg\\rkl\\r\\n'.splitlines()\n" +
++        "[b'ab c', b'', b'de fg', b'kl']\n" +
++        ">>> b'ab c\\n\\nde fg\\rkl\\r\\n'.splitlines(keepends=True)\n" +
++        "[b'ab c\\n', b'\\n', b'de fg\\r', b'kl\\r\\n']\n" +
++        "Unlike split() when a delimiter string sep is given, this method returns an empty list for the empty string, and a terminal line break does not result in an extra line:\n" +
++        "\n" +
++        ">>>\n" +
++        ">>> b\"\".split(b'\\n'), b\"Two lines\\n\".split(b'\\n')\n" +
++        "([b''], [b'Two lines', b''])\n" +
++        ">>> b\"\".splitlines(), b\"One line\\n\".splitlines()\n" +
++        "([], [b'One line'])\n",
++    parameters = {
++      @Param(
++        name = "keepends", named=true,
++        defaultValue = "False",
++        doc = "Whether the line breaks should be included in the resulting list.")
++  })
++  Sequence<StarlarkBytes> splitLines(boolean keepEnds)
++    throws EvalException;
++
++  @StarlarkMethod(
++    name = "swapcase",
++    doc =
++      "Return a copy of the sequence with all the lowercase ASCII characters converted to their corresponding uppercase counterpart and vice-versa.\n" +
++        "\n" +
++        "For example:\n" +
++        "\n" +
++        ">>>\n" +
++        ">>> b'Hello World'.swapcase()\n" +
++        "b'hELLO wORLD'\n" +
++        "Lowercase ASCII characters are those byte values in the sequence b'abcdefghijklmnopqrstuvwxyz'. Uppercase ASCII characters are those byte values in the sequence b'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.\n" +
++        "\n" +
++        "Unlike str.swapcase(), it is always the case that bin.swapcase().swapcase() == bin for the binary versions. Case conversions are symmetrical in ASCII, even though that is not generally true for arbitrary Unicode code points."
++  )
++  StarlarkBytes swapcase() throws EvalException;
++
++  @StarlarkMethod(
++    name = "title",
++    doc =
++      "Return a titlecased version of the binary sequence where words start with an uppercase ASCII character and the remaining characters are lowercase. Uncased byte values are left unmodified.\n" +
++        "\n" +
++        "For example:\n" +
++        "\n" +
++        ">>>\n" +
++        ">>> b'Hello world'.title()\n" +
++        "b'Hello World'\n" +
++        "Lowercase ASCII characters are those byte values in the sequence b'abcdefghijklmnopqrstuvwxyz'. Uppercase ASCII characters are those byte values in the sequence b'ABCDEFGHIJKLMNOPQRSTUVWXYZ'. All other byte values are uncased.\n" +
++        "\n" +
++        "The algorithm uses a simple language-independent definition of a word as groups of consecutive letters. The definition works in many contexts but it means that apostrophes in contractions and possessives form word boundaries, which may not be the desired result:\n" +
++        "\n" +
++        ">>>\n" +
++        ">>> b\"they're bill's friends from the UK\".title()\n" +
++        "b\"They'Re Bill'S Friends From The Uk\"\n" +
++        "A workaround for apostrophes can be constructed using regular expressions:\n" +
++        "\n" +
++        ">>>\n" +
++        ">>> load(\"@stdlib//re\", \"re\")\n" +
++        ">>> def titlecase(s):\n" +
++        "...     return re.sub(rb\"[A-Za-z]+('[A-Za-z]+)?\",\n" +
++        "...                   lambda mo: mo.group(0)[0:1].upper() +\n" +
++        "...                              mo.group(0)[1:].lower(),\n" +
++        "...                   s)\n" +
++        "...\n" +
++        ">>> titlecase(b\"they're bill's friends.\")\n" +
++        "b\"They're Bill's Friends.\""
++  )
++  StarlarkBytes title();
++
++  @StarlarkMethod(
++    name = "upper",
++    doc = "B.upper() -> copy of B\n" +
++            "\n" +
++            "Return a copy of B with all ASCII characters converted to uppercase.")
++  StarlarkBytes upper();
++
++  @StarlarkMethod(
++    name = "zfill",
++    doc = "Return a copy of the sequence left filled with ASCII b'0' " +
++            "digits to make a sequence of length width. A leading " +
++            "sign prefix (b'+'/ b'-') is handled by inserting the " +
++            "padding after the sign character rather than before. " +
++            "\n" +
++            "For bytes objects, the original sequence is returned if " +
++            "width is less than or equal to len(seq).\n" +
++            "\n" +
++            "For example:\n" +
++            "\n" +
++            ">>>\n" +
++            ">>> b\"42\".zfill(5)\n" +
++            "b'00042'\n" +
++            ">>> b\"-42\".zfill(5)\n" +
++            "b'-0042'\n", parameters = {
++    @Param(
++      name = "width",
++      allowedTypes = {
++        @ParamType(type = StarlarkInt.class)})}
++  )
++  StarlarkBytes zfill(StarlarkInt width) throws EvalException;
++}
+diff --git b/libstarlark/src/main/java/net/starlark/java/ext/CodecHelper.java a/libstarlark/src/main/java/net/starlark/java/ext/CodecHelper.java
+new file mode 100644
+index 00000000..ce3dcf3f
+--- /dev/null
++++ a/libstarlark/src/main/java/net/starlark/java/ext/CodecHelper.java
+@@ -0,0 +1,145 @@
++package net.starlark.java.ext;
++
++import java.nio.charset.Charset;
++import java.nio.charset.CharsetDecoder;
++import java.nio.charset.CharsetEncoder;
++import java.nio.charset.CodingErrorAction;
++
++public class CodecHelper {
++
++  private CodecHelper() { } // uninstantiable
++
++  public static final String STRICT = "strict";
++  public static final String IGNORE = "ignore";
++  public static final String REPLACE = "replace";
++  public static final String BACKSLASHREPLACE = "backslashreplace";
++  public static final String NAMEREPLACE = "namereplace";
++  public static final String XMLCHARREFREPLACE = "xmlcharrefreplace";
++  public static final String SURROGATEESCAPE = "surrogateescape";
++  public static final String SURROGATEPASS = "surrogatepass";
++
++  public static CodingErrorAction convertCodingErrorAction(String errors) {
++    CodingErrorAction errorAction;
++    switch (errors) {
++      case IGNORE:
++        errorAction = CodingErrorAction.IGNORE;
++        break;
++      case REPLACE:
++      case NAMEREPLACE:
++        errorAction = CodingErrorAction.REPLACE;
++        break;
++      case STRICT:
++      case BACKSLASHREPLACE:
++      case SURROGATEPASS:
++      case SURROGATEESCAPE:
++      case XMLCHARREFREPLACE:
++      default:
++        errorAction = CodingErrorAction.REPORT;
++        break;
++    }
++    return errorAction;
++  }
++
++  public static final class ThreadLocalCoders {
++
++      private static final int CACHE_SIZE = 10;
++
++      private abstract static class Cache {
++
++        // Thread-local reference to array of cached objects, in LRU order
++        private final ThreadLocal<Object[]> cache = new ThreadLocal<>();
++        private final int size;
++
++        Cache(int size) {
++          this.size = size;
++        }
++
++        abstract Object create(Object name);
++
++        private void moveToFront(Object[] oa, int i) {
++          Object ob = oa[i];
++          System.arraycopy(oa, 0, oa, 1, i);
++          oa[0] = ob;
++        }
++
++        abstract boolean hasName(Object ob, Object name);
++
++        Object forName(Object name) {
++          Object[] oa = cache.get();
++          if (oa == null) {
++            oa = new Object[size];
++            cache.set(oa);
++          } else {
++            for (int i = 0; i < oa.length; i++) {
++              Object ob = oa[i];
++              if (ob == null)
++                continue;
++              if (hasName(ob, name)) {
++                if (i > 0)
++                  moveToFront(oa, i);
++                return ob;
++              }
++            }
++          }
++
++          // Create a new object
++          Object ob = create(name);
++          oa[oa.length - 1] = ob;
++          moveToFront(oa, oa.length - 1);
++          return ob;
++        }
++      }
++
++      private static final ThreadLocalCoders.Cache decoderCache = new ThreadLocalCoders.Cache(CACHE_SIZE) {
++        boolean hasName(Object ob, Object name) {
++          if (name instanceof String)
++            return (((CharsetDecoder) ob).charset().name().equals(name));
++          if (name instanceof Charset)
++            return ((CharsetDecoder) ob).charset().equals(name);
++          return false;
++        }
++
++        Object create(Object name) {
++          if (name instanceof String)
++            return Charset.forName((String) name).newDecoder();
++          if (name instanceof Charset)
++            return ((Charset) name).newDecoder();
++          assert false;
++          return null;
++        }
++      };
++
++      public static CharsetDecoder decoderFor(Object name) {
++        CharsetDecoder cd = (CharsetDecoder) decoderCache.forName(name);
++        cd.reset();
++        return cd;
++      }
++
++      private static final ThreadLocalCoders.Cache encoderCache = new ThreadLocalCoders.Cache(CACHE_SIZE) {
++        boolean hasName(Object ob, Object name) {
++          if (name instanceof String)
++            return (((CharsetEncoder) ob).charset().name().equals(name));
++          if (name instanceof Charset)
++            return ((CharsetEncoder) ob).charset().equals(name);
++          return false;
++        }
++
++        Object create(Object name) {
++          if (name instanceof String)
++            return Charset.forName((String) name).newEncoder();
++          if (name instanceof Charset)
++            return ((Charset) name).newEncoder();
++          assert false;
++          return null;
++        }
++      };
++
++      public static CharsetEncoder encoderFor(Object name) {
++        CharsetEncoder ce = (CharsetEncoder) encoderCache.forName(name);
++        ce.reset();
++        return ce;
++      }
++
++    }
++
++}
+\ No newline at end of file
+diff --git b/libstarlark/src/main/java/net/starlark/java/syntax/ByteLiteral.java a/libstarlark/src/main/java/net/starlark/java/syntax/ByteLiteral.java
+new file mode 100644
+index 00000000..1733a664
+--- /dev/null
++++ a/libstarlark/src/main/java/net/starlark/java/syntax/ByteLiteral.java
+@@ -0,0 +1,139 @@
++// Copyright 2014 The Bazel Authors. All rights reserved.
++//
++// Licensed under the Apache License, Version 2.0 (the "License");
++// you may not use this file except in compliance with the License.
++// You may obtain a copy of the License at
++//
++//    http://www.apache.org/licenses/LICENSE-2.0
++//
++// Unless required by applicable law or agreed to in writing, software
++// distributed under the License is distributed on an "AS IS" BASIS,
++// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++// See the License for the specific language governing permissions and
++// limitations under the License.
++package net.starlark.java.syntax;
++
++import java.io.ByteArrayOutputStream;
++import java.util.stream.IntStream;
++
++/** Syntax node for a bytes literal. */
++public final class ByteLiteral extends Expression {
++
++  private final int startOffset;
++  private final byte[] value;
++  private final int endOffset;
++  private final String raw;
++
++  ByteLiteral(FileLocations locs, int startOffset, String value, int endOffset) {
++    super(locs);
++    this.startOffset = startOffset;
++    this.raw = value;
++    this.value = str2bytearr(value.codePoints());
++    this.endOffset = endOffset;
++  }
++
++  /**
++   * The Starlark specification allows invalid UTF-8 sequences stuffed into UTF-k strings. In Java,
++   * this means that there will be invalid UTF-8 sequences in UTF-16 strings. The lexer uses
++   * StringBuilder which will produce a UTF-16 encoded string that is shuttling embedded UTF-8
++   * sequences.
++   *
++   * As a result, we cannot simply "encode" the string into UTF-8 because it will give us garbage.
++   *
++   * So, we will create a byte array representation consisting of the underlying
++   * bytes of the string, assuming that they're already encoded as UTF-8. If we see a byte greater
++   * than the maximum unsigned byte size, we will then convert that codepoint from UTF-k
++   * (UTF-16 in Java-land) to its equivalent UTF-8 sequence.
++   *
++   * The resulting byte array _should_ be the intended UTF-8 sequence. From there, we can proceed
++   * as normal.
++   */
++  static byte[] str2bytearr(IntStream codePoints) {
++    final ByteArrayOutputStream baos = new ByteArrayOutputStream();
++    // The following is a little trick that will throw IndexOutOfBounds if too large code point
++    //  and as a result avoids having to do bounds checking
++    final byte[] cpBytes = new byte[6];
++    codePoints.forEach((cp) -> {
++      if (cp < 0) {
++        throw new IllegalStateException("No negative code point allowed");
++      }
++      else if(cp <= 0xFF) {
++        baos.write(cp);
++      }
++      else {
++        int bi = 0;
++        int lastPrefix = 0xC0;
++        int lastMask = 0x1F;
++        for (;;) {
++            int b = 0x80 | (cp & 0x3F);
++            cpBytes[bi] = (byte)b;
++            ++bi;
++            cp >>= 6;
++            if ((cp & ~lastMask) == 0) {
++                cpBytes[bi] = (byte) (lastPrefix | cp);
++                ++bi;
++                break;
++            }
++            lastPrefix = 0x80 | (lastPrefix >> 1);
++            lastMask >>= 1;
++        }
++        while (bi > 0) {
++            --bi;
++            baos.write(cpBytes[bi]);
++        }
++      }
++    });
++    return baos.toByteArray();
++  }
++
++  /** Returns the value denoted by the byte literal */
++  public byte[] getValue() {
++    return value;
++  }
++
++  /** Returns the raw source text of the literal. */
++  public String getRaw() {
++    return this.raw;
++  }
++
++  public Location getLocation() {
++    return locs.getLocation(startOffset);
++  }
++
++  @Override
++  public int getStartOffset() {
++    return startOffset;
++  }
++
++  @Override
++  public int getEndOffset() {
++    // TODO(adonovan): when we switch to compilation,
++    // making syntax trees ephemeral, we can afford to
++    // record the raw literal. This becomes:
++    //   return startOffset + raw.length().
++    return endOffset;
++  }
++
++  @Override
++  public void accept(NodeVisitor visitor) {
++    visitor.visit(this);
++  }
++
++  @Override
++  public Kind kind() {
++    return Kind.BYTE_LITERAL;
++  }
++
++  // -- hooks to support Skyframe serialization without creating a dependency --
++
++  /** Returns an opaque serializable object that may be passed to {@link #fromSerialization}. */
++  public Object getFileLocations() {
++    return locs;
++  }
++
++  /** Constructs a ByteLiteral from its serialized components. */
++  public static ByteLiteral fromSerialization(
++      Object fileLocations, int startOffset, String value, int endOffset) {
++    return new ByteLiteral((FileLocations) fileLocations, startOffset, value, endOffset);
++  }
++}
+diff --git b/libstarlark/src/main/java/net/starlark/java/syntax/Expression.java a/libstarlark/src/main/java/net/starlark/java/syntax/Expression.java
+index 543758b2..02292130 100644
+--- b/libstarlark/src/main/java/net/starlark/java/syntax/Expression.java
++++ a/libstarlark/src/main/java/net/starlark/java/syntax/Expression.java
+@@ -44,6 +44,7 @@ public abstract class Expression extends Node {
+     SLICE,
+     STRING_LITERAL,
+     UNARY_OPERATOR,
++    BYTE_LITERAL
+   }
+ 
+   Expression(FileLocations locs) {
+diff --git b/libstarlark/src/main/java/net/starlark/java/syntax/Lexer.java a/libstarlark/src/main/java/net/starlark/java/syntax/Lexer.java
+index 078d3f1a..37c650ad 100644
+--- b/libstarlark/src/main/java/net/starlark/java/syntax/Lexer.java
++++ a/libstarlark/src/main/java/net/starlark/java/syntax/Lexer.java
+@@ -39,12 +39,12 @@ final class Lexer {
+   final FileLocations locs;
+ 
+   // Information about current token. Updated by nextToken.
+-  // raw and value are defined only for STRING, INT, FLOAT, IDENTIFIER, and COMMENT.
++  // raw and value are defined only for STRING, BYTE, INT, FLOAT, IDENTIFIER, and COMMENT.
+   // TODO(adonovan): rename s/xyz/tokenXyz/
+   TokenKind kind;
+   int start; // start offset
+   int end; // end offset
+-  Object value; // String, Integer/Long/BigInteger, or Double value of token
++  Object value; // String, Bytes, Integer/Long/BigInteger, or Double value of token
+ 
+   // --- end of parser-visible fields ---
+ 
+@@ -142,7 +142,7 @@ final class Lexer {
+   }
+ 
+   // setValue sets the value associated with a STRING, FLOAT, INT,
+-  // IDENTIFIER, or COMMENT token, and records the raw text of the token.
++  // BYTE, IDENTIFIER, or COMMENT token, and records the raw text of the token.
+   private void setValue(Object value) {
+     this.value = value;
+   }
+@@ -244,12 +244,12 @@ final class Lexer {
+   }
+ 
+   /**
+-   * Scans a string literal delimited by 'quot', containing escape sequences.
++   * Scans a string or byte literal delimited by 'quot', containing escape sequences.
+    *
+    * <p>ON ENTRY: 'pos' is 1 + the index of the first delimiter
+    * ON EXIT: 'pos' is 1 + the index of the last delimiter.
+    */
+-  private void escapedStringLiteral(char quot, boolean isRaw) {
++  private void escapedLiteral(char quot, boolean isRaw, TokenKind tokenKind) {
+     int literalStartPos = isRaw ? pos - 2 : pos - 1;
+     boolean inTriplequote = skipTripleQuote(quot);
+     // more expensive second choice that expands escaped into a buffer
+@@ -263,15 +263,15 @@ final class Lexer {
+             literal.append(c);
+             break;
+           } else {
+-            error("unclosed string literal", literalStartPos);
+-            setToken(TokenKind.STRING, literalStartPos, pos);
++            error(String.format("unclosed %s", tokenKind.toString()), literalStartPos);
++            setToken(tokenKind, literalStartPos, pos);
+             setValue(literal.toString());
+             return;
+           }
+         case '\\':
+           if (pos == buffer.length) {
+-            error("unclosed string literal", literalStartPos);
+-            setToken(TokenKind.STRING, literalStartPos, pos);
++            error(String.format("unclosed %s", tokenKind.toString()), literalStartPos);
++            setToken(tokenKind, literalStartPos, pos);
+             setValue(literal.toString());
+             return;
+           }
+@@ -304,15 +304,6 @@ final class Lexer {
+             case '\n':
+               // ignore end of line character
+               break;
+-            case 'a':
+-              literal.append('\u0007');
+-              break;
+-            case 'b':
+-              literal.append('\b');
+-              break;
+-            case 'f':
+-              literal.append('\f');
+-              break;
+             case 'n':
+               literal.append('\n');
+               break;
+@@ -322,9 +313,6 @@ final class Lexer {
+             case 't':
+               literal.append('\t');
+               break;
+-            case 'v':
+-              literal.append('\u000b');
+-              break;
+             case '\\':
+               literal.append('\\');
+               break;
+@@ -358,15 +346,123 @@ final class Lexer {
+                     }
+                   }
+                 }
++                if(tokenKind.equals(TokenKind.STRING) && octal > 127) {
++                  error(String.format(
++                    "non-ASCII octal escape \\%o " +
++                      "(use \\u%04X for the UTF-8 encoding of U+%04X)",
++                    octal, octal, octal),
++                    pos-1);
++                  setToken(tokenKind, literalStartPos, pos);
++                  setValue(literal.toString());
++                  break;
++                }
+                 if (octal > 0xff) {
+-                  error("octal escape sequence out of range (maximum is \\377)", pos - 1);
++                  error(
++                    "octal escape sequence out of range"
++                      + " (maximum is \\377)",
++                    pos - 1);
++                  setToken(tokenKind, literalStartPos, pos);
++                  setValue(literal.toString());
++                  break;
+                 }
+                 literal.append((char) (octal & 0xff));
+                 break;
+               }
+-            case 'N':
++            case 'a':
++              literal.append('\u0007');
++              break;
++            case 'b':
++              literal.append('\b');
++              break;
++            case 'f':
++              literal.append('\f');
++              break;
++            case 'v':
++              literal.append('\u000B');
++              break;
++            case 'x': {
++              if (pos + 2 >= buffer.length) {
++                error(String.format(
++                  "truncated escape sequence \\x%s",
++                  bufferSlice(pos, buffer.length - 1)),
++                  pos - 1);
++                setToken(tokenKind, literalStartPos, pos);
++                setValue(literal.toString());
++                break;
++              }
++              int n;
++              try {
++                n = Integer.parseInt(bufferSlice(pos, pos + 2),/*radix*/16);
++              } catch (NumberFormatException nfe) {
++                error(String.format(
++                  "invalid escape sequence \\x%s",
++                  bufferSlice(pos, buffer.length - 1)),
++                  pos - 1);
++                setToken(tokenKind, literalStartPos, pos);
++                setValue(literal.toString());
++                break;
++              }
++              if (tokenKind.equals(TokenKind.STRING) && n > Byte.MAX_VALUE) {
++                error(
++                  String.format("non-ASCII hex escape \\x%s (use \\u%04X for" +
++                                  " the UTF-8 encoding of U+%04X)",
++                    bufferSlice(pos, pos + 2), n, n), pos - 1);
++                setToken(tokenKind, literalStartPos, pos);
++                setValue(literal.toString());
++                break;
++              }
++              literal.append(Character.toChars(n));
++              pos += 2;
++              break;
++            }
+             case 'u':
+-            case 'U':
++            case 'U': {
++              int sz = c == 'u' ? 4 : 8;
++              if (pos + sz >= buffer.length) {
++                error(String.format(
++                  "truncated escape sequence \\%c%s",
++                  c, bufferSlice(pos, buffer.length - 1)),
++                  pos - 1);
++                setToken(tokenKind, literalStartPos, pos);
++                setValue(literal.toString());
++                break;
++              }
++              int n;
++              try {
++                n = Integer.parseInt(bufferSlice(pos, pos + sz),/*radix*/16);
++              } catch (NumberFormatException nfe) {
++                error(String.format(
++                  "invalid escape sequence \\%c%s",
++                  c, bufferSlice(pos, buffer.length - 1)),
++                  pos - 1);
++                setToken(tokenKind, literalStartPos, pos);
++                setValue(literal.toString());
++                break;
++              }
++              if (n > Character.MAX_CODE_POINT) {
++                error(String.format(
++                  "code point out of range: \\U%s (max \\U%08x)",
++                  bufferSlice(pos, buffer.length - 1), n),
++                  pos - 1);
++                setToken(tokenKind, literalStartPos, pos);
++                setValue(literal.toString());
++                break;
++              }
++              // surrogates are disallowed.
++              if (Character.MIN_HIGH_SURROGATE <= n && n < Character.MAX_LOW_SURROGATE) {
++                error(String.format("invalid Unicode code point U+%04X", n), pos - 1);
++                setToken(tokenKind, literalStartPos, pos);
++                setValue(literal.toString());
++                break;
++              }
++              literal.append(Character.toChars(n));
++              pos += sz;
++              break;
++            }
++            case 'N':
++              // exists in Python but not implemented in Blaze => error
++              error("invalid escape sequence: \\" + c, pos - 1);
++              break;
+             default:
+               // unknown char escape => "\literal"
+               error("invalid escape sequence: \\" + c + ". Use '\\\\' to insert '\\'.", pos - 1);
+@@ -382,7 +478,7 @@ final class Lexer {
+             literal.append(c);
+           } else {
+             // Matching close-delimiter, all done.
+-            setToken(TokenKind.STRING, literalStartPos, pos);
++            setToken(tokenKind, literalStartPos, pos);
+             setValue(literal.toString());
+             return;
+           }
+@@ -392,8 +488,8 @@ final class Lexer {
+           break;
+       }
+     }
+-    error("unclosed string literal", literalStartPos);
+-    setToken(TokenKind.STRING, literalStartPos, pos);
++    error(String.format("unclosed %s", tokenKind.toString()), literalStartPos);
++    setToken(tokenKind, literalStartPos, pos);
+     setValue(literal.toString());
+   }
+ 
+@@ -404,17 +500,17 @@ final class Lexer {
+    * <li> ON ENTRY: 'pos' is 1 + the index of the first delimiter
+    * <li> ON EXIT: 'pos' is 1 + the index of the last delimiter.
+    * </ul>
+-   *
+-   * @param isRaw if true, do not escape the string.
++   *  @param isRaw if true, do not escape the string.
++   * @param tokenKind
+    */
+-  private void stringLiteral(char quot, boolean isRaw) {
++  private void stringLiteral(char quot, boolean isRaw, TokenKind tokenKind) {
+     int literalStartPos = isRaw ? pos - 2 : pos - 1;
+     int contentStartPos = pos;
+ 
+     // Don't even attempt to parse triple-quotes here.
+     if (skipTripleQuote(quot)) {
+       pos -= 2;
+-      escapedStringLiteral(quot, isRaw);
++      escapedLiteral(quot, isRaw, tokenKind);
+       return;
+     }
+ 
+@@ -424,7 +520,7 @@ final class Lexer {
+       switch (c) {
+         case '\n':
+           error("unclosed string literal", literalStartPos);
+-          setToken(TokenKind.STRING, literalStartPos, pos);
++          setToken(tokenKind, literalStartPos, pos);
+           setValue(bufferSlice(contentStartPos, pos - 1));
+           return;
+         case '\\':
+@@ -433,7 +529,7 @@ final class Lexer {
+               // There was a CRLF after the newline. No shortcut possible, since it needs to be
+               // transformed into a single LF.
+               pos = contentStartPos;
+-              escapedStringLiteral(quot, true);
++              escapedLiteral(quot, true, tokenKind);
+               return;
+             } else {
+               pos++;
+@@ -442,13 +538,13 @@ final class Lexer {
+           }
+           // oops, hit an escape, need to start over & build a new string buffer
+           pos = contentStartPos;
+-          escapedStringLiteral(quot, false);
++          escapedLiteral(quot, false, tokenKind);
+           return;
+         case '\'':
+         case '"':
+           if (c == quot) {
+             // close-quote, all done.
+-            setToken(TokenKind.STRING, literalStartPos, pos);
++            setToken(tokenKind, literalStartPos, pos);
+             setValue(bufferSlice(contentStartPos, pos - 1));
+             return;
+           }
+@@ -464,7 +560,7 @@ final class Lexer {
+     }
+ 
+     error("unclosed string literal", literalStartPos);
+-    setToken(TokenKind.STRING, literalStartPos, pos);
++    setToken(tokenKind, literalStartPos, pos);
+     setValue(bufferSlice(contentStartPos, pos));
+   }
+ 
+@@ -747,17 +843,26 @@ final class Lexer {
+           break;
+         case '\'':
+         case '\"':
+-          stringLiteral(c, false);
++          stringLiteral(c, false, TokenKind.STRING);
+           break;
+         default:
+-          // detect raw strings, e.g. r"str"
+-          if (c == 'r') {
++          // detect raw strings, e.g. r"str" or b".."
++          if (c == 'r' || c == 'b') {
+             int c0 = peek(0);
+             if (c0 == '\'' || c0 == '\"') {
+               pos++;
+-              stringLiteral((char) c0, true);
++              stringLiteral((char) c0, c == 'r', c == 'r' ? TokenKind.STRING : TokenKind.BYTE);
+               break;
+             }
++            else if (c == 'r' && c0 == 'b' && (buffer.length > 2)) {
++              int c1 = peek(1);
++              // rb"..."
++              if(c1 == '"' || c1 == '\'') {
++                pos+=2;
++                stringLiteral((char) c1, true, TokenKind.BYTE);
++                break;
++              }
++            }
+           }
+ 
+           // int or float literal, or dot
+diff --git b/libstarlark/src/main/java/net/starlark/java/syntax/NodePrinter.java a/libstarlark/src/main/java/net/starlark/java/syntax/NodePrinter.java
+index 7d6cebf8..ba15c487 100644
+--- b/libstarlark/src/main/java/net/starlark/java/syntax/NodePrinter.java
++++ a/libstarlark/src/main/java/net/starlark/java/syntax/NodePrinter.java
+@@ -422,6 +422,7 @@ final class NodePrinter {
+           break;
+         }
+ 
++      case BYTE_LITERAL:
+       case STRING_LITERAL:
+         {
+           StringLiteral literal = (StringLiteral) expr;
+diff --git b/libstarlark/src/main/java/net/starlark/java/syntax/NodeVisitor.java a/libstarlark/src/main/java/net/starlark/java/syntax/NodeVisitor.java
+index cf9ac696..ff76d564 100644
+--- b/libstarlark/src/main/java/net/starlark/java/syntax/NodeVisitor.java
++++ a/libstarlark/src/main/java/net/starlark/java/syntax/NodeVisitor.java
+@@ -116,6 +116,8 @@ public class NodeVisitor {
+ 
+   public void visit(@SuppressWarnings("unused") StringLiteral node) {}
+ 
++  public void visit(@SuppressWarnings("unused") ByteLiteral node) {}
++
+   public void visit(AssignmentStatement node) {
+     visit(node.getRHS());
+     visit(node.getLHS());
+diff --git b/libstarlark/src/main/java/net/starlark/java/syntax/Parser.java a/libstarlark/src/main/java/net/starlark/java/syntax/Parser.java
+index 77b94adb..4bf97e79 100644
+--- b/libstarlark/src/main/java/net/starlark/java/syntax/Parser.java
++++ a/libstarlark/src/main/java/net/starlark/java/syntax/Parser.java
+@@ -565,9 +565,24 @@ final class Parser {
+     return literal;
+   }
+ 
++
++  // expr = BYTE
++  private ByteLiteral parseBytesLiteral() {
++    Preconditions.checkState(token.kind == TokenKind.BYTE);
++    ByteLiteral literal =
++            new ByteLiteral(locs, token.start, intern((String) token.value), token.end);
++    nextToken();
++    if (token.kind == TokenKind.BYTE) {
++      reportError(token.start, "Implicit byte concatenation is forbidden");
++    }
++    return literal;
++  }
++
++
+   //  primary = INT
+   //          | FLOAT
+   //          | STRING
++  //          | BYTE
+   //          | IDENTIFIER
+   //          | list_expression
+   //          | '(' ')'                    // a tuple with zero elements
+@@ -595,6 +610,9 @@ final class Parser {
+       case STRING:
+         return parseStringLiteral();
+ 
++      case BYTE:
++        return parseBytesLiteral();
++
+       case IDENTIFIER:
+         return parseIdent();
+ 
+diff --git b/libstarlark/src/main/java/net/starlark/java/syntax/TokenKind.java a/libstarlark/src/main/java/net/starlark/java/syntax/TokenKind.java
+index 0b6ac6e6..8ed51cf5 100644
+--- b/libstarlark/src/main/java/net/starlark/java/syntax/TokenKind.java
++++ a/libstarlark/src/main/java/net/starlark/java/syntax/TokenKind.java
+@@ -22,6 +22,7 @@ public enum TokenKind {
+   AS("as"),
+   ASSERT("assert"),
+   BREAK("break"),
++  BYTE("byte literal"),
+   CARET("^"),
+   CARET_EQUALS("^="),
+   CLASS("class"),
+diff --git b/libstarlark/src/test/java/net/starlark/java/annot/processor/testsources/EnablingAndDisablingFlag.java a/libstarlark/src/test/java/net/starlark/java/annot/processor/testsources/EnablingAndDisablingFlag.java
+index 7e1c3b3a..d5be296d 100644
+--- b/libstarlark/src/test/java/net/starlark/java/annot/processor/testsources/EnablingAndDisablingFlag.java
++++ a/libstarlark/src/test/java/net/starlark/java/annot/processor/testsources/EnablingAndDisablingFlag.java
+@@ -16,6 +16,7 @@ package net.starlark.java.annot.processor.testsources;
+ 
+ import net.starlark.java.annot.Param;
+ import net.starlark.java.annot.StarlarkMethod;
++import net.starlark.java.eval.StarlarkInt;
+ import net.starlark.java.eval.StarlarkValue;
+ 
+ /**
+diff --git b/libstarlark/src/test/java/net/starlark/java/annot/processor/testsources/MultipleSelfCallMethods.java a/libstarlark/src/test/java/net/starlark/java/annot/processor/testsources/MultipleSelfCallMethods.java
+index cdc28ba9..0280a114 100644
+--- b/libstarlark/src/test/java/net/starlark/java/annot/processor/testsources/MultipleSelfCallMethods.java
++++ a/libstarlark/src/test/java/net/starlark/java/annot/processor/testsources/MultipleSelfCallMethods.java
+@@ -31,11 +31,11 @@ public class MultipleSelfCallMethods implements StarlarkValue {
+       },
+       documented = false)
+   public StarlarkInt selfCallMethod(String one, StarlarkInt two) {
+-    return 0;
++    return StarlarkInt.of(0);
+   }
+ 
+   @StarlarkMethod(name = "selfCallMethodTwo", selfCall = true, documented = false)
+   public StarlarkInt selfCallMethodTwo() {
+-    return 0;
++    return StarlarkInt.of(0);
+   }
+ }
+diff --git b/libstarlark/src/test/java/net/starlark/java/annot/processor/testsources/StructFieldWithInvalidInfo.java a/libstarlark/src/test/java/net/starlark/java/annot/processor/testsources/StructFieldWithInvalidInfo.java
+index 5ad388fa..9cb56618 100644
+--- b/libstarlark/src/test/java/net/starlark/java/annot/processor/testsources/StructFieldWithInvalidInfo.java
++++ a/libstarlark/src/test/java/net/starlark/java/annot/processor/testsources/StructFieldWithInvalidInfo.java
+@@ -15,6 +15,7 @@
+ package net.starlark.java.annot.processor.testsources;
+ 
+ import net.starlark.java.annot.StarlarkMethod;
++import net.starlark.java.eval.StarlarkThread;
+ import net.starlark.java.eval.StarlarkValue;
+ 
+ /** Test case which verifies a struct field method cannot specify useStarlarkThread. */
+diff --git b/libstarlark/src/test/java/net/starlark/java/eval/MethodLibraryTest.java a/libstarlark/src/test/java/net/starlark/java/eval/MethodLibraryTest.java
+index 7eef9872..d875ab38 100644
+--- b/libstarlark/src/test/java/net/starlark/java/eval/MethodLibraryTest.java
++++ a/libstarlark/src/test/java/net/starlark/java/eval/MethodLibraryTest.java
+@@ -501,7 +501,8 @@ public final class MethodLibraryTest {
+         .testExpression("hash('starlark')", StarlarkInt.of("starlark".hashCode()))
+         .testExpression("hash('google')", StarlarkInt.of("google".hashCode()))
+         .testIfErrorContains(
+-            "in call to hash(), parameter 'value' got value of type 'NoneType', want 'string'",
++            "in call to hash(), parameter 'value' got value of type" +
++              " 'NoneType', want 'string or bytes'",
+             "hash(None)");
+   }
+ 
+diff --git b/libstarlark/src/test/java/net/starlark/java/eval/StarlarkMutableTest.java a/libstarlark/src/test/java/net/starlark/java/eval/StarlarkMutableTest.java
+index 66d02a85..723ba03e 100644
+--- b/libstarlark/src/test/java/net/starlark/java/eval/StarlarkMutableTest.java
++++ a/libstarlark/src/test/java/net/starlark/java/eval/StarlarkMutableTest.java
+@@ -107,7 +107,7 @@ public final class StarlarkMutableTest {
+         Dict.<String, String>builder()
+             .put("one", "1")
+             .put("two", "2.0")
+-            .put("two", "2") // overwrites previous entry
++            .put("two", "2") // overrwrites previous entry
+             .put("three", "3")
+             .buildImmutable();
+     assertThat(dict1.toString()).isEqualTo("{\"one\": \"1\", \"two\": \"2\", \"three\": \"3\"}");
+diff --git b/libstarlark/src/test/java/net/starlark/java/eval/testdata/bytes.star a/libstarlark/src/test/java/net/starlark/java/eval/testdata/bytes.star
+new file mode 100644
+index 00000000..3b18e82d
+--- /dev/null
++++ a/libstarlark/src/test/java/net/starlark/java/eval/testdata/bytes.star
+@@ -0,0 +1,178 @@
++
++def assert_ne(arg1, arg2):
++    assert_(arg1 != arg2, "%s == %s!" % (arg1, arg2))
++
++
++def assert_true(arg1):
++    assert_(arg1, "bool(%s) is falsy" % arg1)
++
++
++def assert_lt(arg1, arg2):
++    assert_(arg1 < arg2, "%s >= %s" % (arg1, arg2))
++
++
++# bytes(string) -- UTF-k to UTF-8 transcoding with U+FFFD replacement
++# The result is a bytes whose elements are the UTF-8 encoding of the string.
++# Each element of the string that is not part of a valid encoding of a
++# code point is replaced by the UTF-8 encoding of the
++# replacement character, U+FFFD.
++hello = bytes("hello, 世界")
++goodbye = bytes("goodbye")
++empty = bytes("")
++nonprinting = bytes("\t\n\x7F\u200D")  # TAB, NEWLINE, DEL, ZERO_WIDTH_JOINER
++# in Starlark, [:-1] will cut off the last UTF-K code unit
++# (e.g. byte in Go, char in Java), yielding an invalid string
++# ("hello, 世" plus one half of the encoding of 😿). This test ensures that
++# each invalid byte in a text string is replaced by U+FFFD.
++assert_eq(bytes("hello, 世😿"[:-1]), b"hello, 世�")
++assert_eq(bytes("hello 😃"[:-1]), b"hello \uFFFD")
++
++
++# bytes(iterable of int) -- construct from numeric byte values
++assert_eq(bytes([65, 66, 67]), b"ABC")
++assert_eq(bytes((65, 66, 67)), b"ABC")
++assert_eq(bytes([0xf0, 0x9f, 0x98, 0xbf]), b"😿")
++assert_fails(lambda: bytes([300]),
++             "at index 0, 300 out of range .want value in unsigned 8-bit range")
++assert_fails(lambda: bytes([b"a"]),
++             "at index 0 .* got element of type bytes, want int")
++assert_fails(lambda: bytes(1), "want string, bytes, or iterable of ints")
++
++# literals
++assert_eq(b"hello, 世界", hello)
++assert_eq(b"goodbye", goodbye)
++assert_eq(b"", empty)
++assert_eq(b"\t\n\x7F\u200D", nonprinting)
++assert_ne("abc", b"abc")
++assert_eq(b"\012\xff\u0400\U0001F63F", b"\n\xffЀ😿") # see scanner tests for more
++assert_eq(rb"\r\n\t", b"\\r\\n\\t") # raw
++
++# type
++assert_eq(type(hello), "bytes")
++
++# len
++assert_eq(len(hello), 13)
++assert_eq(len(goodbye), 7)
++assert_eq(len(empty), 0)
++assert_eq(len(b"A"), 1)
++assert_eq(len(b"Ѐ"), 2)
++assert_eq(len(b"世"), 3)
++assert_eq(len(b"😿"), 4)
++
++# truth
++assert_true(hello)
++assert_true(goodbye)
++assert_true(not empty)
++
++# str(bytes) does UTF-8 to UTF-k transcoding.
++# TODO(adonovan): specify.
++assert_eq(str(hello), "hello, 世界")
++assert_eq(str(hello[:-1]), "hello, 世��")  # incomplete UTF-8 encoding => U+FFFD
++assert_eq(str(goodbye), "goodbye")
++assert_eq(str(empty), "")
++assert_eq(str(nonprinting), "\t\n\x7f\u200d")
++assert_eq(str(b"\xED\xB0\x80"), "���") # UTF-16 encoding of unpaired surrogate => U+FFFD * 3
++
++# repr
++assert_eq(repr(hello), r'b"hello, 世界"')
++assert_eq(repr(hello[:-1]), r'b"hello, 世\xe7\x95"')  # (incomplete UTF-8 encoding )
++assert_eq(repr(goodbye), 'b"goodbye"')
++assert_eq(repr(empty), 'b""')
++assert_eq(repr(nonprinting), 'b"\\t\\n\\x7f\\u200d"')
++
++# equality
++assert_eq(hello, hello)
++assert_ne(hello, goodbye)
++assert_eq(b"goodbye", goodbye)
++
++# ordered comparison
++assert_lt(b"abc", b"abd")
++assert_lt(b"abc", b"abcd")
++assert_lt(b"\x7f", b"\x80") # bytes compare as uint8, not int8
++
++# bytes are dict-hashable
++dict = {hello: 1, goodbye: 2}
++dict[b"goodbye"] = 3
++assert_eq(len(dict), 2)
++assert_eq(dict[goodbye], 3)
++
++# hash(bytes) is 32-bit FNV-1a.
++assert_eq(hash(b"") & 0xffffffff, 0x811c9dc5)
++assert_eq(hash(b"a") & 0xffffffff, 0xe40c292c)
++assert_eq(hash(b"ab") & 0xffffffff, 0x4d2505ca)
++assert_eq(hash(b"abc") & 0xffffffff, 0x1a47e90b)
++
++# indexing
++assert_eq(goodbye[0], b"g")
++assert_eq(goodbye[-1], b"e")
++assert_fails(lambda: goodbye[100], "out of range")
++
++# slicing
++assert_eq(goodbye[:4], b"good")
++assert_eq(goodbye[4:], b"bye")
++assert_eq(goodbye[::2], b"gobe")
++assert_eq(goodbye[3:4], b"d")  # special case: len=1
++assert_eq(goodbye[4:4], b"")  # special case: len=0
++
++# bytes in bytes
++assert_eq(b"bc" in b"abcd", True)
++assert_eq(b"bc" in b"dcab", False)
++assert_fails(lambda: "bc" in b"dcab", "requires bytes or int as left operand, not string")
++
++# int in bytes
++assert_eq(97 in b"abc", True)  # 97='a'
++assert_eq(100 in b"abc", False) # 100='d'
++assert_fails(lambda: 256 in b"abc", "int in bytes: 256 out of range")
++assert_fails(lambda: -1 in b"abc", "int in bytes: -1 out of range")
++
++# ord   TODO(adonovan): specify
++assert_eq(ord(b"a"), 97)
++assert_fails(lambda: ord(b"ab"), "ord: bytes has length 2, want 1")
++assert_fails(lambda: ord(b""), "ord: bytes has length 0, want 1")
++
++# repeat (bytes * int)
++assert_eq(goodbye * 3, b"goodbyegoodbyegoodbye")
++assert_eq(3 * goodbye, b"goodbyegoodbyegoodbye")
++
++# elems() returns an iterable value over 1-byte substrings.
++assert_eq(type(hello.elems()), "bytes.elems")
++assert_eq(str(hello.elems()), "b\"hello, 世界\".elems()")
++assert_eq(list(hello.elems()), [104, 101, 108, 108, 111, 44, 32, 228, 184, 150, 231, 149, 140])
++assert_eq(bytes([104, 101, 108, 108, 111, 44, 32, 228, 184, 150, 231, 149, 140]), hello)
++assert_eq(list(goodbye.elems()), [103, 111, 111, 100, 98, 121, 101])
++assert_eq(list(empty.elems()), [])
++assert_eq(bytes(hello.elems()), hello) # bytes(iterable) is dual to bytes.elems()
++
++# x[i] = ...
++def f():
++    b"abc"[1] = b"B"
++
++assert_fails(f, "can only assign an element in a .*, not in a 'bytes'")
++
++# TODO(adonovan): the specification is not finalized in many areas:
++# - chr, ord functions
++# - encoding/decoding bytes to string.
++# - methods: find, index, split, etc.
++#
++# Summary of string operations (put this in spec).
++#
++# string to number:
++# - bytes[i]  returns numeric value of ith byte.
++# - ord(string)  returns numeric value of sole code point in string.
++# - ord(string[i])  is not a useful operation: fails on non-ASCII; see below.
++#   Q. Perhaps ord should return the first (not sole) code point? Then it becomes a UTF-8 decoder.
++#      Perhaps ord(string, index=int) should apply the index and relax the len=1 check.
++# - string.codepoint()  iterates over 1-codepoint substrings.
++# - string.codepoint_ords()  iterates over numeric values of code points in string.
++# - string.elems()  iterates over 1-element (UTF-k code) substrings.
++# - string.elem_ords()  iterates over numeric UTF-k code values.
++# - string.elem_ords()[i]  returns numeric value of ith element (UTF-k code).
++# - string.elems()[i]  returns substring of a single element (UTF-k code).
++# - int(string)  parses string as decimal (or other) numeric literal.
++#
++# number to string:
++# - chr(int) returns string, UTF-k encoding of Unicode code point (like Python).
++#   Redundant with '%c' % int (which Python2 calls 'unichr'.)
++# - bytes(chr(int)) returns byte string containing UTF-8 encoding of one code point.
++# - bytes([int]) returns 1-byte string (with regrettable list allocation).
++# - str(int) - format number as decimal.
+diff --git b/libstarlark/src/test/java/net/starlark/java/eval/testdata/bytes_ext.star a/libstarlark/src/test/java/net/starlark/java/eval/testdata/bytes_ext.star
+new file mode 100644
+index 00000000..7ae6fd8b
+--- /dev/null
++++ a/libstarlark/src/test/java/net/starlark/java/eval/testdata/bytes_ext.star
+@@ -0,0 +1,902 @@
++# copied from:
++# https://github.com/python/cpython/blob/main/Lib/test/test_bytes.py
++# https://github.com/python/cpython/blob/main/Lib/test/string_tests.py
++
++
++# CONSTANTS
++SYS_MAXSIZE = 2147483647
++
++
++# HELPERS
++def assert_ne(arg1, arg2):
++    assert_(arg1 != arg2, "%s == %s!" % (arg1, arg2))
++
++
++def assert_true(arg1):
++    assert_(arg1, "bool(%s) is falsy" % arg1)
++
++
++def assert_false(arg1):
++    assert_(not arg1, "bool(%s) is true!" % arg1)
++
++
++def assert_lt(arg1, arg2):
++    assert_(arg1 < arg2, "%s >= %s" % (arg1, arg2))
++
++
++# check that obj.method(*args) returns result
++def checkequal(result, obj, methodname, *args, **kwargs):
++    realresult = getattr(obj, methodname)(*args, **kwargs)
++    assert_eq(realresult, result)
++
++
++def test_hex():
++    three_bytes = b'\xb9\x01\xef'
++    # test failures
++    assert_fails(lambda: three_bytes.hex(''), ".*sep must be length 1")
++    assert_fails(lambda: three_bytes.hex('xx'), ".*sep must be length 1")
++    assert_fails(lambda: three_bytes.hex(None, 0),
++                 "parameter 'sep' got value of type 'NoneType', want 'string or bytes'")
++    assert_fails(lambda: three_bytes.hex('\u00ff'),
++                 ".*must be ASCII.")
++    assert_fails(lambda: three_bytes.hex(b'\xff'), ".*must be ASCII.")
++    assert_fails(lambda: three_bytes.hex(b'\x80'), ".*must be ASCII.")
++
++    assert_eq(three_bytes.hex(), 'b901ef')
++    assert_eq(three_bytes.hex(':', 0), 'b901ef')
++    assert_eq(three_bytes.hex(':', 0), 'b901ef')
++    assert_eq(three_bytes.hex(b'\x00'), 'b9\x0001\x00ef')
++    assert_eq(three_bytes.hex('\x00'), 'b9\x0001\x00ef')
++    assert_eq(three_bytes.hex(b'\x7f'), 'b9\x7f01\x7fef')
++    assert_eq(three_bytes.hex('\x7f'), 'b9\x7f01\x7fef')
++    assert_eq(three_bytes.hex(':', 3), 'b901ef')
++    assert_eq(three_bytes.hex(':', 4), 'b901ef')
++    assert_eq(three_bytes.hex(':', -4), 'b901ef')
++    assert_eq(three_bytes.hex(':'), 'b9:01:ef')
++    assert_eq(three_bytes.hex(b'$'), 'b9$01$ef')
++    assert_eq(three_bytes.hex(':', 1), 'b9:01:ef')
++    assert_eq(three_bytes.hex(':', -1), 'b9:01:ef')
++    assert_eq(three_bytes.hex(':', 2), 'b9:01ef')
++    assert_eq(three_bytes.hex(':', 1), 'b9:01:ef')
++    assert_eq(three_bytes.hex('*', -2), 'b901*ef')
++
++    value = b'{s\005\000\000\000worldi\002\000\000\000s\005\000\000\000helloi\001\000\000\0000'
++    assert_eq(value.hex('.', 8), '7b7305000000776f.726c646902000000.730500000068656c.6c6f690100000030')
++
++
++def test_count():
++    # b.count
++    b = b'mississippi'
++    i = 105
++    p = 112
++    w = 119
++
++    assert_eq(b.count(b'i'), 4)
++    assert_eq(b.count(b'ss'), 2)
++    assert_eq(b.count(b'w'), 0)
++
++    assert_eq(b.count(i), 4)
++    assert_eq(b.count(w), 0)
++
++    assert_eq(b.count(b'i', 6), 2)
++    assert_eq(b.count(b'p', 6), 2)
++    assert_eq(b.count(b'i', 1, 3), 1)
++    assert_eq(b.count(b'p', 7, 9), 1)
++
++    assert_eq(b.count(i, 6), 2)
++    assert_eq(b.count(p, 6), 2)
++    assert_eq(b.count(i, 1, 3), 1)
++    assert_eq(b.count(p, 7, 9), 1)
++
++    # count.test_none_arguments
++    nonetest_b = b'hello'
++    nonetest_l = b'l'
++    nonetest_h = b'h'
++    nonetest_x = b'x'
++    nonetest_o = b'o'
++    assert_eq(2, nonetest_b.count(nonetest_l, None))
++    assert_eq(1, nonetest_b.count(nonetest_l, -2, None))
++    assert_eq(1, nonetest_b.count(nonetest_l, None, -2))
++    assert_eq(0, nonetest_b.count(nonetest_x, None, None))
++
++
++def test_endswith():
++    b = b'hello'
++    assert_false(bytes('').endswith(b"anything"))
++    assert_true(b.endswith(b"hello"))
++    assert_true(b.endswith(b"llo"))
++    assert_true(b.endswith(b"o"))
++    assert_false(b.endswith(b"whello"))
++    assert_false(b.endswith(b"no"))
++    assert_fails(lambda: b.endswith([b'o']), '.*bytes or tuple.*')
++    # count.test_none_arguments
++    nonetest_b = b'hello'
++    nonetest_l = b'l'
++    nonetest_h = b'h'
++    nonetest_x = b'x'
++    nonetest_o = b'o'
++    assert_true(nonetest_b.endswith(nonetest_o, None))
++    assert_true(nonetest_b.endswith(nonetest_o, -2, None))
++    assert_true(nonetest_b.endswith(nonetest_l, None, -2))
++    assert_false(nonetest_b.endswith(nonetest_x, None, None))
++
++
++def test_find():
++    b = b'mississippi'
++    i = 105
++    w = 119
++
++    assert_eq(b.find(b'ss'), 2)
++    assert_eq(b.find(b'w'), -1)
++    assert_eq(b.find(b'mississippian'), -1)
++
++    assert_eq(b.find(i), 1)
++    assert_eq(b.find(w), -1)
++
++    assert_eq(b.find(b'ss', 3), 5)
++    assert_eq(b.find(b'ss', 1, 7), 2)
++    assert_eq(b.find(b'ss', 1, 3), -1)
++
++    assert_eq(b.find(i, 6), 7)
++    assert_eq(b.find(i, 1, 3), 1)
++    assert_eq(b.find(w, 1, 3), -1)
++
++    for index in (-1, 256, 9223372036854775807 + 1):
++        assert_fails(lambda: b.find(index),
++                     r'.*byte must be in range\(0, 256\)')
++
++
++def test_index():
++    b = b'mississippi'
++    i = 105
++    w = 119
++    assert_eq(b.index(b'ss'), 2)
++    assert_fails(lambda: b.index(b'w'), 'subsection not found')
++    assert_fails(lambda: b.index(b'mississippian'), 'subsection not found')
++
++    assert_eq(b.index(i), 1)
++    assert_fails(lambda: b.index(w), 'subsection not found')
++
++    assert_eq(b.index(b'ss', 3), 5)
++    assert_eq(b.index(b'ss', 1, 7), 2)
++    assert_fails(lambda: b.index(b'ss', 1, 3), 'subsection not found')
++
++    assert_eq(b.index(i, 6), 7)
++    assert_eq(b.index(i, 1, 3), 1)
++    assert_fails(lambda: b.index(w, 1, 3), 'subsection not found')
++
++
++def test_join():
++    assert_eq(b"".join([]), b"")
++    assert_eq(b"".join([b""]), b"")
++    for lst in [[b"abc"], [b"a", b"bc"], [b"ab", b"c"], [b"a", b"b", b"c"]]:
++        assert_eq(b"".join(lst), b"abc")
++        assert_eq(b"".join(tuple(lst)), b"abc")
++        assert_eq(b"".join([i for i in lst]), b"abc")
++    dot_join = b".:".join
++    assert_eq(dot_join([b"ab", b"cd"]), b"ab.:cd")
++    # Stress it with many items
++    seq = [b"abc"] * 100000
++    expected = b"abc" + b".:abc" * 99999
++    assert_eq(dot_join(seq), expected)
++    # Stress test with empty separator
++    seq = [b"abc"] * 100000
++    expected = b"abc" * 100000
++    assert_eq(b"".join(seq), expected)
++    assert_fails(lambda: b" ".join(None),
++                 ".*got value of type 'NoneType', want 'sequence'")
++
++
++def test_partition():
++    b = b'mississippi'
++    assert_eq(b.partition(b'ss'), (b'mi', b'ss', b'issippi'))
++    assert_eq(b.partition(b'w'), (b'mississippi', b'', b''))
++    assert_fails(lambda: b'a b'.partition(' '),
++                 "got value of type 'string', want 'bytes'")
++    assert_fails(lambda: b'a b'.partition(32),
++                 "got value of type 'int', want 'bytes'")
++    checkequal((b'this is the par', b'ti', b'tion method'),
++        b'this is the partition method', 'partition', b'ti')
++
++    # from raymond's original specification
++    S = b'http://www.python.org'
++    checkequal((b'http', b'://', b'www.python.org'), S, 'partition', b'://')
++    checkequal((b'http://www.python.org', b'', b''), S, 'partition', b'?')
++    checkequal((b'', b'http://', b'www.python.org'), S, 'partition', b'http://')
++    checkequal((b'http://www.python.', b'org', b''), S, 'partition', b'org')
++
++
++def test_rpartition():
++    b = b'mississippi'
++    assert_eq(b.rpartition(b'ss'), (b'missi', b'ss', b'ippi'))
++    assert_eq(b.rpartition(b'i'), (b'mississipp', b'i', b''))
++    assert_eq(b.rpartition(b'w'), (b'', b'', b'mississippi'))
++    assert_fails(lambda: b'a b'.rpartition(' '),
++                 "got value of type 'string', want 'bytes'")
++    assert_fails(lambda: b'a b'.rpartition(32),
++                 "got value of type 'int', want 'bytes'")
++    checkequal((b'this is the rparti', b'ti', b'on method'),
++        b'this is the rpartition method', 'rpartition', b'ti')
++
++    # from raymond's original specification
++    S = b'http://www.python.org'
++    checkequal((b'http', b'://', b'www.python.org'), S, 'rpartition', b'://')
++    checkequal((b'', b'', b'http://www.python.org'), S, 'rpartition', b'?')
++    checkequal((b'', b'http://', b'www.python.org'), S, 'rpartition', b'http://')
++    checkequal((b'http://www.python.', b'org', b''), S, 'rpartition', b'org')
++
++
++def test_startswith():
++    b = b'hello'
++    assert_false(b"".startswith(b"anything"))
++    assert_true(b.startswith(b"hello"))
++    assert_true(b.startswith(b"hel"))
++    assert_true(b.startswith(b"h"))
++    assert_false(b.startswith(b"hellow"))
++    assert_false(b.startswith(b"ha"))
++    assert_fails(lambda: b.startswith([b'h']), '.*bytes or tuple.*')
++
++
++def test_replace():
++    b = b'mississippi'
++    assert_eq(b.replace(b'i', b'a'), b'massassappa')
++    assert_eq(b.replace(b'ss', b'x'), b'mixixippi')
++    assert_fails(lambda: b'a b'.replace(32), ".*got value of type 'int', want 'bytes'")
++
++
++def test_split():
++    assert_fails(lambda: b'a b'.split(' '),
++                 "got value of type 'string', want 'bytes or NoneType'")
++    assert_fails(lambda: b'a b'.split(32),
++                 "got value of type 'int', want 'bytes or NoneType'")
++    for b in (b'a\x1Cb', b'a\x1Db', b'a\x1Eb', b'a\x1Fb'):
++        assert_eq(b.split(), [b])
++    b = b"\x09\x0A\x0B\x0C\x0D\x1C\x1D\x1E\x1F"
++    assert_eq(b.split(), [b'\x1c\x1d\x1e\x1f'])
++    assert_eq(b'a b'.split(b' '), [b'a', b'b'])
++    # by 1 byte
++    checkequal([b'a', b'b', b'c', b'd'], b'a|b|c|d', 'split', b'|')
++    checkequal([b'a|b|c|d'], b'a|b|c|d', 'split', b'|', 0)
++    checkequal([b'a', b'b|c|d'], b'a|b|c|d', 'split', b'|', 1)
++    checkequal([b'a', b'b', b'c|d'], b'a|b|c|d', 'split', b'|', 2)
++    checkequal([b'a', b'b', b'c', b'd'], b'a|b|c|d', 'split', b'|', 3)
++    checkequal([b'a', b'b', b'c', b'd'], b'a|b|c|d', 'split', b'|', 4)
++    checkequal([b'a', b'b', b'c', b'd'], b'a|b|c|d', 'split', b'|', SYS_MAXSIZE-2)
++    checkequal([b'a|b|c|d'], b'a|b|c|d', 'split', b'|', 0)
++    checkequal([b'a', b'', b'b||c||d'], b'a||b||c||d', 'split', b'|', 2)
++    checkequal([b'abcd'], b'abcd', 'split', b'|')
++    checkequal([b''], b'', 'split', b'|')
++    checkequal([b'endcase ', b''], b'endcase |', 'split', b'|')
++    checkequal([b'', b' startcase'], b'| startcase', 'split', b'|')
++    checkequal([b'', b'bothcase', b''], b'|bothcase|', 'split', b'|')
++    checkequal([b'a', b'', b'b\x00c\x00d'], b'a\x00\x00b\x00c\x00d', 'split', b'\x00', 2)
++
++    checkequal([b'a']*20, (b'a|'*20)[:-1], 'split', b'|')
++    checkequal([b'a']*15 +[b'a|a|a|a|a'],
++                               (b'a|'*20)[:-1], 'split', b'|', 15)
++
++    # by bytestring
++    checkequal([b'a', b'b', b'c', b'd'], b'a//b//c//d', 'split', b'//')
++    checkequal([b'a', b'b//c//d'], b'a//b//c//d', 'split', b'//', 1)
++    checkequal([b'a', b'b', b'c//d'], b'a//b//c//d', 'split', b'//', 2)
++    checkequal([b'a', b'b', b'c', b'd'], b'a//b//c//d', 'split', b'//', 3)
++    checkequal([b'a', b'b', b'c', b'd'], b'a//b//c//d', 'split', b'//', 4)
++    checkequal([b'a', b'b', b'c', b'd'], b'a//b//c//d', 'split', b'//',SYS_MAXSIZE-10)
++    checkequal([b'a//b//c//d'], b'a//b//c//d', 'split', b'//', 0)
++    checkequal([b'a', b'b', b'c//d'], b'a//b//c//d', 'split', b'//', 2)
++    checkequal([b'endcase ', b''], b'endcase test', 'split', b'test')
++    checkequal([b'', b' begincase'], b'test begincase', 'split', b'test')
++    checkequal([b'', b' bothcase ', b''], b'test bothcase test',
++                    'split', b'test')
++    checkequal([b'a', b'bc'], b'abbbc', 'split', b'bb')
++    checkequal([b'', b''], b'aaa', 'split', b'aaa')
++    checkequal([b'aaa'], b'aaa', 'split', b'aaa', 0)
++    checkequal([b'ab', b'ab'], b'abbaab', 'split', b'ba')
++    checkequal([b'aaaa'], b'aaaa', 'split', b'aab')
++    checkequal([b''], b'', 'split', b'aaa')
++    checkequal([b'aa'], b'aa', 'split', b'aaa')
++    checkequal([b'A', b'bobb'], b'Abbobbbobb', 'split', b'bbobb')
++    checkequal([b'A', b'B', b''], b'AbbobbBbbobb', 'split', b'bbobb')
++
++    checkequal([b'a']*20, (b'aBLAH'*20)[:-4], 'split', b'BLAH')
++    checkequal([b'a']*20, (b'aBLAH'*20)[:-4], 'split', b'BLAH', 19)
++    checkequal([b'a']*18 + [b'aBLAHa'], (b'aBLAH'*20)[:-4],
++                    'split', b'BLAH', 18)
++
++    # with keyword args
++    checkequal([b'a', b'b', b'c', b'd'], b'a|b|c|d', 'split', sep=b'|')
++    checkequal([b'a', b'b|c|d'], b'a|b|c|d', 'split', b'|', maxsplit=1)
++    checkequal([b'a', b'b|c|d'], b'a|b|c|d', 'split', sep=b'|', maxsplit=1)
++    checkequal([b'a', b'b|c|d'], b'a|b|c|d', 'split', maxsplit=1, sep=b'|')
++    checkequal([b'a', b'b c d'], b'a b c d', 'split', maxsplit=1)
++
++
++def test_rsplit():
++    assert_fails(lambda: b'a b'.rsplit(' '),
++                 "got value of type 'string', want 'bytes or NoneType'")
++    assert_fails(lambda: b'a b'.rsplit(32),
++                 "got value of type 'int', want 'bytes or NoneType'")
++    b = b"\x09\x0A\x0B\x0C\x0D\x1C\x1D\x1E\x1F"
++    assert_eq(b.rsplit(), [b'\x1c\x1d\x1e\x1f'])
++    assert_eq(b'a b'.rsplit(b' '), [b'a', b'b'])
++    # by a char
++    checkequal([b'a', b'b', b'c', b'd'], b'a|b|c|d', 'rsplit', b'|')
++    checkequal([b'a|b|c', b'd'], b'a|b|c|d', 'rsplit', b'|', 1)
++    checkequal([b'a|b', b'c', b'd'], b'a|b|c|d', 'rsplit', b'|', 2)
++    checkequal([b'a', b'b', b'c', b'd'], b'a|b|c|d', 'rsplit', b'|', 3)
++    checkequal([b'a', b'b', b'c', b'd'], b'a|b|c|d', 'rsplit', b'|', 4)
++    checkequal([b'a', b'b', b'c', b'd'], b'a|b|c|d', 'rsplit', b'|',
++               SYS_MAXSIZE-100)
++    checkequal([b'a|b|c|d'], b'a|b|c|d', 'rsplit', b'|', 0)
++    checkequal([b'a||b||c', b'', b'd'], b'a||b||c||d', 'rsplit', b'|', 2)
++    checkequal([b'abcd'], b'abcd', 'rsplit', b'|')
++    checkequal([b''], b'', 'rsplit', b'|')
++    checkequal([b'', b' begincase'], b'| begincase', 'rsplit', b'|')
++    checkequal([b'endcase ', b''], b'endcase |', 'rsplit', b'|')
++    checkequal([b'', b'bothcase', b''], b'|bothcase|', 'rsplit', b'|')
++
++    checkequal([b'a\x00\x00b', b'c', b'd'], b'a\x00\x00b\x00c\x00d', 'rsplit', b'\x00', 2)
++
++    checkequal([b'a']*20, (b'a|'*20)[:-1], 'rsplit', b'|')
++    checkequal([b'a|a|a|a|a']+[b'a']*15,
++                 (b'a|'*20)[:-1], 'rsplit', b'|', 15)
++
++    # by string
++    checkequal([b'a', b'b', b'c', b'd'], b'a//b//c//d', 'rsplit', b'//')
++    checkequal([b'a//b//c', b'd'], b'a//b//c//d', 'rsplit', b'//', 1)
++    checkequal([b'a//b', b'c', b'd'], b'a//b//c//d', 'rsplit', b'//', 2)
++    checkequal([b'a', b'b', b'c', b'd'], b'a//b//c//d', 'rsplit', b'//', 3)
++    checkequal([b'a', b'b', b'c', b'd'], b'a//b//c//d', 'rsplit', b'//', 4)
++    checkequal([b'a', b'b', b'c', b'd'], b'a//b//c//d', 'rsplit', b'//',
++               SYS_MAXSIZE-5)
++    checkequal([b'a//b//c//d'], b'a//b//c//d', 'rsplit', b'//', 0)
++    checkequal([b'a////b////c', b'', b'd'], b'a////b////c////d', 'rsplit', b'//', 2)
++    checkequal([b'', b' begincase'], b'test begincase', 'rsplit', b'test')
++    checkequal([b'endcase ', b''], b'endcase test', 'rsplit', b'test')
++    checkequal([b'', b' bothcase ', b''], b'test bothcase test',
++                 'rsplit', b'test')
++    checkequal([b'ab', b'c'], b'abbbc', 'rsplit', b'bb')
++    checkequal([b'', b''], b'aaa', 'rsplit', b'aaa')
++    checkequal([b'aaa'], b'aaa', 'rsplit', b'aaa', 0)
++    checkequal([b'ab', b'ab'], b'abbaab', 'rsplit', b'ba')
++    checkequal([b'aaaa'], b'aaaa', 'rsplit', b'aab')
++    checkequal([b''], b'', 'rsplit', b'aaa')
++    checkequal([b'aa'], b'aa', 'rsplit', b'aaa')
++    checkequal([b'bbob', b'A'], b'bbobbbobbA', 'rsplit', b'bbobb')
++    checkequal([b'', b'B', b'A'], b'bbobbBbbobbA', 'rsplit', b'bbobb')
++
++    checkequal([b'a']*20, (b'aBLAH'*20)[:-4], 'rsplit', b'BLAH')
++    checkequal([b'a']*20, (b'aBLAH'*20)[:-4], 'rsplit', b'BLAH', 19)
++    checkequal([b'aBLAHa'] + [b'a']*18, (b'aBLAH'*20)[:-4],
++                 'rsplit', b'BLAH', 18)
++
++    # with keyword args
++    checkequal([b'a', b'b', b'c', b'd'], b'a|b|c|d', 'rsplit', sep=b'|')
++    checkequal([b'a|b|c', b'd'],
++                 b'a|b|c|d', 'rsplit', b'|', maxsplit=1)
++    checkequal([b'a|b|c', b'd'],
++                 b'a|b|c|d', 'rsplit', sep=b'|', maxsplit=1)
++    checkequal([b'a|b|c', b'd'],
++                 b'a|b|c|d', 'rsplit', maxsplit=1, sep=b'|')
++    checkequal([b'a b c', b'd'],
++                 b'a b c d', 'rsplit', maxsplit=1)
++
++def test_strip():
++    assert_eq(b'abc'.strip(b'ac'), b'b')
++    assert_fails(lambda: b'abc'.strip('ac'), "got value of type 'string', want 'bytes or NoneType'")
++    assert_fails(lambda: b' abc '.strip(32), "got value of type 'int', want 'bytes or NoneType'")
++
++    # whitespace
++    checkequal(b'hello', b'   hello   ', 'strip')
++    checkequal(b'hello', b'hello', 'strip')
++
++    b = b' \t\n\r\f\vabc \t\n\r\f\v'
++    checkequal(b'abc', b, 'strip')
++
++    # strip with None arg
++    checkequal(b'hello', b'   hello   ', 'strip', None)
++    checkequal(b'hello', b'hello', 'strip', None)
++
++    # strip with byte string arg
++    checkequal(b'hello', b'xyzzyhelloxyzzy', 'strip', b'xyz')
++    checkequal(b'hello', b'hello', 'strip', b'xyz')
++    checkequal(b'', b'mississippi', 'strip', b'mississippi')
++
++    # only trim the start and end; does not strip internal characters
++    checkequal(b'mississipp', b'mississippi', 'strip', b'i')
++
++    assert_fails(lambda: checkequal(b'hello', 'strip', 42, 42), "got value of type 'int', want 'string'")
++
++
++def test_lstrip():
++    assert_eq(b'abc'.lstrip(b'ac'), b'bc')
++    assert_fails(lambda: b'abc'.lstrip('ac'), "got value of type 'string', want 'bytes or NoneType'")
++    assert_fails(lambda: b' abc '.lstrip(32), "got value of type 'int', want 'bytes or NoneType'")
++    checkequal(b'hello   ', b'   hello   ', 'lstrip')
++    b = b' \t\n\r\f\vabc \t\n\r\f\v'
++    checkequal(b'abc \t\n\r\f\v', b, 'lstrip')
++    # lstrip with None arg
++    checkequal(b'hello   ', b'   hello   ', 'lstrip', None)
++    # lstrip with byte string arg
++    checkequal(b'helloxyzzy', b'xyzzyhelloxyzzy', 'lstrip', b'xyz')
++    assert_fails(lambda: checkequal(b'hello', 'lstrip', 42, 42), "got value of type 'int', want 'string'")
++
++
++def test_rstrip():
++    assert_eq(b'abc'.rstrip(b'ac'), b'ab')
++    assert_fails(lambda: b'abc'.rstrip('ac'), "got value of type 'string', want 'bytes or NoneType'")
++    assert_fails(lambda: b' abc '.rstrip(32), "got value of type 'int', want 'bytes or NoneType'")
++    checkequal(b'   hello', b'   hello   ', 'rstrip')
++    b = b' \t\n\r\f\vabc \t\n\r\f\v'
++    checkequal(b' \t\n\r\f\vabc', b, 'rstrip')
++    # rstrip with None arg
++    checkequal(b'   hello', b'   hello   ', 'rstrip', None)
++    # rstrip with byte string arg
++    checkequal(b'xyzzyhello', b'xyzzyhelloxyzzy', 'rstrip', b'xyz')
++    assert_fails(lambda: checkequal(b'hello', 'rstrip', 42, 42), "got value of type 'int', want 'string'")
++
++
++def test_rindex():
++    b = b'mississippi'
++    i = 105
++    w = 119
++
++    assert_eq(b.rindex(b'ss'), 5)
++    assert_fails(lambda: b.rindex(b'w'), "subsection not found")
++    assert_fails(lambda: b.rindex(b'mississippian'), "subsection not found")
++
++    assert_eq(b.rindex(i), 10)
++    assert_fails(lambda: b.rindex(w), "subsection not found")
++
++    assert_eq(b.rindex(b'ss', 3), 5)
++    assert_eq(b.rindex(b'ss', 0, 6), 2)
++
++    assert_eq(b.rindex(i, 1, 3), 1)
++    assert_eq(b.rindex(i, 3, 9), 7)
++    assert_fails(lambda: b.rindex(w, 1, 3), "subsection not found")
++
++    checkequal(12, b'abcdefghiabc', 'rindex', b'')
++    checkequal(3,  b'abcdefghiabc', 'rindex', b'def')
++    checkequal(9,  b'abcdefghiabc', 'rindex', b'abc')
++    checkequal(0,  b'abcdefghiabc', 'rindex', b'abc', 0, -1)
++
++    assert_fails(lambda: checkequal(b'abcdefghiabc', 'rindex', b'hib'), "got value of type 'bytes', want 'string'")
++    assert_fails(lambda: checkequal(b'defghiabc', 'rindex', b'def', 1), "got value of type 'bytes', want 'string'")
++    assert_fails(lambda: checkequal(b'defghiabc', 'rindex', b'abc', 0, -1), "got value of type 'bytes', want 'string'")
++    assert_fails(lambda: checkequal(b'abcdefghi', 'rindex', b'ghi', 0, 8), "got value of type 'bytes', want 'string'")
++    assert_fails(lambda: checkequal(b'abcdefghi', 'rindex', b'ghi', 0, -1), "got value of type 'bytes', want 'string'")
++
++    # to check the ability to pass None as defaults
++    checkequal(12, b'rrarrrrrrrrra', 'rindex', b'a')
++    checkequal(12, b'rrarrrrrrrrra', 'rindex', b'a', 4)
++    assert_fails(lambda: checkequal(b'rrarrrrrrrrra', 'rindex', b'a', 4, 6), "got value of type 'bytes', want 'string'")
++    checkequal(12, b'rrarrrrrrrrra', 'rindex', b'a', 4, None)
++    checkequal( 2, b'rrarrrrrrrrra', 'rindex', b'a', None, 6)
++
++    assert_fails(lambda: checkequal("fail?", b'hello', 'rindex'), "missing 1 required positional argument")
++
++    # none tests
++    b = b'hello'
++    l = b'l'
++    h = b'h'
++    x = b'x'
++    o = b'o'
++    assert_eq(3, b.rindex(l, None))
++    assert_eq(3, b.rindex(l, -2, None))
++    assert_eq(2, b.rindex(l, None, -2))
++    assert_eq(0, b.rindex(h, None, None))
++
++
++def test_rfind():
++    b = b'mississippi'
++    i = 105
++    w = 119
++
++    assert_eq(b.rfind(b'ss'), 5)
++    assert_eq(b.rfind(b'w'), -1)
++    assert_eq(b.rfind(b'mississippian'), -1)
++
++    assert_eq(b.rfind(i), 10)
++    assert_eq(b.rfind(w), -1)
++
++    assert_eq(b.rfind(b'ss', 3), 5)
++    assert_eq(b.rfind(b'ss', 0, 6), 2)
++
++    assert_eq(b.rfind(i, 1, 3), 1)
++    assert_eq(b.rfind(i, 3, 9), 7)
++    assert_eq(b.rfind(w, 1, 3), -1)
++
++    checkequal(9,  b'abcdefghiabc', 'rfind', b'abc')
++    checkequal(12, b'abcdefghiabc', 'rfind', b'')
++    checkequal(0, b'abcdefghiabc', 'rfind', b'abcd')
++    checkequal(-1, b'abcdefghiabc', 'rfind', b'abcz')
++
++    checkequal(3, b'abc', 'rfind', b'', 0)
++    checkequal(3, b'abc', 'rfind', b'', 3)
++    checkequal(-1, b'abc', 'rfind', b'', 4)
++
++    # to check the ability to pass None as defaults
++    checkequal(12, b'rrarrrrrrrrra', 'rfind', b'a')
++    checkequal(12, b'rrarrrrrrrrra', 'rfind', b'a', 4)
++    checkequal(-1, b'rrarrrrrrrrra', 'rfind', b'a', 4, 6)
++    checkequal(12, b'rrarrrrrrrrra', 'rfind', b'a', 4, None)
++    checkequal( 2, b'rrarrrrrrrrra', 'rfind', b'a', None, 6)
++
++    assert_fails(lambda: checkequal("fail?", b'hello', 'rfind'), "missing 1 required positional argument")
++
++    # none tests
++    b = b'hello'
++    l = b'l'
++    h = b'h'
++    x = b'x'
++    o = b'o'
++    assert_eq(3, b.rfind(l, None))
++    assert_eq(3, b.rfind(l, -2, None))
++    assert_eq(2, b.rfind(l, None, -2))
++    assert_eq(0, b.rfind(h, None, None))
++
++
++def test_ljust():
++    checkequal(b'abc       ', b'abc', 'ljust', 10)
++    checkequal(b'abc   ', b'abc', 'ljust', 6)
++    checkequal(b'abc', b'abc', 'ljust', 3)
++    checkequal(b'abc', b'abc', 'ljust', 2)
++    checkequal(b'abc*******', b'abc', 'ljust', 10, b'*')
++    assert_fails(lambda: checkequal("fail?", b'abc', 'ljust'), "missing 1 required positional argument")
++    assert_fails(lambda: checkequal("fail?", b'abc', 'ljust', 7, 32), "'fillbyte' got value of type 'int', want 'bytes'")
++    b = b'abc'
++    for fill_type in (bytes,):
++        assert_eq(b.ljust(7, fill_type(b'-')), fill_type(b'abc----'))
++
++
++def test_rjust():
++    checkequal(b'       abc', b'abc', 'rjust', 10)
++    checkequal(b'   abc', b'abc', 'rjust', 6)
++    checkequal(b'abc', b'abc', 'rjust', 3)
++    checkequal(b'abc', b'abc', 'rjust', 2)
++    checkequal(b'*******abc', b'abc', 'rjust', 10, b'*')
++    assert_fails(lambda: checkequal("fail?", b'abc', 'rjust'), "missing 1 required positional argument")
++    assert_fails(lambda: checkequal("fail?", b'abc', 'rjust', 7, 32), "'fillbyte' got value of type 'int', want 'bytes'")
++    b = b'abc'
++    for fill_type in (bytes,):
++        assert_eq(b.rjust(7, fill_type(b'-')), fill_type(b'----abc'))
++
++
++def test_center():
++    checkequal(b'   abc    ', b'abc', 'center', 10)
++    checkequal(b' abc  ', b'abc', 'center', 6)
++    checkequal(b'abc', b'abc', 'center', 3)
++    checkequal(b'abc', b'abc', 'center', 2)
++    checkequal(b'***abc****', b'abc', 'center', 10, b'*')
++    assert_fails(lambda: checkequal("fail?", b'abc', 'center'), "missing 1 required positional argument")
++    assert_fails(lambda: checkequal("fail?", b'abc', 'center', 7, 32), "'fillbyte' got value of type 'int', want 'bytes'")
++    # Fill character can be either bytes or bytearray (issue 12380)
++    b = b'abc'
++    for fill_type in (bytes,):
++        assert_eq(b.center(7, fill_type(b'-')), fill_type(b'--abc--'))
++
++
++def test_swapcase():
++    checkequal(b'hEllO CoMPuTErS', b'HeLLo cOmpUteRs', 'swapcase')
++    assert_fails(lambda: checkequal("fail?", b'hello', 'swapcase', 42), "got unexpected positional argument")
++
++
++def test_zfill():
++    checkequal(b'123', b'123', 'zfill', 2)
++    checkequal(b'123', b'123', 'zfill', 3)
++    checkequal(b'0123', b'123', 'zfill', 4)
++    checkequal(b'+123', b'+123', 'zfill', 3)
++    checkequal(b'+123', b'+123', 'zfill', 4)
++    checkequal(b'+0123', b'+123', 'zfill', 5)
++    checkequal(b'-123', b'-123', 'zfill', 3)
++    checkequal(b'-123', b'-123', 'zfill', 4)
++    checkequal(b'-0123', b'-123', 'zfill', 5)
++    checkequal(b'000', b'', 'zfill', 3)
++    checkequal(b'34', b'34', 'zfill', 1)
++    checkequal(b'0034', b'34', 'zfill', 4)
++
++    assert_fails(lambda: checkequal("fail?", b'123', 'zfill'), "missing 1 required positional argument")
++
++
++def test_islower():
++    checkequal(False, b'', 'islower')
++    checkequal(True, b'a', 'islower')
++    checkequal(False, b'A', 'islower')
++    checkequal(False, b'\n', 'islower')
++    checkequal(True, b'abc', 'islower')
++    checkequal(False, b'aBc', 'islower')
++    checkequal(True, b'abc\n', 'islower')
++    assert_fails(lambda: checkequal("fail?", b'abc', 'islower', 42), "got unexpected positional argument")
++
++
++def test_isupper():
++    checkequal(False, b'', 'isupper')
++    checkequal(False, b'a', 'isupper')
++    checkequal(True, b'A', 'isupper')
++    checkequal(False, b'\n', 'isupper')
++    checkequal(True, b'ABC', 'isupper')
++    checkequal(False, b'AbC', 'isupper')
++    checkequal(True, b'ABC\n', 'isupper')
++    assert_fails(lambda: checkequal("fail?", b'abc', 'isupper', 42), "got unexpected positional argument")
++
++
++def test_istitle():
++    checkequal(False, b'', 'istitle')
++    checkequal(False, b'a', 'istitle')
++    checkequal(True, b'A', 'istitle')
++    checkequal(False, b'\n', 'istitle')
++    checkequal(True, b'A Titlecased Line', 'istitle')
++    checkequal(True, b'A\nTitlecased Line', 'istitle')
++    checkequal(True, b'A Titlecased, Line', 'istitle')
++    checkequal(False, b'Not a capitalized String', 'istitle')
++    checkequal(False, b'Not\ta Titlecase String', 'istitle')
++
++
++def test_isspace():
++    checkequal(False, b'a', 'isspace')
++    checkequal(True, b' ', 'isspace')
++    checkequal(True, '\t', 'isspace')
++    checkequal(True, b'\r', 'isspace')
++    checkequal(True, b'\n', 'isspace')
++    checkequal(True, b' \t\r\n', 'isspace')
++    checkequal(False, b' \t\r\na', 'isspace')
++    assert_fails(lambda: checkequal("fail?", b'abc', 'isspace', 42), "got unexpected positional argument")
++
++
++def test_isalpha():
++    checkequal(False, b'', 'isalpha')
++    checkequal(True, b'a', 'isalpha')
++    checkequal(True, b'A', 'isalpha')
++    checkequal(False, b'\n', 'isalpha')
++    checkequal(True, b'abc', 'isalpha')
++    checkequal(False, b'aBc123', 'isalpha')
++    checkequal(False, b'abc\n', 'isalpha')
++    assert_fails(lambda: checkequal("fail?", b'abc', 'isalpha', 42), "got unexpected positional argument")
++
++
++def test_isalnum():
++    checkequal(False, b'', 'isalnum')
++    checkequal(True, b'a', 'isalnum')
++    checkequal(True, b'A', 'isalnum')
++    checkequal(False, b'\n', 'isalnum')
++    checkequal(True, b'123abc456', 'isalnum')
++    checkequal(True, b'a1b3c', 'isalnum')
++    checkequal(False, b'aBc000 ', 'isalnum')
++    checkequal(False, b'abc\n', 'isalnum')
++    assert_fails(lambda: checkequal("fail?", b'abc', 'isalnum', 42), "got unexpected positional argument")
++
++
++def test_isascii():
++    checkequal(True, b'', 'isascii')
++    checkequal(True, b'\x00', 'isascii')
++    checkequal(True, b'\x7f', 'isascii')
++    checkequal(True, b'\x00\x7f', 'isascii')
++    checkequal(False, b'\x80', 'isascii')
++    checkequal(False, b'\xe9', 'isascii')
++
++    # bytes.isascii() and bytearray.isascii() has optimization which
++    # check 4 or 8 bytes at once.  So check some alignments.
++    for p in range(8):
++      checkequal(True, b' '*p + b'\x7f', 'isascii')
++      checkequal(False, b' '*p + b'\u0080', 'isascii')
++      checkequal(True, b' '*p + b'\x7f' + b' '*8, 'isascii')
++      checkequal(False, b' '*p + b'\u0080' + b' '*8, 'isascii')
++
++
++def test_isdigit():
++    checkequal(False, b'', 'isdigit')
++    checkequal(False, b'a', 'isdigit')
++    checkequal(True, b'0', 'isdigit')
++    checkequal(True, b'0123456789', 'isdigit')
++    checkequal(False, b'0123456789a', 'isdigit')
++
++    assert_fails(lambda: checkequal("fail?", b'abc', 'isdigit', 42), "got unexpected positional argument")
++
++
++def test_title():
++    checkequal(b' Hello ', b' hello ', 'title')
++    checkequal(b'Hello ', b'hello ', 'title')
++    checkequal(b'Hello ', b'Hello ', 'title')
++    checkequal(b'Format This As Title String', b"fOrMaT thIs aS titLe String", 'title')
++    checkequal(b'Format,This-As*Title;String', b"fOrMaT,thIs-aS*titLe;String", 'title', )
++    checkequal(b'Getint', b"getInt", 'title')
++    assert_fails(lambda: checkequal("fail?", b'hello', 'title', 42), "got unexpected positional argument")
++
++
++def test_splitlines():
++    checkequal([b'abc', b'def', b'', b'ghi'], b"abc\ndef\n\rghi", 'splitlines')
++    checkequal([b'abc', b'def', b'', b'ghi'], b"abc\ndef\n\r\nghi", 'splitlines')
++    checkequal([b'abc', b'def', b'ghi'], b"abc\ndef\r\nghi", 'splitlines')
++    checkequal([b'abc', b'def', b'ghi'], b"abc\ndef\r\nghi\n", 'splitlines')
++    checkequal([b'abc', b'def', b'ghi', b''], b"abc\ndef\r\nghi\n\r", 'splitlines')
++    checkequal([b'', b'abc', b'def', b'ghi', b''], b"\nabc\ndef\r\nghi\n\r", 'splitlines')
++    checkequal([b'', b'abc', b'def', b'ghi', b''],
++                  b"\nabc\ndef\r\nghi\n\r", 'splitlines', False)
++    checkequal([b'\n', b'abc\n', b'def\r\n', b'ghi\n', b'\r'],
++                  b"\nabc\ndef\r\nghi\n\r", 'splitlines', True)
++    checkequal([b'', b'abc', b'def', b'ghi', b''], b"\nabc\ndef\r\nghi\n\r",
++                  'splitlines', keepends=False)
++    checkequal([b'\n', b'abc\n', b'def\r\n', b'ghi\n', b'\r'],
++                  b"\nabc\ndef\r\nghi\n\r", 'splitlines', keepends=True)
++
++    assert_fails(lambda: checkequal("fail?", b'abc', 'splitlines', 42, 42), "parameter 'keepends' got value of type 'int', want 'bool'")
++
++
++def test_lower():
++    checkequal(b'hello', b'HeLLo', 'lower')
++    checkequal(b'hello', b'hello', 'lower')
++    assert_fails(lambda: checkequal("fail?", b'hello', 'lower', 42), "got unexpected positional argument")
++
++
++def test_upper():
++    checkequal(b'HELLO', b'HeLLo', 'upper')
++    checkequal(b'HELLO', b'HELLO', 'upper')
++    assert_fails(lambda: checkequal("fail?", b'hello', 'upper', 42), "got unexpected positional argument")
++
++
++def test_removeprefix():
++    prefix= b'pip-'
++    filename = b'pip-20.2.2-py2.py3-none-any.whl'
++    # from: https://github.com/python/cpython/blob/521ba8892ef367c45bf1647b04a726d3f553637c/Lib/ensurepip/__init__.py#L54-L55
++    # Extract '20.2.2' from 'pip-20.2.2-py2.py3-none-any.whl'
++    version = filename.removeprefix(prefix).partition(b'-')[0]
++    assert_eq(version, b"20.2.2")
++
++    checkequal(b'am', b'spam', 'removeprefix', b'sp')
++    checkequal(b'spamspam', b'spamspamspam', 'removeprefix', b'spam')
++    checkequal(b'spam', b'spam', 'removeprefix', b'python')
++    checkequal(b'spam', b'spam', 'removeprefix', b'spider')
++    checkequal(b'spam', b'spam', 'removeprefix', b'spam and eggs')
++
++    checkequal(b'', b'', 'removeprefix', b'')
++    checkequal(b'', b'', 'removeprefix', b'abcde')
++    checkequal(b'abcde', b'abcde', 'removeprefix', b'')
++    checkequal(b'', b'abcde', 'removeprefix', b'abcde')
++
++    assert_fails(lambda: checkequal("fail?", b'hello', 'removeprefix'), "missing 1 required positional argument: prefix")
++    assert_fails(lambda: checkequal("fail?", b'hello', 'removeprefix', 42), "parameter 'prefix' got value of type 'int', want 'bytes'")
++    assert_fails(lambda: checkequal("fail?", b'hello', 'removeprefix', 42, b'h'), "parameter 'prefix' got value of type 'int', want 'bytes'")
++    assert_fails(lambda: checkequal("fail?", b'hello', 'removeprefix', b'h', 42), "accepts no more than 1 positional argument but got 2")
++    assert_fails(lambda: checkequal("fail?", b'hello', 'removeprefix', (b"he", b"l")), "parameter 'prefix' got value of type 'tuple', want 'bytes'")
++
++
++def test_removesuffix():
++    checkequal(b'sp', b'spam', 'removesuffix', b'am')
++    checkequal(b'spamspam', b'spamspamspam', 'removesuffix', b'spam')
++    checkequal(b'spam', b'spam', 'removesuffix', b'python')
++    checkequal(b'spam', b'spam', 'removesuffix', b'blam')
++    checkequal(b'spam', b'spam', 'removesuffix', b'eggs and spam')
++
++    checkequal(b'', b'', 'removesuffix', b'')
++    checkequal(b'', b'', 'removesuffix', b'abcde')
++    checkequal(b'abcde', b'abcde', 'removesuffix', b'')
++    checkequal(b'', b'abcde', 'removesuffix', b'abcde')
++
++    assert_fails(lambda: checkequal("fail?", b'hello', 'removesuffix'),  "missing 1 required positional argument: suffix")
++    assert_fails(lambda: checkequal("fail?", b'hello', 'removesuffix', 42), "parameter 'suffix' got value of type 'int', want 'bytes'")
++    assert_fails(lambda: checkequal("fail?", b'hello', 'removesuffix', 42, b'h'), "parameter 'suffix' got value of type 'int', want 'bytes'")
++    assert_fails(lambda: checkequal("fail?", b'hello', 'removesuffix', b'h', 42), "accepts no more than 1 positional argument but got 2")
++    assert_fails(lambda: checkequal("fail?", b'hello', 'removesuffix', (b"lo", b"l")),  "parameter 'suffix' got value of type 'tuple', want 'bytes'")
++
++
++def test_capitalize():
++    checkequal(b' hello ', b' hello ', 'capitalize')
++    checkequal(b'Hello ', b'Hello ','capitalize')
++    checkequal(b'Hello ', b'hello ', 'capitalize')
++    checkequal(b'Aaaa', b'aaaa', 'capitalize')
++    checkequal(b'Aaaa', b'AaAa', 'capitalize')
++
++    assert_fails(lambda: checkequal("fail?", b'hello', 'capitalize', 42), " got unexpected positional argument")
++
++
++def test_translate():
++    b = b'hello'
++    rosetta = list(range(256))
++    rosetta[ord('o')] = ord('e')
++    rosetta = bytes(rosetta)
++
++    assert_fails(lambda: checkequal("fail?", b, 'translate'), "missing 1 required positional argument: table")
++    assert_fails(lambda: checkequal("fail?", b, 'translate', None, None), "parameter 'delete' got value of type 'NoneType', want 'bytes'")
++    assert_fails(lambda: checkequal("fail?", b, 'translate', bytes(range(255))), "translation table must be 256 characters long")
++
++    c = b.translate(rosetta)
++    d = b.translate(rosetta, b'')
++    assert_eq(c, d)
++    assert_eq(c, b'helle')
++
++    c = b.translate(rosetta, b'hello')
++    assert_eq(b, b'hello')  # does not mutate
++    assert_eq(type(c), "bytes")
++    assert_eq(c, b'')
++
++    c = b.translate(rosetta, b'l')
++    assert_eq(c, b'hee')
++    c = b.translate(None, b'e')
++    assert_eq(c, b'hllo')
++
++    # test delete as a keyword argument
++    c = b.translate(rosetta, delete=b'')
++    assert_eq(c, b'helle')
++    c = b.translate(rosetta, delete=b'l')
++    assert_eq(c, b'hee')
++    c = b.translate(None, delete=b'e')
++    assert_eq(c, b'hllo')
++
++
++def test_expandtabs():
++    checkequal(b'abc\rab      def\ng       hi', b'abc\rab\tdef\ng\thi',
++                    'expandtabs')
++    checkequal(b'abc\rab      def\ng       hi', b'abc\rab\tdef\ng\thi',
++                    'expandtabs', 8)
++    checkequal(b'abc\rab  def\ng   hi', b'abc\rab\tdef\ng\thi',
++                    'expandtabs', 4)
++    checkequal(b'abc\r\nab      def\ng       hi', b'abc\r\nab\tdef\ng\thi',
++                    'expandtabs')
++    checkequal(b'abc\r\nab      def\ng       hi', b'abc\r\nab\tdef\ng\thi',
++                    'expandtabs', 8)
++    checkequal(b'abc\r\nab  def\ng   hi', b'abc\r\nab\tdef\ng\thi',
++                    'expandtabs', 4)
++    checkequal(b'abc\r\nab\r\ndef\ng\r\nhi', b'abc\r\nab\r\ndef\ng\r\nhi',
++                    'expandtabs', 4)
++    # check keyword args
++    checkequal(b'abc\rab      def\ng       hi', b'abc\rab\tdef\ng\thi',
++                    'expandtabs', tabsize=8)
++    checkequal(b'abc\rab  def\ng   hi', b'abc\rab\tdef\ng\thi',
++                    'expandtabs', tabsize=4)
++
++    checkequal(b'  a\n b', b' \ta\n\tb', 'expandtabs', 1)
++
++    assert_fails(
++        lambda: checkequal("fail?", b'hello', 'expandtabs', 42, 42),
++        "accepts no more than 1 positional argument but got 2")
++
++# test_bytearray_append()
++test_capitalize()
++test_center()
++# test_bytearray_clear()
++# test_bytearray_copy()
++test_count()
++# unsupported: test_decode()
++test_endswith()
++test_expandtabs()
++# test_bytearray_extend()
++test_find()
++# TODO: test_fromhex()
++test_hex()
++test_index()
++# test_bytearray_insert()
++test_isalnum()
++test_isalpha()
++test_isascii()
++test_isdigit()
++test_islower()
++test_isspace()
++test_istitle()
++test_isupper()
++test_join()
++test_ljust()
++test_lower()
++test_lstrip()
++# TODO: test_maketrans()
++test_partition()
++# test_bytearray_pop()
++# test_bytearray_remove()
++test_removeprefix()
++test_removesuffix()
++test_replace()
++# test_bytearray_reverse()
++test_rfind()
++test_rindex()
++test_rjust()
++test_rpartition()
++test_rsplit()
++test_rstrip()
++test_split()
++test_splitlines()
++test_startswith()
++test_strip()
++test_swapcase()
++test_title()
++test_translate()
++test_upper()
++test_zfill()
+\ No newline at end of file
+diff --git b/libstarlark/src/test/java/net/starlark/java/ext/ByteListTest.java a/libstarlark/src/test/java/net/starlark/java/ext/ByteListTest.java
+new file mode 100644
+index 00000000..b7b9a8a5
+--- /dev/null
++++ a/libstarlark/src/test/java/net/starlark/java/ext/ByteListTest.java
+@@ -0,0 +1,1216 @@
++package net.starlark.java.ext;
++
++import static org.junit.Assert.assertArrayEquals;
++import static org.junit.Assert.assertEquals;
++import static org.junit.Assert.assertFalse;
++import static org.junit.Assert.assertSame;
++import static org.junit.Assert.assertTrue;
++
++import com.google.common.collect.Iterables;
++import java.nio.charset.StandardCharsets;
++import java.util.ArrayList;
++import java.util.Random;
++
++import org.junit.Test;
++
++public class ByteListTest {
++
++  public static byte[] b(final String s) {
++    return s.getBytes(StandardCharsets.ISO_8859_1);
++  }
++
++  public void checkEqual(ByteList a1, ArrayList<Byte> a2) {
++    assertEquals(a1.size(), a2.size());
++    for (int i = 0; i < a1.size(); i++) {
++      assertEquals(a1.get(i), (byte) a2.get(i));
++      assertEquals(a1.byteAt(i), (byte) a2.get(i));
++    }
++    //noinspection AssertBetweenInconvertibleTypes
++    assertEquals(a1, a2);  // testing implicit iterator conversion
++    assertTrue(a1.iterator().itemsEqual(a2.iterator()));
++    assertTrue(ByteList.OfByte.itemsEqual(a2.iterator(), a1.iterator()));
++  }
++
++  public void check(int length) {
++    ByteList a1 = new ByteList();
++    ArrayList<Byte> a2 = new ArrayList<>();
++    Random random = new Random();
++    for (int i = 0; i < length; i++) {
++      byte l = ((byte) random.nextInt());
++      a1.add(l);
++      a2.add(l);
++    }
++
++    checkEqual(a1, a2);
++
++    boolean flag = false;
++    for (Byte l : a2) {
++      flag = !flag;
++      if (flag) {
++        a1.remove(l);
++      } else {
++        a1.removeValue(l);
++      }
++    }
++
++    assertTrue(a1.isEmpty());
++    a1.addAll(0, a2);
++    checkEqual(a1, a2);
++  }
++
++  public void performanceChecks(int length) {
++    Random random = new Random();
++    ByteList data = new ByteList();
++    for (int i = 0; i < length; i++) {
++      byte l = ((byte) random.nextInt());
++      data.add(l);
++    }
++
++    long begin1 = System.currentTimeMillis();
++    ByteList a1 = new ByteList();
++
++    for (int i = 0; i < length; i++) {
++      a1.add(data.get(i));
++    }
++    //a1.sort(null);
++    Object a1c = ByteList.copy(a1);
++    for (int i = 0; i < length; i++) {
++      a1.removeValue(data.get(i));
++    }
++    long score1 = (System.currentTimeMillis() - begin1);
++    System.out.println("ByteList time : " + score1);
++
++    long begin2 = System.currentTimeMillis();
++    ArrayList<Byte> a2 = new ArrayList<>();
++    for (int i = 0; i < length; i++) {
++      a2.add(data.get(i));
++    }
++    //a2.sort(null);
++    Object a2c = a2.clone();
++    for (int i = 0; i < length; i++) {
++      a2.remove((Byte) data.get(i));
++    }
++    long score2 = (System.currentTimeMillis() - begin2);
++    System.out.println("ArrayList<Byte> time : " + score2);
++    assertTrue(score2 > score1);
++    assertEquals(a1c, a2c);
++  }
++
++  @Test
++  public void testMicroCapacity() {
++    for (int i = 0; i < 1000; i++) {
++      check(100);
++    }
++  }
++
++  @Test
++  public void testSmallCapacity() {
++    for (int i = 0; i < 20; i++) {
++      check(10000);
++    }
++  }
++
++  @Test
++  public void testMediumCapacity() {
++    for (int i = 0; i < 5; i++) {
++      check(100000);
++    }
++  }
++
++  @Test
++  public void testLargeCapacity() {
++    for (int i = 0; i < 1; i++) {
++      check(1000000);
++    }
++  }
++
++  @Test
++  public void testPerformanceIsBetterThanJDKListImplementation() {
++    performanceChecks(100000);
++  }
++
++  @Test
++  public void subSequenceTest() {
++    byte[] init = {'t', 'h', 'i', 's', ' ', 'i', 's', ' ', 'a', ' ', 't', 'e', 's', 't'};
++    ByteList ascii = new ByteList(init);
++    final int start = 2;
++    final int end = init.length;
++    CharSequence sub1 = ascii.subSequence(start, end);
++    CharSequence sub2 = ascii.subSequence(start, end);
++    assertEquals(sub1, sub2);
++    for (int i = start; i < end; ++i) {
++      assertEquals(init[i], sub1.charAt(i - start));
++    }
++  }
++
++  /**
++   * Tests {@link ByteList#insert(int, int)}.
++   */
++  protected void testInsert(final ByteList array) {
++    final int size = array.size();
++    final Object e0 = array.get(0);
++    final Object e2 = array.get(2);
++    final Object e3 = array.get(3);
++    final Object eN = array.get(size - 1);
++
++    array.insert(size, 3);
++    assertEquals(size + 3, array.size());
++    assertEquals(e0, array.get(0));
++    assertEquals(eN, array.get(size - 1));
++
++    array.insert(3, 7);
++    assertEquals(size + 10, array.size());
++    assertEquals(e0, array.get(0));
++    assertEquals(e3, array.get(10));
++    assertEquals(eN, array.get(size + 6));
++
++    array.insert(0, 5);
++    assertEquals(size + 15, array.size());
++    assertEquals(e0, array.get(5));
++    assertEquals(e2, array.get(7));
++    assertEquals(e3, array.get(15));
++    assertEquals(eN, array.get(size + 11));
++  }
++
++  /**
++   * Tests {@link ByteList#delete(int, int)}.
++   */
++  protected void testDelete(final ByteList array) {
++    final byte[] a = array.toArray();
++
++    array.delete(a.length - 2, 2);
++    assertEquals(a.length - 2, array.size());
++    for (int i = 0; i < a.length - 2; i++) {
++      assertEquals("@" + i, a[i], array.get(i));
++    }
++
++    array.delete(0, 2);
++    assertEquals(a.length - 4, array.size());
++    for (int i = 0; i < a.length - 4; i++) {
++      assertEquals("@" + i, a[i + 2], array.get(i));
++    }
++  }
++
++  /**
++   * Tests {@link ByteList#ByteList()}.
++   */
++  @Test
++  public void testConstructorNoArgs() {
++    final ByteList array = new ByteList();
++    assertEquals(0, array.size());
++    assertEquals(0, array.copy().length);
++  }
++
++  /**
++   * Tests {@link ByteList#ByteList(int)}.
++   */
++  @Test
++  public void testConstructorWithCapacity() {
++    final ByteList array = new ByteList(10);
++    assertEquals(0, array.size()); // capacity != size
++    assertEquals(array.size(), array.length());
++    assertEquals(10, array.capacity()); // but the underlying array length *should* have capacity of 10
++  }
++
++  /**
++   * Tests {@link ByteList#ByteList(byte[])}.
++   */
++  @Test
++  public void testConstructorArray() {
++    final byte[] raw = {3, 5, 8, 13, 21};
++    final ByteList array = new ByteList(raw);
++    assertSame(raw, array.getArrayUnsafe());
++    assertEquals(raw.length, array.size());
++    for (int i = 0; i < raw.length; i++) {
++      assertEquals("@" + i, raw[i], array.getValue(i));
++    }
++    assertArrayEquals(raw, array.toArray());
++  }
++
++  /**
++   * Tests {@link ByteList#addValue(byte)}.
++   */
++  @Test
++  public void testAddValue() {
++    final byte[] raw = {3, 5, 8, 13, 21};
++    final ByteList array = new ByteList(raw.clone());
++    final byte e6 = 1, e7 = 2;
++    array.addValue(e6);
++    array.addValue(e7);
++    assertEquals(raw.length + 2, array.size());
++    for (int i = 0; i < raw.length; i++) {
++      assertEquals("@" + i, raw[i], array.getValue(i));
++    }
++    assertEquals(e6, array.getValue(5));
++    assertEquals(e7, array.getValue(6));
++  }
++
++  /**
++   * Tests {@link ByteList#removeValue(byte)}.
++   */
++  @Test
++  public void testRemoveValue() {
++    final byte[] raw = {3, 5, 8, 13, 21};
++    final ByteList array = new ByteList(raw.clone());
++    assertEquals(raw.length, array.size());
++    array.removeValue(raw[0]);
++    assertEquals(raw.length - 1, array.size());
++    array.removeValue(raw[2]);
++    assertEquals(raw.length - 2, array.size());
++    array.removeValue(raw[4]);
++    assertEquals(raw.length - 3, array.size());
++    assertEquals(raw[1], array.getValue(0));
++    assertEquals(raw[3], array.getValue(1));
++  }
++
++  /**
++   * Tests {@link ByteList#getValue(int)}.
++   */
++  @Test
++  public void testGetValue() {
++    final byte[] raw = {3, 5, 8, 13, 21};
++    final ByteList array = new ByteList(raw.clone());
++    for (int i = 0; i < raw.length; i++) {
++      assertEquals("@" + i, raw[i], array.getValue(i));
++    }
++  }
++
++  /**
++   * Tests {@link ByteList#setValue(int, byte)}.
++   */
++  @Test
++  public void testSetValue() {
++    final byte[] raw = {3, 5, 8, 13, 21};
++    final ByteList array = new ByteList(raw.clone());
++    final byte e0 = 7, e2 = 1, e4 = 2;
++    array.setValue(0, e0);
++    array.setValue(2, e2);
++    array.setValue(4, e4);
++    assertEquals(raw.length, array.size());
++    assertEquals(e0, array.getValue(0));
++    assertEquals(raw[1], array.getValue(1));
++    assertEquals(e2, array.getValue(2));
++    assertEquals(raw[3], array.getValue(3));
++    assertEquals(e4, array.getValue(4));
++  }
++
++  /**
++   * Tests {@link ByteList#addValue(int, byte)}.
++   */
++  @Test
++  public void testAddValueIndex() {
++    final byte[] raw = {3, 5, 8, 13, 21};
++    final ByteList array = new ByteList(raw.clone());
++    final byte e0 = 7, e4 = 1, e7 = 2;
++    array.addValue(0, e0);
++    array.addValue(4, e4);
++    array.addValue(7, e7);
++    assertEquals(raw.length + 3, array.size());
++    assertEquals(e0, array.getValue(0));
++    assertEquals(raw[0], array.getValue(1));
++    assertEquals(raw[1], array.getValue(2));
++    assertEquals(raw[2], array.getValue(3));
++    assertEquals(e4, array.getValue(4));
++    assertEquals(raw[3], array.getValue(5));
++    assertEquals(raw[4], array.getValue(6));
++    assertEquals(e7, array.getValue(7));
++  }
++
++  /**
++   * Tests {@link ByteList#removeAt(int)}.
++   */
++  @Test
++  public void testRemoveIndex() {
++    final byte[] raw = {3, 5, 8, 13, 21};
++    final ByteList array = new ByteList(raw.clone());
++    assertEquals(raw.length, array.size());
++    byte r = array.removeAt(0);
++    assertEquals(3, r);
++    assertEquals(raw.length - 1, array.size());
++    // {5, 8, 13, 21};
++    r = array.removeAt(2);
++    assertEquals(13, r);
++    assertEquals(raw.length - 2, array.size());
++    // {5, 8, 21};
++    assertEquals(raw[1], array.getValue(0));
++    assertEquals(raw[2], array.getValue(1));
++  }
++
++  /**
++   * Tests {@link ByteList#indexOf(byte)}.
++   */
++  @Test
++  public void testIndexOf() {
++    final byte[] raw = {3, 5, 8, 13, 21};
++    final ByteList array = new ByteList(raw.clone());
++    for (int i = 0; i < raw.length; i++) {
++      assertEquals("@" + i, i, array.indexOf(raw[i]));
++    }
++    assertEquals(-1, array.indexOf((byte) -1));
++    assertEquals(-1, array.indexOf((byte) 0));
++    assertEquals(-1, array.indexOf((byte) 1));
++    assertEquals(-1, array.indexOf(Byte.MAX_VALUE));
++    assertEquals(-1, array.indexOf(Byte.MIN_VALUE));
++  }
++
++  /**
++   * Tests {@link ByteList#lastIndexOf(byte)}.
++   */
++  @Test
++  public void testLastIndexOf() {
++    final byte[] raw = {3, 5, 8, 13, 21};
++    final ByteList array = new ByteList(raw.clone());
++    for (int i = 0; i < raw.length; i++) {
++      assertEquals("@" + i, i, array.lastIndexOf(raw[i]));
++    }
++    assertEquals(-1, array.lastIndexOf((byte) -1));
++    assertEquals(-1, array.lastIndexOf((byte) 0));
++    assertEquals(-1, array.lastIndexOf((byte) 1));
++    assertEquals(-1, array.lastIndexOf(Byte.MAX_VALUE));
++    assertEquals(-1, array.lastIndexOf(Byte.MIN_VALUE));
++  }
++
++  /**
++   * Tests {@link ByteList#contains(byte)}.
++   */
++  @Test
++  public void testContains() {
++    final byte[] raw = {3, 5, 8, 13, 21};
++    final ByteList array = new ByteList(raw.clone());
++    for (int i = 0; i < raw.length; i++) {
++      assertTrue("@" + i, array.contains(raw[i]));
++    }
++    assertFalse(array.contains(-1));
++    assertFalse(array.contains(0));
++    assertFalse(array.contains(1));
++    assertFalse(array.contains(Byte.MAX_VALUE));
++    assertFalse(array.contains(Byte.MIN_VALUE));
++  }
++
++  /**
++   * Tests: - {@link ByteList#toArray()} - {@link ByteList#setArrayUnsafe(byte[])}. - {@link
++   * ByteList#getArrayUnsafe()}.
++   */
++  @Test
++  public void testSetArray() {
++    final ByteList array = new ByteList();
++    final byte[] raw = {1, 2, 3, 5, 8, 13, 21};
++    array.setArrayUnsafe(raw);
++    assertSame(raw, array.getArrayUnsafe());
++  }
++
++  /**
++   * Tests {@link ByteList#insert(int, int)}.
++   */
++  @Test
++  public void testInsert() {
++    final byte[] raw = {3, 5, 8, 13, 21};
++    testInsert(new ByteList(raw));
++  }
++
++  /**
++   * Tests {@link ByteList#delete(int, int)}.
++   */
++  @Test
++  public void testDelete() {
++    final byte[] raw = {3, 5, 8, 13, 21};
++    testDelete(new ByteList(raw));
++  }
++
++  /**
++   * Tests {@link ByteList#get(int)}.
++   */
++  @Test
++  public void testGet() {
++    final byte[] raw = {3, 5, 8, 13, 21};
++    final ByteList array = new ByteList(raw.clone());
++    for (int i = 0; i < raw.length; i++) {
++      assertEquals("@" + i, raw[i], array.get(i));
++    }
++  }
++
++  /**
++   * Tests {@link ByteList#set(int, Byte)}.
++   */
++  @Test
++  public void testSet() {
++    final byte[] raw = {3, 5, 8, 13, 21};
++    final ByteList array = new ByteList(raw.clone());
++    final Byte e0 = 7, e2 = 1, e4 = 2;
++    array.set(0, e0);
++    array.set(2, e2);
++    array.set(4, e4);
++    assertEquals(raw.length, array.size());
++    assertEquals((byte) e0, array.get(0));
++    assertEquals(raw[1], array.getValue(1));
++    assertEquals((byte) e2, array.get(2));
++    assertEquals(raw[3], array.getValue(3));
++    assertEquals((byte) e4, array.get(4));
++  }
++
++  /**
++   * Tests {@link ByteList#add(int, Byte)}.
++   */
++  @Test
++  public void testAdd() {
++    final byte[] raw = {3, 5, 8, 13, 21};
++    final ByteList array = new ByteList(raw.clone());
++    final Byte e6 = 1, e7 = 2;
++    array.add(e6);
++    array.add(e7);
++    assertEquals(raw.length + 2, array.size());
++    for (int i = 0; i < raw.length; i++) {
++      assertEquals("@" + i, raw[i], array.getValue(i));
++    }
++    assertEquals((byte) e6, array.get(5));
++    assertEquals((byte) e7, array.get(6));
++  }
++
++  /**
++   * Tests {@link ByteList#indexOf(byte)}.
++   */
++  @SuppressWarnings("UnnecessaryBoxing")
++  @Test
++  public void testIndexOfBoxed() {
++    final byte[] raw = {3, 5, 8, 13, 21};
++    final ByteList array = new ByteList(raw.clone());
++    for (int i = 0; i < raw.length; i++) {
++      assertEquals("@" + i, i, array.indexOf(Byte.valueOf(raw[i])));
++    }
++    assertEquals(-1, array.indexOf((byte) -1));
++    assertEquals(-1, array.indexOf(Byte.valueOf((byte) 0)));
++    assertEquals(-1, array.indexOf(Byte.valueOf((byte) 1)));
++    assertEquals(-1, array.indexOf(Byte.valueOf(Byte.MAX_VALUE)));
++    assertEquals(-1, array.indexOf(Byte.valueOf(Byte.MIN_VALUE)));
++  }
++
++  /**
++   * Tests {@link ByteList#lastIndexOf(byte)}}.
++   */
++  @SuppressWarnings("UnnecessaryBoxing")
++  @Test
++  public void testLastIndexOfBoxed() {
++    final byte[] raw = {3, 5, 8, 13, 21};
++    final ByteList array = new ByteList(raw.clone());
++    for (int i = 0; i < raw.length; i++) {
++      assertEquals("@" + i, i, array.lastIndexOf(Byte.valueOf(raw[i])));
++    }
++    assertEquals(-1, array.lastIndexOf(Byte.valueOf((byte) -1)));
++    assertEquals(-1, array.lastIndexOf(Byte.valueOf((byte) 0)));
++    assertEquals(-1, array.lastIndexOf(Byte.valueOf((byte) 1)));
++    assertEquals(-1, array.lastIndexOf(Byte.valueOf(Byte.MAX_VALUE)));
++    assertEquals(-1, array.lastIndexOf(Byte.valueOf(Byte.MIN_VALUE)));
++  }
++
++  /**
++   * Tests {@link ByteList#contains(byte)}.
++   */
++  @Test
++  public void testContainsBoxed() {
++    final byte[] raw = {3, 5, 8, 13, 21};
++    final ByteList array = new ByteList(raw.clone());
++    for (int i = 0; i < raw.length; i++) {
++      assertTrue("@" + i, array.contains(Byte.valueOf(raw[i])));
++    }
++    assertFalse(array.contains(Byte.valueOf((byte) -1)));
++    assertFalse(array.contains(Byte.valueOf((byte) 0)));
++    assertFalse(array.contains(Byte.valueOf((byte) 1)));
++    assertFalse(array.contains(Byte.valueOf(Byte.MAX_VALUE)));
++    assertFalse(array.contains(Byte.valueOf(Byte.MIN_VALUE)));
++  }
++
++  /**
++   * Tests {@link ByteList#removeAt(int)}.
++   */
++  @Test
++  public void testRemove() {
++    final byte[] raw = {3, 5, 8, 13, 21};
++    final ByteList array = new ByteList(raw.clone());
++    assertEquals(raw.length, array.size());
++    array.remove(Byte.valueOf(raw[0]));
++    assertEquals(raw.length - 1, array.size());
++    array.remove(Byte.valueOf(raw[2]));
++    assertEquals(raw.length - 2, array.size());
++    array.remove(Byte.valueOf(raw[4]));
++    assertEquals(raw.length - 3, array.size());
++    assertEquals(raw[1], array.getValue(0));
++    assertEquals(raw[3], array.getValue(1));
++  }
++
++  /**
++   * Tests {@link ByteList#containsAll}.
++   */
++  @Test
++  public void testContainsAll() {
++    final byte[] raw = {3, 5, 8, 13, 21};
++    final ByteList array = new ByteList(raw.clone());
++
++    final ArrayList<Byte> list = new ArrayList<>();
++    assertTrue(array.containsAll(list));
++    list.add((byte) 13);
++    assertTrue(array.containsAll(list));
++    list.add((byte) 1);
++    assertFalse(array.containsAll(list));
++
++    final ByteList yes = new ByteList(new byte[]{3, 8, 21});
++    assertTrue(Iterables.all(yes, array::contains));
++
++    final ByteList no = new ByteList(new byte[]{5, 13, 1});
++    assertFalse(Iterables.all(no, array::contains));
++  }
++
++  /**
++   * Tests {@link ByteList#addAll(int, java.util.Collection)}.
++   */
++  @Test
++  public void testAddAll() {
++    final byte[] raw = {3, 5, 8, 13, 21};
++    final ByteList array = new ByteList(raw.clone());
++    final byte[] add = {1, 7};
++    final ByteList toAdd = new ByteList(add.clone());
++    final int index = 3;
++    array.addAll(index, toAdd);
++    for (int i = 0; i < index; i++) {
++      assertEquals(raw[i], array.getValue(i));
++    }
++    for (int i = index; i < index + add.length; i++) {
++      assertEquals(add[i - index], array.getValue(i));
++    }
++    for (int i = index + add.length; i < raw.length + add.length; i++) {
++      assertEquals(raw[i - add.length], array.getValue(i));
++    }
++  }
++
++  /**
++   * Tests {@link ByteList#removeAll}.
++   */
++  @Test
++  public void testRemoveAll() {
++    final byte[] raw = {3, 5, 8, 13, 21};
++    final ByteList array = new ByteList(raw.clone());
++    final ByteList toRemove = new ByteList(new byte[]{3, 8, 21});
++    assertEquals(raw.length, array.size());
++    array.removeAll(toRemove);
++    assertEquals(raw.length - 3, array.size());
++    assertEquals(raw[1], array.getValue(0));
++    assertEquals(raw[3], array.getValue(1));
++  }
++
++  @Test
++  public void testHex() {
++    final ByteList three_bytes = ByteList.wrap(new byte[] {(byte) 0xb9, 0x01, (byte) 0xef});
++    assertEquals(three_bytes.hex(), "b901ef");
++    assertEquals(three_bytes.hex(ByteList.wrap(b(":")), 0), "b901ef");
++    assertEquals(three_bytes.hex(ByteList.wrap(b("\u0000"))), "b9\u000001\u0000ef");
++    assertEquals(three_bytes.hex(ByteList.wrap(b("\u0000"))), "b9\u000001\u0000ef");
++    assertEquals(three_bytes.hex(ByteList.wrap(b("\u007f"))), "b9\u007f01\u007fef");
++    assertEquals(three_bytes.hex(ByteList.wrap(b("\u007f"))), "b9\u007f01\u007fef");
++    assertEquals(three_bytes.hex(ByteList.wrap(b(":")), 3), "b901ef");
++    assertEquals(three_bytes.hex(ByteList.wrap(b(":")), 4), "b901ef");
++    assertEquals(three_bytes.hex(ByteList.wrap(b(":")), -4), "b901ef");
++    assertEquals(three_bytes.hex(ByteList.wrap(b(":"))),"b9:01:ef");
++    assertEquals(three_bytes.hex(ByteList.wrap(b("$"))),"b9$01$ef");
++    assertEquals(three_bytes.hex(ByteList.wrap(b(":")), 1),"b9:01:ef");
++    assertEquals(three_bytes.hex(ByteList.wrap(b(":")), -1), "b9:01:ef");
++    assertEquals(three_bytes.hex(ByteList.wrap(b(":")), 2), "b9:01ef");
++    assertEquals(three_bytes.hex(ByteList.wrap(b(":")), 1), "b9:01:ef");
++    assertEquals(three_bytes.hex(ByteList.wrap(b("*")), -2), "b901*ef");
++
++    final ByteList value = ByteList.wrap(b("{s\u0005\u0000\u0000\u0000worldi\u0002\u0000\u0000\u0000s\u0005\u0000\u0000\u0000helloi\u0001\u0000\u0000\u00000"));
++    assertEquals(value.hex(ByteList.wrap(b(".")), 8), "7b7305000000776f.726c646902000000.730500000068656c.6c6f690100000030");
++  }
++
++  @Test
++  public void testCount() {
++    final ByteList b = ByteList.copy("mississippi");
++    byte i = 105;
++    byte p = 112;
++    byte w = 119;
++    assertEquals(4, b.count(b("i")));
++    assertEquals(2, b.count(b("ss")));
++    assertEquals(0, b.count(b("w")));
++
++    assertEquals(4, b.count(i));
++    assertEquals(0, b.count(w));
++
++    assertEquals(2, b.count(b("i"), 6));
++    assertEquals(2, b.count(b("p"), 6));
++    assertEquals(1, b.count(b("i"), 1, 3));
++    assertEquals(1, b.count(b("p"), 7, 9));
++
++    assertEquals(2, b.count(i, 6));
++    assertEquals(2, b.count(p, 6));
++    assertEquals(1, b.count(i, 1, 3));
++    assertEquals(1, b.count(p, 7, 9));
++  }
++
++  @Test
++  public void testEndsWith() {
++    ByteList b = ByteList.wrap(b("hello"));
++    assertFalse(ByteList.empty().endsWith(b("anything")));
++    assertTrue(b.endsWith(b("hello")));
++    assertTrue(b.endsWith(b("llo")));
++    assertTrue(b.endsWith(b("o")));
++    assertFalse(b.endsWith(b("whello")));
++    assertFalse(b.endsWith(b("no")));
++  }
++
++  @Test
++  public void testFind() {
++    final ByteList b = ByteList.copy("mississippi");
++    byte i = 105;
++    byte w = 119;
++    assertEquals(2, b.find(b("ss")));
++    assertEquals(-1, b.find(b("w")));
++    assertEquals(-1, b.find(b("mississippian")));
++
++    assertEquals(1, b.find(i));
++    assertEquals(-1, b.find(w));
++
++    assertEquals(5, b.find(b("ss"), 3));
++    assertEquals(2, b.find(b("ss"), 1, 7));
++    assertEquals(-1, b.find(b("ss"), 1, 3));
++
++    assertEquals(7, b.find(i, 6));
++    assertEquals(1, b.find(i, 1, 3));
++    assertEquals(-1, b.find(w, 1, 3));
++  }
++
++  @Test
++  public void testJoin() {
++    assertEquals(ByteList.empty(), ByteList.wrap(b("")).join(new byte[][]{new byte[0]}));
++    assertEquals(ByteList.empty(), ByteList.wrap(b("")).join(new byte[][]{b("")}));
++    final byte[][][] abcs = {
++      new byte[][] {b("abc")},
++      new byte[][] {b("a"), b("bc")},
++      new byte[][] {b("ab"), b("c")},
++      new byte[][] {b("ab"), b("c")},
++      new byte[][] {b("a"), b("b"), b("c")},
++    };
++    final ByteList abc = ByteList.wrap(b("abc"));
++    for (byte[][] bytes : abcs) {
++//      System.out.println(Arrays.deepToString(abcs[i]));
++      assertEquals(ByteList.empty().join(bytes), abc);
++    }
++    final ByteList joiner = ByteList.wrap(b(".:"));
++    //final $Function<ByteList, ByteList> dotJoin2 = ByteList.of(b(".:"))::join;
++    assertEquals(ByteList.wrap(b("ab.:cd")), joiner.join(new byte[][]{b("ab"), b("cd")}));
++    // Stress it with many items
++    ByteList[] seq = new ByteList[100000];
++    for (int i = 0; i < seq.length; i++) {
++      seq[i] = ByteList.wrap(b("abc"));
++    }
++    ByteList expected = ByteList.wrap(b("abc"))
++                          .mergedCopy(ByteList.wrap(b(".:abc")).repeat(99999));
++    assertEquals(expected, joiner.join(seq));
++     //Stress test with empty separator
++    assertEquals(ByteList.wrap(b("abc")).repeat(100000), ByteList.wrap(b("")).join(seq));
++   }
++
++  @SuppressWarnings("HttpUrlsUsage")
++  @Test
++  public void testPartition() {
++    final ByteList b = ByteList.copy("mississippi");
++    assertArrayEquals(
++      new ByteList[]{ByteList.copy("mi"), ByteList.copy("ss"), ByteList.copy("issippi")},
++      b.partition(b("ss"))
++    );
++    assertArrayEquals(
++      new ByteList[]{b, ByteList.empty(), ByteList.empty()},
++      b.partition(b("w"))
++    );
++    final ByteList ex = ByteList.copy("this is the partition method");
++    assertArrayEquals(
++      new ByteList[]{ByteList.copy("this is the par"), ByteList.copy("ti"), ByteList.copy("tion method")},
++      ex.partition(b("ti"))
++    );
++    // from raymond's original specification
++    final ByteList S = ByteList.copy("http://www.python.org");
++
++    assertArrayEquals(
++      new ByteList[]{ByteList.copy("http"), ByteList.copy("://"), ByteList.copy("www.python.org")},
++      S.partition(b("://"))
++    );
++    assertArrayEquals(
++      new ByteList[]{ByteList.copy("http://www.python.org"), ByteList.empty(), ByteList.empty()},
++      S.partition(b("?"))
++    );
++    assertArrayEquals(
++      new ByteList[]{ByteList.empty(), ByteList.copy("http://"), ByteList.copy("www.python.org")},
++      S.partition(b("http://"))
++    );
++    assertArrayEquals(
++      new ByteList[]{ByteList.copy("http://www.python."), ByteList.copy("org"), ByteList.empty()},
++      S.partition(b("org"))
++    );
++  }
++
++  @SuppressWarnings("HttpUrlsUsage")
++  @Test
++  public void testRightPartition() {
++    final ByteList b = ByteList.copy("mississippi");
++    assertArrayEquals(
++      new ByteList[]{ByteList.copy("missi"), ByteList.copy("ss"), ByteList.copy("ippi")},
++      b.rpartition(b("ss"))
++    );
++    assertArrayEquals(
++      new ByteList[]{ByteList.copy("mississipp"), ByteList.copy("i"), ByteList.empty()},
++      b.rpartition(b("i"))
++    );
++    assertArrayEquals(
++      new ByteList[]{ByteList.empty(), ByteList.empty(), b},
++      b.rpartition(b("w"))
++    );
++    final ByteList ex = ByteList.copy("this is the rpartition method");
++    assertArrayEquals(
++      new ByteList[]{ByteList.copy("this is the rparti"), ByteList.copy("ti"), ByteList.copy("on method")},
++      ex.rpartition(b("ti"))
++    );
++    // from raymond's original specification
++    final ByteList S = ByteList.copy("http://www.python.org");
++
++    assertArrayEquals(
++      new ByteList[]{ByteList.copy("http"), ByteList.copy("://"), ByteList.copy("www.python.org")},
++      S.rpartition(b("://"))
++    );
++    assertArrayEquals(
++      new ByteList[]{ByteList.empty(), ByteList.empty(), ByteList.copy("http://www.python.org")},
++      S.rpartition(b("?"))
++    );
++    assertArrayEquals(
++      new ByteList[]{ByteList.empty(), ByteList.copy("http://"), ByteList.copy("www.python.org")},
++      S.rpartition(b("http://"))
++    );
++    assertArrayEquals(
++      new ByteList[]{ByteList.copy("http://www.python."), ByteList.copy("org"), ByteList.empty()},
++      S.rpartition(b("org"))
++    );
++  }
++
++  @Test
++  public void testStartsWith() {
++    final ByteList hello = ByteList.copy("hello");
++    assertFalse(ByteList.empty().startsWith(b("anything")));
++    assertFalse(ByteList.empty().startsWith(ByteList.copy("anything")));
++    assertTrue(hello.startsWith(b("hello")));
++    assertTrue(hello.startsWith(b("hel")));
++    assertTrue(hello.startsWith(b("h")));
++    assertFalse(hello.startsWith(b("hellow")));
++    assertFalse(hello.startsWith(b("ha")));
++    assertTrue(hello.startsWith(ByteList.copy("hello")));
++    assertTrue(hello.startsWith(ByteList.copy("hel")));
++    assertTrue(hello.startsWith(ByteList.copy("h")));
++    assertFalse(hello.startsWith(ByteList.copy("hellow")));
++    assertFalse(hello.startsWith(ByteList.copy("ha")));
++  }
++
++  @Test
++  public void testReplace() {
++    final ByteList hello = ByteList.copy("mississippi");
++    assertEquals(ByteList.copy("massassappa"), hello.replace(b("i"), b("a")));
++    assertEquals(ByteList.copy("mixixippi"), hello.replace(b("ss"), b("x")));
++  }
++
++  @Test
++  public void testSplit() {
++//    for b in (b'a\x1Cb', b'a\x1Db', b'a\x1Eb', b'a\x1Fb'):
++    final byte[][] bytes = {
++      b("a\u001Cb"), b("a\u001Db"), b("a\u001Eb"), b("a\u001Fb")
++    };
++    for(byte[] bz : bytes) {
++//        assertEquals(b.split(), [b])
++      assertArrayEquals(ByteList.wrap(bz).split(), new ByteList[] { ByteList.wrap(bz) });
++    }
++
++    final ByteList b = ByteList.copy("\u0009\n\u000B\u000C\r\u001C\u001D\u001E\u001F");
++    assertArrayEquals(b.split(), new ByteList[] {ByteList.wrap(b("\u001c\u001d\u001e\u001f"))});
++    assertArrayEquals(ByteList.wrap(b("a b")).split(ByteList.wrap(b(" "))), new ByteList[] {ByteList.copy("a"), ByteList.copy("b")});
++    // by 1 byte
++    assertArrayEquals(new ByteList[] { ByteList.wrap(b("a")), ByteList.wrap(b("b")), ByteList.wrap(b("c")), ByteList.wrap(b("d")) }, ByteList.wrap(b("a|b|c|d")).split(ByteList.wrap(b("|"))));
++    assertArrayEquals(new ByteList[] { ByteList.wrap(b("a|b|c|d")) }, ByteList.wrap(b("a|b|c|d")).split(ByteList.wrap(b("|")),0));
++    assertArrayEquals(new ByteList[] { ByteList.wrap(b("a")), ByteList.wrap(b("b|c|d"))}, ByteList.wrap(b("a|b|c|d")).split(ByteList.wrap(b("|")),1));
++    assertArrayEquals(new ByteList[] { ByteList.wrap(b("a")), ByteList.wrap(b("b")), ByteList.wrap(b("c|d"))}, ByteList.wrap(b("a|b|c|d")).split(ByteList.wrap(b("|")),2));
++    assertArrayEquals(new ByteList[] { ByteList.wrap(b("a")), ByteList.wrap(b("b")), ByteList.wrap(b("c")), ByteList.wrap(b("d"))}, ByteList.wrap(b("a|b|c|d")).split(ByteList.wrap(b("|")),3));
++    assertArrayEquals(new ByteList[] { ByteList.wrap(b("a")), ByteList.wrap(b("b")), ByteList.wrap(b("c")), ByteList.wrap(b("d"))}, ByteList.wrap(b("a|b|c|d")).split(ByteList.wrap(b("|")),4));
++    assertArrayEquals(new ByteList[] { ByteList.wrap(b("a")), ByteList.wrap(b("b")), ByteList.wrap(b("c")), ByteList.wrap(b("d"))}, ByteList.wrap(b("a|b|c|d")).split(ByteList.wrap(b("|")), Integer.MAX_VALUE - 2));
++    assertArrayEquals(new ByteList[] { ByteList.wrap(b("a|b|c|d"))}, ByteList.wrap(b("a|b|c|d")).split(ByteList.wrap(b("|")),0));
++    assertArrayEquals(new ByteList[] { ByteList.wrap(b("a")), ByteList.wrap(b("")), ByteList.wrap(b("b||c||d"))}, ByteList.wrap(b("a||b||c||d")).split(ByteList.wrap(b("|")),2));
++    assertArrayEquals(new ByteList[] { ByteList.wrap(b("abcd"))}, ByteList.wrap(b("abcd")).split(ByteList.wrap(b("|"))));
++    assertArrayEquals(new ByteList[] { ByteList.wrap(b(""))}, ByteList.wrap(b("")).split(ByteList.wrap(b("|"))));
++    assertArrayEquals(new ByteList[] { ByteList.wrap(b("endcase ")), ByteList.wrap(b(""))}, ByteList.wrap(b("endcase |")).split(ByteList.wrap(b("|"))));
++    assertArrayEquals(new ByteList[] { ByteList.wrap(b("")), ByteList.wrap(b(" startcase"))}, ByteList.wrap(b("| startcase")).split(ByteList.wrap(b("|"))));
++    assertArrayEquals(new ByteList[] { ByteList.wrap(b("")), ByteList.wrap(b("bothcase")), ByteList.wrap(b(""))}, ByteList.wrap(b("|bothcase|")).split(ByteList.wrap(b("|"))));
++    assertArrayEquals(new ByteList[] { ByteList.wrap(b("a")), ByteList.wrap(b("")), ByteList.wrap(b("b\u0000c\u0000d"))}, ByteList.wrap(b("a\u0000\u0000b\u0000c\u0000d")).split(ByteList.wrap(b("\u0000")),2));
++
++    // by a bytelist
++    assertArrayEquals(new ByteList[] {ByteList.wrap(b("a")), ByteList.wrap(b("b")), ByteList.wrap(b("c")), ByteList.wrap(b("d"))}, ByteList.wrap(b("a//b//c//d")).split(ByteList.wrap(b("//"))));
++
++  }
++
++  @Test
++  public void testRSplit() {
++    final ByteList b = ByteList.wrap(b("\u0009\n\u000B\u000C\r\u001C\u001D\u001E\u001F"));
++    assertArrayEquals(b.split(), new ByteList[] {ByteList.wrap(b("\u001c\u001d\u001e\u001f"))});
++    assertArrayEquals(ByteList.wrap(b("a b")).rsplit(ByteList.wrap(b(" "))), new ByteList[] {ByteList.copy("a"), ByteList.copy("b")});
++    // by 1 byte
++    assertArrayEquals(new ByteList[] { ByteList.wrap(b("a")), ByteList.wrap(b("b")), ByteList.wrap(b("c")), ByteList.wrap(b("d")) }, ByteList.wrap(b("a|b|c|d")).rsplit(ByteList.wrap(b("|"))));
++    assertArrayEquals(new ByteList[] { ByteList.wrap(b("a|b|c")), ByteList.wrap(b("d")) }, ByteList.wrap(b("a|b|c|d")).rsplit(ByteList.wrap(b("|")),1));
++    assertArrayEquals(new ByteList[] { ByteList.wrap(b("a|b")), ByteList.wrap(b("c")), ByteList.wrap(b("d"))}, ByteList.wrap(b("a|b|c|d")).rsplit(ByteList.wrap(b("|")),2));
++    assertArrayEquals(new ByteList[] { ByteList.wrap(b("a")), ByteList.wrap(b("b")), ByteList.wrap(b("c")), ByteList.wrap(b("d"))}, ByteList.wrap(b("a|b|c|d")).rsplit(ByteList.wrap(b("|")),3));
++    assertArrayEquals(new ByteList[] { ByteList.wrap(b("a")), ByteList.wrap(b("b")), ByteList.wrap(b("c")), ByteList.wrap(b("d"))}, ByteList.wrap(b("a|b|c|d")).rsplit(ByteList.wrap(b("|")),4));
++    assertArrayEquals(new ByteList[] { ByteList.wrap(b("a")), ByteList.wrap(b("b")), ByteList.wrap(b("c")), ByteList.wrap(b("d"))}, ByteList.wrap(b("a|b|c|d")).rsplit(ByteList.wrap(b("|")), Integer.MAX_VALUE - 100));
++
++    // by a bytelist
++    assertArrayEquals(new ByteList[] { ByteList.wrap(b("a")), ByteList.wrap(b("b")), ByteList.wrap(b("c")), ByteList.wrap(b("d"))}, ByteList.wrap(b("a//b//c//d")).rsplit(ByteList.wrap(b("//"))));
++  }
++
++  @Test
++  public void testStrip() {
++    assertEquals(ByteList.wrap(b("abc")).strip(ByteList.wrap(b("ac"))), ByteList.wrap(b("b")));
++    // whitespace
++    assertEquals(ByteList.wrap(b("hello")), ByteList.wrap(b("   hello   ")).strip());
++    assertEquals(ByteList.wrap(b("hello")), ByteList.wrap(b("hello")).strip());
++    final ByteList b = ByteList.copy(" \t\n\r\f\u000babc \t\n\r\f\u000b");
++    assertEquals(ByteList.copy("abc"), b.strip());
++
++    // strip with None arg
++    assertEquals(ByteList.wrap(b("hello")), ByteList.wrap(b("   hello   ")).strip(null));
++    assertEquals(ByteList.wrap(b("hello")), ByteList.wrap(b("hello")).strip(null));
++
++    // strip with byte string arg
++    assertEquals(ByteList.wrap(b("hello")), ByteList.wrap(b("xyzzyhelloxyzzy")).strip(ByteList.wrap(b("xyz"))));
++    assertEquals(ByteList.wrap(b("hello")), ByteList.wrap(b("hello")).strip(ByteList.wrap(b("xyz"))));
++    assertEquals(ByteList.wrap(b("")), ByteList.wrap(b("mississippi")).strip(ByteList.wrap(b("mississippi"))));
++
++    // only trim the start and end; does not strip internal characters
++    assertEquals(ByteList.wrap(b("mississipp")), ByteList.wrap(b("mississippi")).strip(ByteList.wrap(b("i"))));
++  }
++
++  @Test
++  public void testLeftStrip() {
++    assertEquals(ByteList.wrap(b("abc")).lstrip(ByteList.wrap(b("ac"))), ByteList.wrap(b("bc")));
++    assertEquals(ByteList.wrap(b("hello   ")), ByteList.wrap(b("   hello   ")).lstrip());
++    final ByteList b = ByteList.copy(" \t\n\r\f\u000babc \t\n\r\f\u000b");
++    assertEquals(ByteList.copy("abc \t\n\r\f\u000b"), b.lstrip());
++    // lstrip with None arg
++    assertEquals(ByteList.wrap(b("hello   ")), ByteList.wrap(b("   hello   ")).lstrip(null));
++    // lstrip with byte string arg
++    assertEquals(ByteList.wrap(b("helloxyzzy")), ByteList.wrap(b("xyzzyhelloxyzzy")).lstrip(ByteList.wrap(b("xyz"))));
++  }
++
++  @Test
++  public void testRightStrip() {
++    assertEquals(ByteList.wrap(b("abc")).rstrip(ByteList.wrap(b("ac"))), ByteList.wrap(b("ab")));
++    assertEquals(ByteList.wrap(b("   hello")), ByteList.wrap(b("   hello   ")).rstrip());
++    final ByteList b = ByteList.copy(" \t\n\r\f\u000babc \t\n\r\f\u000b");
++    assertEquals(ByteList.copy(" \t\n\r\f\u000babc"), b.rstrip());
++    // rstrip with None arg
++    assertEquals(ByteList.wrap(b("   hello")), ByteList.wrap(b("   hello   ")).rstrip(null));
++    // rstrip with byte string arg
++    assertEquals(ByteList.wrap(b("xyzzyhello")), ByteList.wrap(b("xyzzyhelloxyzzy")).rstrip(ByteList.wrap(b("xyz"))));
++  }
++
++  @Test
++  public void testRightFind() {
++    final ByteList b = ByteList.copy("mississippi");
++    byte i = 105;
++    byte w = 119;
++    assertEquals(b.rfind(ByteList.wrap(b("ss"))), 5);
++    assertEquals(b.rfind(ByteList.wrap(b("w"))), -1);
++    assertEquals(b.rfind(ByteList.wrap(b("mississippian"))), -1);
++
++    assertEquals(b.rfind(i), 10);
++    assertEquals(b.rfind(w), -1);
++
++    assertEquals(b.rfind(ByteList.wrap(b("ss")), 3), 5);
++    assertEquals(b.rfind(ByteList.wrap(b("ss")), 0, 6), 2);
++
++    assertEquals(b.rfind(i, 1, 3), 1);
++    assertEquals(b.rfind(i, 3, 9), 7);
++    assertEquals(b.rfind(w, 1, 3), -1);
++
++    assertEquals(9,  ByteList.wrap(b("abcdefghiabc")).rfind(ByteList.wrap(b("abc"))));
++    assertEquals(12, ByteList.wrap(b("abcdefghiabc")).rfind(ByteList.wrap(b(""))));
++    assertEquals(0, ByteList.wrap(b("abcdefghiabc")).rfind(ByteList.wrap(b("abcd"))));
++    assertEquals(-1, ByteList.wrap(b("abcdefghiabc")).rfind(ByteList.wrap(b("abcz"))));
++    assertEquals(0, ByteList.wrap(b("abcdefghiabc")).rfind(ByteList.wrap(b("abc")), 0, -1));
++
++    assertEquals(3, ByteList.wrap(b("abc")).rfind(ByteList.wrap(b("")),0));
++    assertEquals(3, ByteList.wrap(b("abc")).rfind(ByteList.wrap(b("")),3));
++    assertEquals(-1, ByteList.wrap(b("abc")).rfind(ByteList.wrap(b("")),4));
++
++    assertEquals(12, ByteList.wrap(b("rrarrrrrrrrra")).rfind(ByteList.wrap(b("a"))));
++    assertEquals(12, ByteList.wrap(b("rrarrrrrrrrra")).rfind(ByteList.wrap(b("a")),4));
++    assertEquals(-1, ByteList.wrap(b("rrarrrrrrrrra")).rfind(ByteList.wrap(b("a")),4,6));
++    assertEquals(2, ByteList.wrap(b("rrarrrrrrrrra")).rfind(ByteList.wrap(b("a")),0,6));
++  }
++
++  @Test
++  public void testLeftJustify() {
++    assertEquals(ByteList.wrap(b("abc       ")), ByteList.wrap(b("abc")).ljust(10));
++    assertEquals(ByteList.wrap(b("abc   ")), ByteList.wrap(b("abc")).ljust(6));
++    assertEquals(ByteList.wrap(b("abc")), ByteList.wrap(b("abc")).ljust(3));
++    assertEquals(ByteList.wrap(b("abc")), ByteList.wrap(b("abc")).ljust(2));
++    assertEquals(ByteList.wrap(b("abc*******")), ByteList.wrap(b("abc")).ljust(10,ByteList.wrap(b("*"))));
++  }
++
++  @Test
++  public void testRightJustify() {
++    assertEquals(ByteList.wrap(b("       abc")), ByteList.wrap(b("abc")).rjust(10));
++    assertEquals(ByteList.wrap(b("   abc")), ByteList.wrap(b("abc")).rjust(6));
++    assertEquals(ByteList.wrap(b("abc")), ByteList.wrap(b("abc")).rjust(3));
++    assertEquals(ByteList.wrap(b("abc")), ByteList.wrap(b("abc")).rjust(2));
++    assertEquals(ByteList.wrap(b("*******abc")), ByteList.wrap(b("abc")).rjust(10,b("*")));
++    assertEquals(ByteList.wrap(b("*******abc")), ByteList.wrap(b("abc")).rjust(10,ByteList.wrap(b("*"))));
++    final ByteList b = ByteList.copy("abc");
++    assertEquals(b.rjust(7, b("-")), ByteList.copy("----abc"));
++  }
++
++  @Test
++  public void testCenter() {
++    assertEquals(ByteList.wrap(b("   abc    ")), ByteList.wrap(b("abc")).center(10));
++    assertEquals(ByteList.wrap(b(" abc  ")), ByteList.wrap(b("abc")).center(6));
++    assertEquals(ByteList.wrap(b("abc")), ByteList.wrap(b("abc")).center(3));
++    assertEquals(ByteList.wrap(b("abc")), ByteList.wrap(b("abc")).center(2));
++    assertEquals(ByteList.wrap(b("***abc****")), ByteList.wrap(b("abc")).center(10, b("*")));
++    assertEquals(ByteList.wrap(b("***abc****")), ByteList.wrap(b("abc")).center(10, ByteList.wrap(b("*"))));
++    // Fill character can be either bytes or bytearray (issue 12380)
++    final ByteList b = ByteList.copy("abc");
++    assertEquals(b.center(7, b("-")), ByteList.copy("--abc--"));
++  }
++
++  @Test
++  public void testSwapCase() {
++    assertEquals(
++      ByteList.wrap(b("hEllO CoMPuTErS")),
++      ByteList.wrap(b("HeLLo cOmpUteRs")).swapcase());
++  }
++
++  @Test
++  public void testZFill() {
++    assertEquals(ByteList.wrap(b("123")), ByteList.wrap(b("123")).zfill(2));
++    assertEquals(ByteList.wrap(b("123")), ByteList.wrap(b("123")).zfill(3));
++    assertEquals(ByteList.wrap(b("0123")), ByteList.wrap(b("123")).zfill(4));
++    assertEquals(ByteList.wrap(b("+123")), ByteList.wrap(b("+123")).zfill(3));
++    assertEquals(ByteList.wrap(b("+123")), ByteList.wrap(b("+123")).zfill(4));
++    assertEquals(ByteList.wrap(b("+0123")), ByteList.wrap(b("+123")).zfill(5));
++    assertEquals(ByteList.wrap(b("-123")), ByteList.wrap(b("-123")).zfill(3));
++    assertEquals(ByteList.wrap(b("-123")), ByteList.wrap(b("-123")).zfill(4));
++    assertEquals(ByteList.wrap(b("-0123")), ByteList.wrap(b("-123")).zfill(5));
++    assertEquals(ByteList.wrap(b("000")), ByteList.wrap(b("")).zfill(3));
++    assertEquals(ByteList.wrap(b("34")), ByteList.wrap(b("34")).zfill(1));
++    assertEquals(ByteList.wrap(b("0034")), ByteList.wrap(b("34")).zfill(4));
++  }
++
++  @Test
++  public void testIsLower() {
++    assertFalse(ByteList.wrap(b("")).islower());
++    assertTrue(ByteList.wrap(b("a")).islower());
++    assertFalse(ByteList.wrap(b("A")).islower());
++    assertFalse(ByteList.wrap(b("\n")).islower());
++    assertTrue(ByteList.wrap(b("abc")).islower());
++    assertFalse(ByteList.wrap(b("aBc")).islower());
++    assertTrue(ByteList.wrap(b("abc\n")).islower());
++  }
++
++  @Test
++  public void testIsUpper() {
++    assertFalse(ByteList.wrap(b("")).isupper());
++    assertFalse(ByteList.wrap(b("a")).isupper());
++    assertTrue(ByteList.wrap(b("A")).isupper());
++    assertFalse(ByteList.wrap(b("\n")).isupper());
++    assertTrue(ByteList.wrap(b("ABC")).isupper());
++    assertFalse(ByteList.wrap(b("AbC")).isupper());
++    assertTrue(ByteList.wrap(b("ABC\n")).isupper());
++  }
++
++  @Test
++  public void testIsTitle() {
++    assertFalse(ByteList.wrap(b("")).istitle());
++    assertFalse(ByteList.wrap(b("a")).istitle());
++    assertTrue(ByteList.wrap(b("A")).istitle());
++    assertFalse(ByteList.wrap(b("\n")).istitle());
++    assertTrue(ByteList.wrap(b("A Titlecased Line")).istitle());
++    assertTrue(ByteList.wrap(b("A\nTitlecased Line")).istitle());
++    assertTrue(ByteList.wrap(b("A Titlecased, Line")).istitle());
++    assertFalse(ByteList.wrap(b("Not a capitalized String")).istitle());
++    assertFalse(ByteList.wrap(b("Not\ta Titlecase String")).istitle());
++  }
++
++  @Test
++  public void testIsSpace() {
++    assertFalse(ByteList.wrap(b("a")).isspace());
++    assertTrue(ByteList.wrap(b(" ")).isspace());
++    assertTrue(ByteList.wrap(b("\t")).isspace());
++    assertTrue(ByteList.wrap(b("\r")).isspace());
++    assertTrue(ByteList.wrap(b("\n")).isspace());
++    assertTrue(ByteList.wrap(b(" \t\r\n")).isspace());
++    assertFalse(ByteList.wrap(b(" \t\r\na")).isspace());
++  }
++
++  @Test
++  public void testIsAlpha() {
++    assertFalse(ByteList.wrap(b("")).isalpha());
++    assertTrue(ByteList.wrap(b("a")).isalpha());
++    assertTrue(ByteList.wrap(b("A")).isalpha());
++    assertFalse(ByteList.wrap(b("\n")).isalpha());
++    assertTrue(ByteList.wrap(b("abc")).isalpha());
++    assertFalse(ByteList.wrap(b("aBc123")).isalpha());
++    assertFalse(ByteList.wrap(b("abc\n")).isalpha());
++  }
++
++  @Test
++  public void testIsAlphaNumeric() {
++    assertFalse(ByteList.wrap(b("")).isalnum());
++    assertTrue(ByteList.wrap(b("a")).isalnum());
++    assertTrue(ByteList.wrap(b("A")).isalnum());
++    assertFalse(ByteList.wrap(b("\n")).isalnum());
++    assertTrue(ByteList.wrap(b("123abc456")).isalnum());
++    assertTrue(ByteList.wrap(b("a1b3c")).isalnum());
++    assertFalse(ByteList.wrap(b("aBc000 ")).isalnum());
++    assertFalse(ByteList.wrap(b("abc\n")).isalnum());
++  }
++
++  @Test
++  public void testIsAscii() {
++    assertTrue(ByteList.wrap(b("")).isascii());
++    assertTrue(ByteList.wrap(b(" ")).isascii());
++    assertTrue(ByteList.wrap(b("")).isascii());
++    assertTrue(ByteList.wrap(b(" ")).isascii());
++    assertFalse(ByteList.wrap(b("")).isascii());
++    assertFalse(ByteList.wrap(b("é")).isascii());
++  }
++
++  @Test
++  public void testIsDigit() {
++    assertFalse(ByteList.wrap(b("")).isdigit());
++    assertFalse(ByteList.wrap(b("a")).isdigit());
++    assertTrue(ByteList.wrap(b("0")).isdigit());
++    assertTrue(ByteList.wrap(b("0123456789")).isdigit());
++    assertFalse(ByteList.wrap(b("0123456789a")).isdigit());
++  }
++
++  @Test
++  public void testTitle() {
++    assertEquals(ByteList.wrap(b(" Hello ")), ByteList.wrap(b(" hello ")).title());
++    assertEquals(ByteList.wrap(b("Hello ")), ByteList.wrap(b("hello ")).title());
++    assertEquals(ByteList.wrap(b("Hello ")), ByteList.wrap(b("Hello ")).title());
++    assertEquals(ByteList.wrap(b("Format This As Title String")), ByteList.wrap(b("fOrMaT thIs aS titLe String")).title());
++    assertEquals(ByteList.wrap(b("Format,This-As*Title;String")), ByteList.wrap(b("fOrMaT,thIs-aS*titLe;String")).title());
++    assertEquals(ByteList.wrap(b("Getint")), ByteList.wrap(b("getInt")).title());
++  }
++
++  @Test
++  public void testLower() {
++    assertEquals(ByteList.wrap(b("hello")), ByteList.wrap(b("HeLLo")).lower());
++    assertEquals(ByteList.wrap(b("hello")), ByteList.wrap(b("hello")).lower());
++  }
++
++  @Test
++  public void testUpper() {
++    assertEquals(ByteList.wrap(b("HELLO")), ByteList.wrap(b("HeLLo")).upper());
++    assertEquals(ByteList.wrap(b("HELLO")), ByteList.wrap(b("HELLO")).upper());
++  }
++
++  @Test
++  public void testCapitalize() {
++    assertEquals(ByteList.wrap(b(" hello ")), ByteList.wrap(b(" hello ")).capitalize());
++    assertEquals(ByteList.wrap(b("Hello ")), ByteList.wrap(b("Hello ")).capitalize());
++    assertEquals(ByteList.wrap(b("Hello ")), ByteList.wrap(b("hello ")).capitalize());
++    assertEquals(ByteList.wrap(b("Aaaa")), ByteList.wrap(b("aaaa")).capitalize());
++    assertEquals(ByteList.wrap(b("Aaaa")), ByteList.wrap(b("AaAa")).capitalize());
++  }
++
++  @Test
++  public void testRemovePrefix() {
++    assertEquals(ByteList.wrap(b("am")), ByteList.wrap(b("spam")).removeprefix(ByteList.wrap(b("sp"))));
++    assertEquals(ByteList.wrap(b("spamspam")), ByteList.wrap(b("spamspamspam")).removeprefix(ByteList.wrap(b("spam"))));
++    assertEquals(ByteList.wrap(b("spam")), ByteList.wrap(b("spam")).removeprefix(ByteList.wrap(b("python"))));
++    assertEquals(ByteList.wrap(b("spam")), ByteList.wrap(b("spam")).removeprefix(ByteList.wrap(b("spider"))));
++    assertEquals(ByteList.wrap(b("spam")), ByteList.wrap(b("spam")).removeprefix(ByteList.wrap(b("spam and eggs"))));
++    assertEquals(ByteList.wrap(b("")), ByteList.wrap(b("")).removeprefix(ByteList.wrap(b(""))));
++    assertEquals(ByteList.wrap(b("")), ByteList.wrap(b("")).removeprefix(ByteList.wrap(b("abcde"))));
++    assertEquals(ByteList.wrap(b("abcde")), ByteList.wrap(b("abcde")).removeprefix(ByteList.wrap(b(""))));
++    assertEquals(ByteList.wrap(b("")), ByteList.wrap(b("abcde")).removeprefix(ByteList.wrap(b("abcde"))));
++
++  }
++
++  @Test
++  public void testRemoveSuffix() {
++    assertEquals(ByteList.wrap(b("sp")), ByteList.wrap(b("spam")).removesuffix(ByteList.wrap(b("am"))));
++    assertEquals(ByteList.wrap(b("spamspam")), ByteList.wrap(b("spamspamspam")).removesuffix(ByteList.wrap(b("spam"))));
++    assertEquals(ByteList.wrap(b("spam")), ByteList.wrap(b("spam")).removesuffix(ByteList.wrap(b("python"))));
++    assertEquals(ByteList.wrap(b("spam")), ByteList.wrap(b("spam")).removesuffix(ByteList.wrap(b("blam"))));
++    assertEquals(ByteList.wrap(b("spam")), ByteList.wrap(b("spam")).removesuffix(ByteList.wrap(b("eggs and spam"))));
++
++    assertEquals(ByteList.wrap(b("")), ByteList.wrap(b("")).removesuffix(ByteList.wrap(b(""))));
++    assertEquals(ByteList.wrap(b("")), ByteList.wrap(b("")).removesuffix(ByteList.wrap(b("abcde"))));
++    assertEquals(ByteList.wrap(b("abcde")), ByteList.wrap(b("abcde")).removesuffix(ByteList.wrap(b(""))));
++    assertEquals(ByteList.wrap(b("")), ByteList.wrap(b("abcde")).removesuffix(ByteList.wrap(b("abcde"))));
++  }
++
++  @Test
++  public void testSplitLines() {
++    assertArrayEquals(new ByteList[] {ByteList.wrap(b("abc")), ByteList.wrap(b("def")), ByteList.wrap(b("")), ByteList.wrap(b("ghi"))}, ByteList.wrap(b("abc\ndef\n\rghi")).splitlines());
++    assertArrayEquals(new ByteList[] {ByteList.wrap(b("abc")), ByteList.wrap(b("def")), ByteList.wrap(b("")), ByteList.wrap(b("ghi"))}, ByteList.wrap(b("abc\ndef\n\r\nghi")).splitlines());
++    assertArrayEquals(new ByteList[] {ByteList.wrap(b("abc")), ByteList.wrap(b("def")), ByteList.wrap(b("ghi"))}, ByteList.wrap(b("abc\ndef\r\nghi")).splitlines());
++    assertArrayEquals(new ByteList[] {ByteList.wrap(b("abc")), ByteList.wrap(b("def")), ByteList.wrap(b("ghi"))}, ByteList.wrap(b("abc\ndef\r\nghi\n")).splitlines());
++    assertArrayEquals(new ByteList[] {ByteList.wrap(b("abc")), ByteList.wrap(b("def")), ByteList.wrap(b("ghi")), ByteList.wrap(b(""))}, ByteList.wrap(b("abc\ndef\r\nghi\n\r")).splitlines());
++    assertArrayEquals(new ByteList[] {ByteList.wrap(b("")), ByteList.wrap(b("abc")), ByteList.wrap(b("def")), ByteList.wrap(b("ghi")), ByteList.wrap(b(""))}, ByteList.wrap(b("\nabc\ndef\r\nghi\n\r")).splitlines());
++    assertArrayEquals(new ByteList[] {ByteList.wrap(b("")), ByteList.wrap(b("abc")), ByteList.wrap(b("def")), ByteList.wrap(b("ghi")), ByteList.wrap(b(""))}, ByteList.wrap(b("\nabc\ndef\r\nghi\n\r")).splitlines(false));
++    assertArrayEquals(new ByteList[] {ByteList.wrap(b("\n")), ByteList.wrap(b("abc\n")), ByteList.wrap(b("def\r\n")), ByteList.wrap(b("ghi\n")), ByteList.wrap(b("\r"))},
++                  ByteList.wrap(b("\nabc\ndef\r\nghi\n\r")).splitlines(true));
++    assertArrayEquals(new ByteList[] {ByteList.wrap(b("")), ByteList.wrap(b("abc")), ByteList.wrap(b("def")), ByteList.wrap(b("ghi")), ByteList.wrap(b(""))}, ByteList.wrap(b("\nabc\ndef\r\nghi\n\r")).splitlines(false));
++    assertArrayEquals(new ByteList[] {ByteList.wrap(b("\n")), ByteList.wrap(b("abc\n")), ByteList.wrap(b("def\r\n")), ByteList.wrap(b("ghi\n")), ByteList.wrap(b("\r"))},
++                  ByteList.wrap(b("\nabc\ndef\r\nghi\n\r")).splitlines(true));
++  }
++
++  @Test
++  public void testTranslate() {
++    final ByteList b = ByteList.copy("hello");
++    final byte[] rosetta = new byte[256];
++    for (int i = 0; i < rosetta.length; i++) {
++      rosetta[i] = (byte) i;
++      if(i == 'o') {
++        rosetta[i] = (byte) 'e';
++      }
++    }
++
++    ByteList c = b.translate(rosetta);
++    ByteList d = b.translate(rosetta, b(""));
++    ByteList dd = b.translate(rosetta, ByteList.wrap(b("")));
++    assertEquals(c, d);
++    assertEquals(c, dd);
++    assertEquals(c, ByteList.wrap(b("helle")));
++
++    c = b.translate(rosetta, b("hello"));
++    assertEquals(b, ByteList.wrap(b("hello")));
++    assertEquals(c, ByteList.wrap(b("")));
++
++    c = b.translate(rosetta, b("l"));
++    assertEquals(c, ByteList.wrap(b("hee")));
++    c = b.translate(null, b("e"));
++    assertEquals(c, ByteList.wrap(b("hllo")));
++
++    c = b.translate(rosetta, b(""));
++    assertEquals(c, ByteList.wrap(b("helle")));
++    c = b.translate(rosetta, b("l"));
++    assertEquals(c, ByteList.wrap(b("hee")));
++    c = b.translate(null, b("e"));
++    assertEquals(c, ByteList.wrap(b("hllo")));
++  }
++
++  @Test
++  public void testExpandTabs() {
++    assertEquals(ByteList.wrap(b("abc\rab      def\ng       hi")), ByteList.wrap(b("abc\rab\tdef\ng\thi")).expandtabs());
++    assertEquals(ByteList.wrap(b("abc\rab      def\ng       hi")), ByteList.wrap(b("abc\rab\tdef\ng\thi")).expandtabs(8));
++    assertEquals(ByteList.wrap(b("abc\rab  def\ng   hi")), ByteList.wrap(b("abc\rab\tdef\ng\thi")).expandtabs(4));
++    assertEquals(ByteList.wrap(b("abc\r\nab      def\ng       hi")), ByteList.wrap(b("abc\r\nab\tdef\ng\thi")).expandtabs());
++    assertEquals(ByteList.wrap(b("abc\r\nab      def\ng       hi")), ByteList.wrap(b("abc\r\nab\tdef\ng\thi")).expandtabs(8));
++    assertEquals(ByteList.wrap(b("abc\r\nab  def\ng   hi")), ByteList.wrap(b("abc\r\nab\tdef\ng\thi")).expandtabs(4));
++    assertEquals(ByteList.wrap(b("abc\r\nab\r\ndef\ng\r\nhi")), ByteList.wrap(b("abc\r\nab\r\ndef\ng\r\nhi")).expandtabs(4));
++    assertEquals(ByteList.wrap(b("abc\rab      def\ng       hi")), ByteList.wrap(b("abc\rab\tdef\ng\thi")).expandtabs(8));
++    assertEquals(ByteList.wrap(b("abc\rab  def\ng   hi")), ByteList.wrap(b("abc\rab\tdef\ng\thi")).expandtabs(4));
++    assertEquals(ByteList.wrap(b("  a\n b")), ByteList.wrap(b(" \ta\n\tb")).expandtabs(1));
++  }
++}
+\ No newline at end of file
+diff --git b/libstarlark/src/test/java/net/starlark/java/syntax/LexerTest.java a/libstarlark/src/test/java/net/starlark/java/syntax/LexerTest.java
+index 1f79dea7..91344816 100644
+--- b/libstarlark/src/test/java/net/starlark/java/syntax/LexerTest.java
++++ a/libstarlark/src/test/java/net/starlark/java/syntax/LexerTest.java
+@@ -365,12 +365,38 @@ public class LexerTest {
+         "STRING(\\$$) NEWLINE EOF",
+         "  ^ invalid escape sequence: \\$. Use '\\\\' to insert '\\'.");
+     check("'a\\\nb'", "STRING(ab) NEWLINE EOF"); // escape end of line
+-    checkErrors(
+-        "\"ab\\ucd\"", //
+-        "STRING(ab\\ucd) NEWLINE EOF",
+-        "    ^ invalid escape sequence: \\u. Use '\\\\' to insert '\\'.");
++    checkErrors("\"ab\\ucd\"",
++      "STRING(abcd) NEWLINE EOF",
++      "    ^ truncated escape sequence \\ucd");
++
++    // hex escapes
++    check("'\\x00\\x20\\x09\\x41\\x7e\\x7f'", "STRING(\u0000 \tA~\u007F) NEWLINE EOF"); // DEL is non-printable
++    checkErrors("'\\x80'", "STRING(80) NEWLINE EOF", "  ^ non-ASCII hex escape \\x80 (use \\u0080 for the UTF-8 encoding of U+0080)");
++    checkErrors("'\\xff'", "STRING(ff) NEWLINE EOF", "  ^ non-ASCII hex escape \\xff (use \\u00FF for the UTF-8 encoding of U+00FF)");
++    checkErrors("'\\xFf'", "STRING(Ff) NEWLINE EOF", "  ^ non-ASCII hex escape \\xFf (use \\u00FF for the UTF-8 encoding of U+00FF)");
++    checkErrors("'\\xF'", "STRING(F) NEWLINE EOF", "  ^ truncated escape sequence \\xF");
++    checkErrors("'\\x'", "STRING() NEWLINE EOF", "  ^ truncated escape sequence \\x");
++    checkErrors("'\\xfg'", "STRING(fg) NEWLINE EOF", "  ^ invalid escape sequence \\xfg");
++    // Unicode escapes
++    // \\uXXXX
++    check("'\\u0400'", "STRING(Ѐ) NEWLINE EOF");
++    checkErrors("'\\u100'", "STRING(100) NEWLINE EOF", "  ^ truncated escape sequence \\u100");
++    check("'\\u04000'", "STRING(Ѐ0) NEWLINE EOF"); // = U+0400 + '0'
++    checkErrors("'\\u100g'", "STRING(100g) NEWLINE EOF", "  ^ invalid escape sequence \\u100g");
++    check("'\\u4E16'", "STRING(世) NEWLINE EOF");
++    checkErrors("'\\udc00'", "STRING(dc00) NEWLINE EOF", "  ^ invalid Unicode code point U+DC00"); // surrogate
++    // \\UXXXXXXXX
++    check("'\\U00000400'", "STRING(Ѐ) NEWLINE EOF");
++    checkErrors("'\\U0000400'", "STRING(0000400) NEWLINE EOF", "  ^ truncated escape sequence \\U0000400");
++    check("'\\U000004000'", "STRING(Ѐ0) NEWLINE EOF"); // = U+0400 + '0'
++    checkErrors("'\\U1000000g'", "STRING(1000000g) NEWLINE EOF", "  ^ invalid escape sequence \\U1000000g");
++    check("'\\U0010FFFF'", "STRING(\uDBFF\uDFFF) NEWLINE EOF");
++    checkErrors("'\\U00110000'", "STRING(00110000) NEWLINE EOF", "  ^ code point out of range: \\U00110000 (max \\U00110000)");
++    check("'\\U0001F63F'", "STRING(\uD83D\uDE3F) NEWLINE EOF");
++    checkErrors("'\\U0000dc00'", "STRING(0000dc00) NEWLINE EOF", "  ^ invalid Unicode code point U+DC00"); // surrogate
+   }
+ 
++
+   @Test
+   public void testEscapedCrlfInString() throws Exception {
+     check("'a\\\r\nb'", "STRING(ab) NEWLINE EOF");
+@@ -398,6 +424,16 @@ public class LexerTest {
+         "  ^ unclosed string literal");
+   }
+ 
++  @Test
++  public void testBytePrefix() throws Exception {
++    check("b'abcd'", "BYTE(abcd) NEWLINE EOF");
++    check("b\'AЀ世\uD83D\uDE3F\'", "BYTE(AЀ世\uD83D\uDE3F) NEWLINE EOF");
++    check("b\'\\x41\\u0400\\u4e16\\U0001F63F\'", "BYTE(AЀ世\uD83D\uDE3F) NEWLINE EOF");
++    check("b\'\\377\\378\\x80\\xff\\xFf\'", "BYTE(ÿ\u001F8\u0080ÿÿ) NEWLINE EOF");
++    checkErrors("b\'\\400\'", "BYTE() NEWLINE EOF", "     ^ octal escape sequence out of range (maximum is \\377)");
++    checkErrors("b\'\\udc00\'", "BYTE(dc00) NEWLINE EOF", "   ^ invalid Unicode code point U+DC00");
++  }
++
+   @Test
+   public void testTripleRawString() throws Exception {
+     // r'''a\ncd'''
+@@ -415,20 +451,32 @@ public class LexerTest {
+ 
+   @Test
+   public void testOctalEscapes() throws Exception {
+-    // Regression test for a bug.
+-    check(
+-        "'\\0 \\1 \\11 \\77 \\111 \\1111 \\377'",
+-        "STRING(\0 \1 \t \u003f I I1 \u00ff) NEWLINE EOF");
+     // Test boundaries (non-octal char, EOF).
+     check("'\\1b \\1'", "STRING(\1b \1) NEWLINE EOF");
++    check("'\\037'", "STRING(\u001F) NEWLINE EOF");
++    check("'\\378'", "STRING(\u001F8) NEWLINE EOF");  // = '\37' + '8'
+   }
+ 
+   @Test
+   public void testOctalEscapeOutOfRange() throws Exception {
++    // Regression test for a bug.
++    checkErrors(
++        "'\\0 \\1 \\11 \\77 \\111 \\1111 \\377'",
++        "STRING(\0 \1 \t \u003f I I1 ) NEWLINE EOF",
++      "                             ^ non-ASCII octal " +
++        "escape \\377 (use \\u00FF for the UTF-8 encoding of U+00FF)");
+     checkErrors(
+         "'\\777'",
+-        "STRING(\u00ff) NEWLINE EOF",
+-        "    ^ octal escape sequence out of range (maximum is \\377)");
++        "STRING() NEWLINE EOF",
++        "    ^ non-ASCII octal escape \\777 (use \\u01FF for the UTF-8 encoding of U+01FF)");
++    checkErrors(
++      "'\\377'",
++      "STRING() NEWLINE EOF",
++      "    ^ non-ASCII octal escape \\377 (use \\u00FF for the UTF-8 encoding of U+00FF)");
++    checkErrors(
++      "'\\400'",
++      "STRING() NEWLINE EOF",
++      "    ^ non-ASCII octal escape \\400 (use \\u0100 for the UTF-8 encoding of U+0100)");
+   }
+ 
+   @Test

--- a/larky/pom.xml
+++ b/larky/pom.xml
@@ -23,34 +23,38 @@
     </repositories>
 
     <properties>
+        <maven.compiler.plugin.version>3.10.1</maven.compiler.plugin.version>
+        <maven.source.plugin.version>3.2.1</maven.source.plugin.version>
+
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.source.plugin.version>3.2.1</maven.source.plugin.version>
-        <maven.compiler.plugin.version>3.6.2</maven.compiler.plugin.version>
-        <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
+
         <libstarlark.version>1.0-SNAPSHOT</libstarlark.version>
-        <org.projectlombok.version>1.18.22</org.projectlombok.version>
+
         <apache.commons-text.version>1.9</apache.commons-text.version>
-        <google.re2j.version>1.6</google.re2j.version>
-        <google.flogger.version>0.7.2</google.flogger.version>
-        <org.bouncycastle.version>1.70</org.bouncycastle.version>
-        <org.junit.version>4.13.2</org.junit.version>
-        <google.errorprone.version>2.9.0</google.errorprone.version>
         <google.crypto.tink>1.6.1</google.crypto.tink>
+        <google.errorprone.version>2.9.0</google.errorprone.version>
+        <google.flogger.version>0.7.4</google.flogger.version>
         <google.guava.version>31.0.1-jre</google.guava.version>
         <google.jimfs.version>1.2</google.jimfs.version>
+        <google.re2j.version>1.6</google.re2j.version>
         <google.truth.version>1.1.3</google.truth.version>
         <javax.xml.bind.jaxb-api.version>2.3.1</javax.xml.bind.jaxb-api.version>
+        <org.bouncycastle.version>1.70</org.bouncycastle.version>
         <org.conscrypt.version>2.5.2</org.conscrypt.version>
         <org.jetbrains.annotations.version>22.0.0</org.jetbrains.annotations.version>
+        <org.junit.version>4.13.2</org.junit.version>
         <org.mockito.version>3.12.4</org.mockito.version>
+        <org.projectlombok.version>1.18.22</org.projectlombok.version>
         <org.slf4j.version>1.7.32</org.slf4j.version>
         <os-maven-plugin.version>1.7.0</os-maven-plugin.version>
         <protobuf-maven-plugin>0.6.1</protobuf-maven-plugin>
         <protobuf.version>3.18.1</protobuf.version>
+        <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>
     </properties>
 
     <dependencies>

--- a/larky/src/main/java/com/verygood/security/larky/modules/CollectionsModule.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/CollectionsModule.java
@@ -185,7 +185,7 @@ public class CollectionsModule implements StarlarkValue {
     }
 
     @Override
-    public Sequence<Object> getSlice(Mutability mu, int start, int stop, int step) {
+    public Sequence<Object> getSlice(Mutability mu, int start, int stop, int step) throws EvalException {
       return this.backingTuple.getSlice(mu,start,stop,step);
     }
 

--- a/larky/src/main/java/com/verygood/security/larky/parser/LarkyScript.java
+++ b/larky/src/main/java/com/verygood/security/larky/parser/LarkyScript.java
@@ -22,6 +22,10 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
 
 import com.verygood.security.larky.ModuleSupplier;
 import com.verygood.security.larky.ModuleSupplier.ModuleSet;
@@ -30,11 +34,6 @@ import com.verygood.security.larky.console.Console;
 import net.starlark.java.eval.EvalException;
 import net.starlark.java.eval.Module;
 import net.starlark.java.syntax.FileOptions;
-
-import java.io.IOException;
-import java.util.Map;
-import java.util.Set;
-import java.util.function.Supplier;
 
 /**
  * Loads Larky out of Starlark files.
@@ -60,7 +59,6 @@ public class LarkyScript {
 
   public static final FileOptions STARLARK_LOOSE_FILE_OPTIONS =
       STARLARK_STRICT_FILE_OPTIONS.toBuilder()
-          .restrictStringEscapes(false)
           .requireLoadStatementsFirst(false)
           .build();
 

--- a/larky/src/main/java/net/starlark/java/eval/StarlarkSequence.java
+++ b/larky/src/main/java/net/starlark/java/eval/StarlarkSequence.java
@@ -15,7 +15,7 @@ public interface StarlarkSequence<K extends Collection<T>, T> extends StarlarkIn
   K collection();
 
   @Override
-  Sequence<T> getSlice(Mutability mu, int start, int stop, int step);
+  Sequence<T> getSlice(Mutability mu, int start, int stop, int step) throws EvalException;
 
   @NotNull
   @Override

--- a/larky/src/test/java/com/verygood/security/larky/jsr223/LarkyScriptEngineTest.java
+++ b/larky/src/test/java/com/verygood/security/larky/jsr223/LarkyScriptEngineTest.java
@@ -6,6 +6,14 @@ import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
+import java.io.StringWriter;
+import java.io.Writer;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 import com.verygood.security.larky.parser.ParsedStarFile;
 
 import net.starlark.java.eval.EvalException;
@@ -16,13 +24,6 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.StringWriter;
-import java.io.Writer;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 import javax.script.Bindings;
 import javax.script.Compilable;
 import javax.script.CompiledScript;
@@ -39,45 +40,44 @@ public class LarkyScriptEngineTest {
   private ScriptEngine instance;
 
   @Before
-   public void setUp() {
+  public void setUp() {
     synchronized (this) {
-       ScriptEngineManager manager = new ScriptEngineManager();
-       instance = manager.getEngineByName("Larky");
+      ScriptEngineManager manager = new ScriptEngineManager();
+      instance = manager.getEngineByName("Larky");
     }
 
-   }
+  }
 
-   @After
-   public void tearDown() {
-     instance.getBindings(ScriptContext.ENGINE_SCOPE).clear();
-     instance = null;
-   }
-
+  @After
+  public void tearDown() {
+    instance.getBindings(ScriptContext.ENGINE_SCOPE).clear();
+    instance = null;
+  }
 
   @Test
   public void testCompile_String() throws ScriptException, EvalException {
     assertNotNull(instance);
     String script = String.join("\n",
-        "",
-        String.format("load(\"@stdlib/%1$s\", \"%1$s\")", "math"),
-        "",
-        "def norman_window(x, y):",
-        "    return get_area(x, y), get_perimeter(x, y)",
-        "",
-        "def get_area(x, y):",
-        "    return x * y + math.pi / 8.0 * math.pow(x, 2.0)",
-        "",
-        "def get_perimeter(x, y):",
-        "    return x + 2.0 * y + math.pi / 2.0 * x",
-        "",
-        "output = norman_window(2, 1)"
+      "",
+      String.format("load(\"@stdlib/%1$s\", \"%1$s\")", "math"),
+      "",
+      "def norman_window(x, y):",
+      "    return get_area(x, y), get_perimeter(x, y)",
+      "",
+      "def get_area(x, y):",
+      "    return x * y + math.pi / 8.0 * math.pow(x, 2.0)",
+      "",
+      "def get_perimeter(x, y):",
+      "    return x + 2.0 * y + math.pi / 2.0 * x",
+      "",
+      "output = norman_window(2, 1)"
     );
-    CompiledScript cs = ((Compilable)instance).compile(script);
+    CompiledScript cs = ((Compilable) instance).compile(script);
     ParsedStarFile evaluatedResult = (ParsedStarFile) cs.eval();
     Sequence<StarlarkFloat> output = Sequence.cast(
-        evaluatedResult.getGlobalEnvironmentVariable("output", Sequence.class),
-        StarlarkFloat.class,
-        "Error casting output to expected type of Sequence<StarlarkFloat>.");
+      evaluatedResult.getGlobalEnvironmentVariable("output", Sequence.class),
+      StarlarkFloat.class,
+      "Error casting output to expected type of Sequence<StarlarkFloat>.");
     List<Double> result = output.stream().map(StarlarkFloat::toDouble).collect(Collectors.toList());
     assertEquals(3.570796327, result.get(0), 0.000001);
     assertEquals(7.141592654, result.get(1), 0.000001);
@@ -126,10 +126,10 @@ public class LarkyScriptEngineTest {
     assertNotNull(instance);
 
     try {
-        instance.put(key, value);
+      instance.put(key, value);
     } catch (IllegalArgumentException e) {
-        String expResult = "key can not be empty";
-        assertEquals(expResult, e.getMessage());
+      String expResult = "key can not be empty";
+      assertEquals(expResult, e.getMessage());
     }
   }
 
@@ -154,12 +154,12 @@ public class LarkyScriptEngineTest {
     instance.put("abc_", map);
 
     result = instance.get(key);
-    assertEquals(expResult, ((List<String>)result).get(0));
+    assertEquals(expResult, ((List<String>) result).get(0));
 
     key = "abc_";
     expResult = "IsPythonLike";
     result = instance.get(key);
-    assertEquals(expResult, ((Map<String, String>)result).get("Larky"));
+    assertEquals(expResult, ((Map<String, String>) result).get("Larky"));
 
   }
 
@@ -187,18 +187,18 @@ public class LarkyScriptEngineTest {
   public void setBindings() throws ScriptException {
     assertNotNull(instance);
 
-     String script =
-         "def message():\n" +
-         "    return \"message: {}\".format(amessage)\n" +
-         "\n" +
-         "output = message()\n";
-     Bindings bindings = new SimpleBindings();
-     bindings.put("amessage", "What's up?");
-     int scope = ScriptContext.ENGINE_SCOPE;
-     Object expResult = "message: What's up?";
-     instance.setBindings(bindings, scope);
-     Object result = instance.eval(script);
-     assertEquals(expResult, ((ParsedStarFile)result).getGlobalEnvironmentVariable("output", String.class));
+    String script =
+      "def message():\n" +
+        "    return \"message: {}\".format(amessage)\n" +
+        "\n" +
+        "output = message()\n";
+    Bindings bindings = new SimpleBindings();
+    bindings.put("amessage", "What's up?");
+    int scope = ScriptContext.ENGINE_SCOPE;
+    Object expResult = "message: What's up?";
+    instance.setBindings(bindings, scope);
+    Object result = instance.eval(script);
+    assertEquals(expResult, ((ParsedStarFile) result).getGlobalEnvironmentVariable("output", String.class));
 
   }
 

--- a/libstarlark/pom.xml
+++ b/libstarlark/pom.xml
@@ -12,25 +12,29 @@
     <packaging>jar</packaging>
 
     <properties>
-        <maven.compiler.source>8</maven.compiler.source>
-        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.plugin.version>3.10.1</maven.compiler.plugin.version>
+        <maven.source.plugin.version>3.2.1</maven.source.plugin.version>
+
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.release>11</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <compiler-plugin.version>3.8.1</compiler-plugin.version>
-        <surefire-plugin.version>2.22.1</surefire-plugin.version>
-        <maven.compiler.plugin.version>3.6.2</maven.compiler.plugin.version>
-        <maven.source.plugin.version>3.2.1</maven.source.plugin.version>
-        <google.errorprone.javac.version>9+181-r4173-1</google.errorprone.javac.version>
-        <org.projectlombok.version>1.18.22</org.projectlombok.version>
-        <google.errorprone.version>2.9.0</google.errorprone.version>
+
         <google.auto.value.version>1.9</google.auto.value.version>
-        <google.truth.version>1.1.3</google.truth.version>
-        <google.jimfs.version>1.2</google.jimfs.version>
         <google.compile.testing.version>0.19</google.compile.testing.version>
+        <google.errorprone.javac.version>9+181-r4173-1</google.errorprone.javac.version>
+        <google.errorprone.version>2.9.0</google.errorprone.version>
+        <google.flogger.version>0.7.4</google.flogger.version>
+        <google.guava.version>31.1-jre</google.guava.version>
+        <google.jimfs.version>1.2</google.jimfs.version>
+        <google.truth.version>1.1.3</google.truth.version>
         <org.jetbrains.annotations.version>22.0.0</org.jetbrains.annotations.version>
-        <google.guava.version>31.0.1-jre</google.guava.version>
         <org.junit.version>4.13.2</org.junit.version>
+        <org.projectlombok.version>1.18.22</org.projectlombok.version>
+
+        <surefire-plugin.version>2.22.1</surefire-plugin.version>
     </properties>
 
     <dependencies>
@@ -63,6 +67,24 @@
             <groupId>com.google.auto.value</groupId>
             <artifactId>auto-value-annotations</artifactId>
             <version>${google.auto.value.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.flogger</groupId>
+            <artifactId>flogger</artifactId>
+            <version>${google.flogger.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.flogger</groupId>
+            <artifactId>flogger-system-backend</artifactId>
+            <version>${google.flogger.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.google.flogger</groupId>
+            <artifactId>google-extensions</artifactId>
+            <version>${google.flogger.version}</version>
         </dependency>
 
         <!--Tests-->
@@ -135,8 +157,9 @@
                     <showWarnings>true</showWarnings>
                     <failOnWarning>false</failOnWarning>
                     <showDeprecation>true</showDeprecation>
-                    <source>${maven.compiler.source}</source>
-                    <target>${maven.compiler.target}</target>
+                    <source>11</source>
+                    <target>11</target>
+                    <release>${maven.compiler.release}</release>
                     <forceJavacCompilerUse>true</forceJavacCompilerUse>
                     <compilerArgs combine.children="append">
                         <compilerArg>-Xlint:unchecked</compilerArg>

--- a/libstarlark/pom.xml
+++ b/libstarlark/pom.xml
@@ -15,9 +15,9 @@
         <maven.compiler.plugin.version>3.10.1</maven.compiler.plugin.version>
         <maven.source.plugin.version>3.2.1</maven.source.plugin.version>
 
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
-        <maven.compiler.release>11</maven.compiler.release>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <maven.compiler.release>8</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/libstarlark/src/main/java/net/starlark/java/annot/StarlarkMethod.java
+++ b/libstarlark/src/main/java/net/starlark/java/annot/StarlarkMethod.java
@@ -80,6 +80,10 @@ import java.lang.annotation.Target;
  * unless the method is marked as {@link #allowReturnNones}, in which case {@link Starlark#fromJava}
  * converts the Java null value to {@link Starlark#NONE}. This feature prevents a method whose
  * declared (and documented) result type is T from unexpectedly returning a value of type NoneType.
+ *
+ * <p>The annotated method may throw any checked or unchecked exceptions. When it is invoked,
+ * unchecked exceptions, {@code EvalException}s, and {@code InterruptedException}s are passed
+ * through; all other (checked) exceptions are wrapped in an {@code EvalException} and thrown.
  */
 // TODO(adonovan): rename to StarlarkAttribute and factor Starlark{Method,Field} as subinterfaces.
 @Target({ElementType.METHOD})
@@ -138,7 +142,7 @@ public @interface StarlarkMethod {
    *
    * <p>If this is left as default, it is an error for the caller to pass any named arguments not
    * explicitly declared by the method signature. If this is defined, all additional named arguments
-   * are passed as elements of a {@link Dict<String, Object>} to the method.
+   * are passed as elements of a {@code Dict<String, Object>} to the method.
    *
    * <p>See Python's <code>**kwargs</code> (http://thepythonguru.com/python-args-and-kwargs/).
    *

--- a/libstarlark/src/main/java/net/starlark/java/eval/Dict.java
+++ b/libstarlark/src/main/java/net/starlark/java/eval/Dict.java
@@ -15,6 +15,8 @@
 package net.starlark.java.eval;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -23,6 +25,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.BiConsumer;
 import javax.annotation.Nullable;
 import net.starlark.java.annot.Param;
 import net.starlark.java.annot.StarlarkBuiltin;
@@ -71,7 +74,7 @@ import net.starlark.java.annot.StarlarkMethod;
             + "0 in d, \"a\" in d  # (True, False)\n"
             + "[(k, v) for k, v in d.items()]  # [(0, \"a\"), (1, 1), (2, \"b\")]\n"
             + "</pre>\n"
-            + "<p>There are three ways to construct a dictionary:\n"
+            + "<p>There are four ways to construct a dictionary:\n"
             + "<ol>\n"
             + "<li>A dictionary expression <code>{k: v, ...}</code> yields a new dictionary with"
             + " the specified key/value entries, inserted in the order they appear in the"
@@ -89,37 +92,68 @@ import net.starlark.java.annot.StarlarkMethod;
             + " a dictionary containing the specified entries, which are inserted in argument"
             + " order, positional arguments before named. As with comprehensions, duplicate keys"
             + " are permitted.\n"
+            + "<li>The union expression <code>x | y</code> yields a new dictionary by combining two"
+            + " existing dictionaries. If the two dictionaries have a key <code>k</code> in common,"
+            + " the right hand side dictionary's value of the key (in other words,"
+            + " <code>y[k]</code>) wins. The <code>|=</code> variant of the union operator modifies"
+            + " a dictionary in-place. Example:<br>"
+            + "<pre class=language-python>"
+            + "d = {\"foo\": \"FOO\", \"bar\": \"BAR\"} | {\"foo\": \"FOO2\", \"baz\": \"BAZ\"}\n"
+            + "# d == {\"foo\": \"FOO2\", \"bar\": \"BAR\", \"baz\": \"BAZ\"}\n"
+            + "d = {\"a\": 1, \"b\": 2}\n"
+            + "d |= {\"b\": 3, \"c\": 4}\n"
+            + "# d == {\"a\": 1, \"b\": 3, \"c\": 4}</pre>"
             + "</ol>")
-public final class Dict<K, V>
+public class Dict<K, V>
     implements Map<K, V>,
         StarlarkValue,
         Mutability.Freezable,
         StarlarkIndexable,
         StarlarkIterable<K> {
 
-  // TODO(adonovan): for dicts that are born frozen, use ImmutableMap, which is also
-  // insertion-ordered and has smaller Entries (singly linked, no hash).
-  private final LinkedHashMap<K, V> contents;
+  private final Map<K, V> contents;
   private int iteratorCount; // number of active iterators (unused once frozen)
 
   /** Final except for {@link #unsafeShallowFreeze}; must not be modified any other way. */
   private Mutability mutability;
 
-  private Dict(@Nullable Mutability mutability, LinkedHashMap<K, V> contents) {
-    this.mutability = mutability == null ? Mutability.IMMUTABLE : mutability;
+  private Dict(Mutability mutability, LinkedHashMap<K, V> contents) {
+    Preconditions.checkNotNull(mutability);
+    Preconditions.checkState(mutability != Mutability.IMMUTABLE);
+    this.mutability = mutability;
+    // TODO(bazel-team): Memory optimization opportunity: Make it so that a call to
+    // `mutability.freeze()` causes `contents` here to become an ImmutableMap. Benchmarks show that
+    // for many targets, this can save a small amount of retained heap (up to 1%). But for some
+    // targets the bookkeeping required for this causes unacceptably increased temporary heap, and
+    // the CPU overhead of the bookkeeping and the CPU cost of the ImmutableMap#copyOf call cause
+    // unacceptably increased CPU. In other words, the overall tradeoff is not obviously worth it
+    // in all cases. So be careful making this optimization! See comment #12 of b/225469491 for
+    // details.
     this.contents = contents;
   }
 
-  private Dict(@Nullable Mutability mutability) {
-    this(mutability, new LinkedHashMap<>());
+  private Dict(ImmutableMap<K, V> contents) {
+    // An immutable dict might as well store its contents as an ImmutableMap, since ImmutableMap
+    // both is more memory-efficient than LinkedHashMap and also it has the requisite deterministic
+    // iteration order.
+    this.mutability = Mutability.IMMUTABLE;
+    this.contents = contents;
   }
 
   /**
    * Takes ownership of the supplied LinkedHashMap and returns a new Dict that wraps it. The caller
    * must not subsequently modify the map, but the Dict may do so.
    */
-  static <K, V> Dict<K, V> wrap(@Nullable Mutability mutability, LinkedHashMap<K, V> contents) {
-    return new Dict<>(mutability, contents);
+  static <K, V> Dict<K, V> wrap(@Nullable Mutability mu, LinkedHashMap<K, V> contents) {
+    if (mu == null) {
+      mu = Mutability.IMMUTABLE;
+    }
+    if (mu == Mutability.IMMUTABLE && contents.isEmpty()) {
+      return empty();
+    }
+    // #wrap is used in situations where the resulting Dict isn't necessarily retained [forever].
+    // So, don't make an ImmutableMap copy of `contents`, as #copyOf would do.
+    return new Dict<>(mu, contents);
   }
 
   @Override
@@ -163,7 +197,7 @@ public final class Dict<K, V>
 
   @Override
   public Iterator<K> iterator() {
-    return contents.keySet().iterator();
+    return keySet().iterator();
   }
 
   @StarlarkMethod(
@@ -360,7 +394,7 @@ public final class Dict<K, V>
   public StarlarkList<?> items(StarlarkThread thread) throws EvalException {
     Object[] array = new Object[size()];
     int i = 0;
-    for (Map.Entry<?, ?> e : entrySet()) {
+    for (Map.Entry<?, ?> e : contents.entrySet()) {
       array[i++] = Tuple.pair(e.getKey(), e.getValue());
     }
     return StarlarkList.wrap(thread.mutability(), array);
@@ -376,13 +410,13 @@ public final class Dict<K, V>
   public StarlarkList<?> keys(StarlarkThread thread) throws EvalException {
     Object[] array = new Object[size()];
     int i = 0;
-    for (Map.Entry<?, ?> e : entrySet()) {
-      array[i++] = e.getKey();
+    for (K e : contents.keySet()) {
+      array[i++] = e;
     }
     return StarlarkList.wrap(thread.mutability(), array);
   }
 
-  private static final Dict<?, ?> EMPTY = of(Mutability.IMMUTABLE);
+  private static final Dict<?, ?> EMPTY = new Dict<>(ImmutableMap.of());
 
   /** Returns an immutable empty dict. */
   // Safe because the empty singleton is immutable.
@@ -393,24 +427,49 @@ public final class Dict<K, V>
 
   /** Returns a new empty dict with the specified mutability. */
   public static <K, V> Dict<K, V> of(@Nullable Mutability mu) {
-    return new Dict<>(mu);
+    if (mu == null) {
+      mu = Mutability.IMMUTABLE;
+    }
+    if (mu == Mutability.IMMUTABLE) {
+      return empty();
+    } else {
+      return new Dict<>(mu, new LinkedHashMap<>());
+    }
   }
 
   /** Returns a new dict with the specified mutability containing the entries of {@code m}. */
   public static <K, V> Dict<K, V> copyOf(@Nullable Mutability mu, Map<? extends K, ? extends V> m) {
-    if (mu == null && m instanceof Dict && ((Dict) m).isImmutable()) {
+    if (mu == null) {
+      mu = Mutability.IMMUTABLE;
+    }
+
+    if (mu == Mutability.IMMUTABLE && m instanceof Dict && ((Dict) m).isImmutable()) {
       @SuppressWarnings("unchecked")
       Dict<K, V> dict = (Dict<K, V>) m; // safe
       return dict;
     }
 
-    Dict<K, V> dict = new Dict<>(mu);
-    for (Map.Entry<? extends K, ? extends V> e : m.entrySet()) {
-      dict.contents.put(
-          Starlark.checkValid(e.getKey()), //
-          Starlark.checkValid(e.getValue()));
+    if (mu == Mutability.IMMUTABLE) {
+      if (m.isEmpty()) {
+        return empty();
+      }
+      ImmutableMap.Builder<K, V> immutableMapBuilder =
+          ImmutableMap.builderWithExpectedSize(m.size());
+      for (Map.Entry<? extends K, ? extends V> e : m.entrySet()) {
+        immutableMapBuilder.put(
+            Starlark.checkValid(e.getKey()), //
+            Starlark.checkValid(e.getValue()));
+      }
+      return new Dict<>(immutableMapBuilder.buildOrThrow());
+    } else {
+      LinkedHashMap<K, V> linkedHashMap = new LinkedHashMap<>();
+      for (Map.Entry<? extends K, ? extends V> e : m.entrySet()) {
+        linkedHashMap.put(
+            Starlark.checkValid(e.getKey()), //
+            Starlark.checkValid(e.getValue()));
+      }
+      return new Dict<>(mu, linkedHashMap);
     }
-    return dict;
   }
 
   /** Returns an immutable dict containing the entries of {@code m}. */
@@ -448,21 +507,53 @@ public final class Dict<K, V>
       return build(null);
     }
 
+    /** Returns a new {@link ImmutableKeyTrackingDict} containing the entries added so far. */
+    public ImmutableKeyTrackingDict<K, V> buildImmutableWithKeyTracking() {
+      return new ImmutableKeyTrackingDict<>(buildImmutableMap());
+    }
+
     /**
      * Returns a new Dict containing the entries added so far. The result has the specified
      * mutability; null means immutable.
      */
     public Dict<K, V> build(@Nullable Mutability mu) {
-      int n = items.size() / 2;
-      LinkedHashMap<K, V> map = Maps.newLinkedHashMapWithExpectedSize(n);
+      if (mu == null) {
+        mu = Mutability.IMMUTABLE;
+      }
+
+      if (mu == Mutability.IMMUTABLE) {
+        if (items.isEmpty()) {
+          return empty();
+        }
+        return new Dict<>(buildImmutableMap());
+      } else {
+        return new Dict<>(mu, buildLinkedHashMap());
+      }
+    }
+
+    private void populateMap(int n, BiConsumer<K, V> mapEntryConsumer) {
       for (int i = 0; i < n; i++) {
         @SuppressWarnings("unchecked")
         K k = (K) items.get(2 * i); // safe
         @SuppressWarnings("unchecked")
         V v = (V) items.get(2 * i + 1); // safe
-        map.put(k, v);
+        mapEntryConsumer.accept(k, v);
       }
-      return wrap(mu, map);
+    }
+
+    private ImmutableMap<K, V> buildImmutableMap() {
+      int n = items.size() / 2;
+      ImmutableMap.Builder<K, V> immutableMapBuilder = ImmutableMap.builderWithExpectedSize(n);
+      populateMap(n, immutableMapBuilder::put);
+      // Respect the desired semantics of Builder#put.
+      return immutableMapBuilder.buildKeepingLast();
+    }
+
+    private LinkedHashMap<K, V> buildLinkedHashMap() {
+      int n = items.size() / 2;
+      LinkedHashMap<K, V> map = Maps.newLinkedHashMapWithExpectedSize(n);
+      populateMap(n, map::put);
+      return map;
     }
   }
 
@@ -662,5 +753,57 @@ public final class Dict<K, V>
   @Override
   public V remove(Object key) {
     throw new UnsupportedOperationException();
+  }
+
+  /**
+   * An immutable {@code Dict} that tracks accessed keys.
+   *
+   * <p>Only keys present in the dict are tracked. Any call to {@link #keySet} or {@link #entrySet}
+   * conservatively results in all keys being considered as accessed - notably, this happens with
+   * iteration, {@link #repr}, and a mutable copy.
+   */
+  public static final class ImmutableKeyTrackingDict<K, V> extends Dict<K, V> {
+    private final ImmutableSet.Builder<K> accessedKeys = ImmutableSet.builder();
+
+    private ImmutableKeyTrackingDict(ImmutableMap<K, V> contents) {
+      super(contents);
+    }
+
+    public ImmutableSet<K> getAccessedKeys() {
+      return accessedKeys.build();
+    }
+
+    @Override
+    @SuppressWarnings("unchecked") // Present keys must be of type K.
+    public boolean containsKey(Object key) {
+      if (super.containsKey(key)) {
+        accessedKeys.add((K) key);
+        return true;
+      }
+      return false;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked") // Present keys must be of type K.
+    public V get(Object key) {
+      V value = super.get(key);
+      if (value != null) {
+        accessedKeys.add((K) key);
+      }
+      return value;
+    }
+
+    @Override
+    public Set<K> keySet() {
+      Set<K> keySet = super.keySet();
+      accessedKeys.addAll(keySet);
+      return keySet;
+    }
+
+    @Override
+    public Set<Map.Entry<K, V>> entrySet() {
+      accessedKeys.addAll(super.keySet());
+      return super.entrySet();
+    }
   }
 }

--- a/libstarlark/src/main/java/net/starlark/java/eval/Eval.java
+++ b/libstarlark/src/main/java/net/starlark/java/eval/Eval.java
@@ -22,7 +22,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-
 import net.starlark.java.spelling.SpellChecker;
 import net.starlark.java.syntax.Argument;
 import net.starlark.java.syntax.AssignmentStatement;
@@ -460,6 +459,14 @@ final class Eval {
       StarlarkList<?> list = (StarlarkList) x;
       list.extend(y);
       return list;
+    } else if (op == TokenKind.PIPE && x instanceof Dict && y instanceof Dict) {
+      // dict |= dict merges the contents of the second dict into the first.
+      @SuppressWarnings("unchecked")
+      Dict<Object, Object> xDict = (Dict<Object, Object>) x;
+      @SuppressWarnings("unchecked")
+      Dict<Object, Object> yDict = (Dict<Object, Object>) y;
+      xDict.putEntries(yDict);
+      return xDict;
     }
     return EvalUtils.binaryOp(op, x, y, fr.thread);
   }

--- a/libstarlark/src/main/java/net/starlark/java/eval/EvalUtils.java
+++ b/libstarlark/src/main/java/net/starlark/java/eval/EvalUtils.java
@@ -13,7 +13,6 @@
 // limitations under the License.
 package net.starlark.java.eval;
 
-import com.google.common.base.Strings;
 import java.util.IllegalFormatException;
 import net.starlark.java.syntax.TokenKind;
 
@@ -126,6 +125,11 @@ final class EvalUtils {
           if (y instanceof StarlarkInt) {
             // int | int
             return StarlarkInt.or((StarlarkInt) x, (StarlarkInt) y);
+          }
+        } else if (x instanceof Dict) {
+          if (y instanceof Dict) {
+            // dict | dict
+            return Dict.builder().putAll((Dict<?, ?>) x).putAll((Dict<?, ?>) y).build(mu);
           }
         }
         break;
@@ -394,11 +398,10 @@ final class EvalUtils {
     if (n <= 0) {
       return "";
     } else if ((long) s.length() * (long) n > Integer.MAX_VALUE) {
-      // Would exceed max length of a java String (and would cause an undocumented
-      // ArrayIndexOutOfBoundsException to be thrown in Strings.repeat()).
+      // Would exceed max length of a java String.
       throw Starlark.errorf("excessive repeat (%d * %d characters)", s.length(), n);
     } else {
-      return Strings.repeat(s, n);
+      return s.repeat(n);
     }
   }
 

--- a/libstarlark/src/main/java/net/starlark/java/eval/EvalUtils.java
+++ b/libstarlark/src/main/java/net/starlark/java/eval/EvalUtils.java
@@ -13,6 +13,7 @@
 // limitations under the License.
 package net.starlark.java.eval;
 
+import com.google.common.base.Strings;
 import java.util.IllegalFormatException;
 import net.starlark.java.syntax.TokenKind;
 
@@ -401,7 +402,10 @@ final class EvalUtils {
       // Would exceed max length of a java String.
       throw Starlark.errorf("excessive repeat (%d * %d characters)", s.length(), n);
     } else {
-      return s.repeat(n);
+      // We currently do not support JDK11 (for now), so we will avoid this:
+      // We can remove this once we are on JDK11.
+      // return s.repeat(n);
+      return Strings.repeat(s, n);
     }
   }
 

--- a/libstarlark/src/main/java/net/starlark/java/eval/MethodLibrary.java
+++ b/libstarlark/src/main/java/net/starlark/java/eval/MethodLibrary.java
@@ -23,7 +23,6 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
-
 import net.starlark.java.annot.Param;
 import net.starlark.java.annot.ParamType;
 import net.starlark.java.annot.StarlarkBuiltin;

--- a/libstarlark/src/main/java/net/starlark/java/eval/Mutability.java
+++ b/libstarlark/src/main/java/net/starlark/java/eval/Mutability.java
@@ -20,12 +20,12 @@ import java.util.IdentityHashMap;
  * An object that manages the capability to mutate Starlark objects and their {@link
  * StarlarkThread}s. Collectively, the managed objects are called {@link Freezable}s.
  *
- * <p>Each {@code StarlarkThread}, and each of the mutable Starlark values (i.e., {@link
- * StarlarkMutable}s) that are created in that {@code StarlarkThread}, holds a pointer to the same
- * {@code Mutability} instance. Once the {@code StarlarkThread} is done evaluating, its {@code
- * Mutability} is irreversibly closed ("frozen"). At that point, it is no longer possible to change
- * either the bindings in that {@code StarlarkThread} or the state of its objects. This protects
- * each {@code StarlarkThread} from unintentional and unsafe modification.
+ * <p>Each {@code StarlarkThread}, and each of the mutable Starlark values that are created in that
+ * {@code StarlarkThread}, holds a pointer to the same {@code Mutability} instance. Once the {@code
+ * StarlarkThread} is done evaluating, its {@code Mutability} is irreversibly closed ("frozen"). At
+ * that point, it is no longer possible to change either the bindings in that {@code StarlarkThread}
+ * or the state of its objects. This protects each {@code StarlarkThread} from unintentional and
+ * unsafe modification.
  *
  * <p>{@code Mutability}s enforce isolation between {@code StarlarkThread}s; it is illegal for an
  * evaluation in one {@code StarlarkThread} to affect the bindings or values of another. In
@@ -78,8 +78,7 @@ import java.util.IdentityHashMap;
  * </ol>
  *
  * It follows that, if these invariants hold, an unfrozen value cannot appear as the child of a
- * value whose {@code Mutability} is already frozen. This knowledge is used by {@link
- * StarlarkMutable#isImmutable} to prune traversals of a compound value.
+ * value whose {@code Mutability} is already frozen.
  *
  * <p>There is a special API for freezing individual values rather than whole {@code
  * StarlarkThread}s. Because this API makes it easier to violate the above invariants, you should
@@ -203,7 +202,8 @@ public final class Mutability implements AutoCloseable {
   public interface Freezable {
     /**
      * Returns the {@link Mutability} associated with this {@code Freezable}. This should not change
-     * over the lifetime of the object, except by calling {@link #shallowFreeze} if applicable.
+     * over the lifetime of the object, except by calling {@link #unsafeShallowFreeze} if
+     * applicable.
      */
     Mutability mutability();
 
@@ -234,17 +234,16 @@ public final class Mutability implements AutoCloseable {
     /**
      * Freezes this object (and not its contents). Use with care.
      *
-     * <p>This method is optional (i.e. may throw {@link NotImplementedException}).
+     * <p>This method is optional (i.e. may throw {@link UnsupportedOperationException}).
      *
      * <p>If this object's {@link Mutability} is 1) not frozen, and 2) has {@link
-     * #allowUnsafeShallowFreeze} return true, then the object's {@code Mutability} reference is
+     * #allowsUnsafeShallowFreeze} return true, then the object's {@code Mutability} reference is
      * updated to point to {@link #IMMUTABLE}. Otherwise, this method throws {@link
      * IllegalArgumentException}.
      *
      * <p>It is up to the caller to ensure that any contents of this {@code Freezable} are also
      * frozen in order to preserve/restore the invariant that an immutable value cannot contain a
-     * mutable one. Note that {@link StarlarkMutable#isImmutable} correctness and thread-safety are
-     * not guaranteed otherwise.
+     * mutable one. Note that thread-safety is not guaranteed otherwise.
      */
     default void unsafeShallowFreeze() {
       throw new UnsupportedOperationException();

--- a/libstarlark/src/main/java/net/starlark/java/eval/ParamDescriptor.java
+++ b/libstarlark/src/main/java/net/starlark/java/eval/ParamDescriptor.java
@@ -15,6 +15,7 @@
 package net.starlark.java.eval;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
@@ -105,11 +106,16 @@ final class ParamDescriptor {
     // "a or b"
     // "a, b, or c"
     StringBuilder buf = new StringBuilder();
-    for (int i = 0, n = allowedClasses.size(); i < n; i++) {
+    // TODO(b/200065655#comment3): Remove when we have an official way for package defaults.
+    ImmutableList<Class<?>> allowedClassesFiltered =
+        allowedClasses.stream()
+            .filter(x -> !Starlark.classType(x).equals("NativeComputedDefault"))
+            .collect(ImmutableList.toImmutableList());
+    for (int i = 0, n = allowedClassesFiltered.size(); i < n; i++) {
       if (i > 0) {
         buf.append(n == 2 ? " or " : i < n - 1 ? ", " : ", or ");
       }
-      buf.append(Starlark.classType(allowedClasses.get(i)));
+      buf.append(Starlark.classType(allowedClassesFiltered.get(i)));
     }
     return buf.toString();
   }

--- a/libstarlark/src/main/java/net/starlark/java/eval/RangeList.java
+++ b/libstarlark/src/main/java/net/starlark/java/eval/RangeList.java
@@ -30,6 +30,8 @@ import net.starlark.java.annot.StarlarkBuiltin;
  * simple math to compute a value at each index. This is particularly useful when range is huge or
  * only a few elements from it are used.
  *
+ * <p>The start, stop, step, and size of the range must all fit within 32-bit signed integers.
+ *
  * <p>Eventually {@code range} function should produce an instance of the {@code range} type as is
  * the case in Python 3, but for now to preserve backwards compatibility with Python 2, {@code list}
  * is returned.
@@ -56,8 +58,7 @@ final class RangeList extends AbstractList<StarlarkInt> implements Sequence<Star
   private final int step;
   private final int size; // (derived)
 
-  // TODO(adonovan): use StarlarkInt computation, to avoid overflow.
-  RangeList(int start, int stop, int step) {
+  RangeList(int start, int stop, int step) throws EvalException {
     Preconditions.checkArgument(step != 0);
 
     this.start = start;
@@ -69,19 +70,25 @@ final class RangeList extends AbstractList<StarlarkInt> implements Sequence<Star
     // https://github.com/python/cpython/blob/09bb918a61031377d720f1a0fa1fe53c962791b6/Objects/rangeobject.c#L144
     int low; // [low,high) is a half-open interval
     int high;
+    long absStep;
     if (step > 0) {
       low = start;
       high = stop;
+      absStep = step;
     } else {
       low = stop;
       high = start;
-      step = -step;
+      absStep = -(long) step;
     }
     if (low >= high) {
       this.size = 0;
     } else {
-      int diff = high - low - 1;
-      this.size = diff / step + 1;
+      long diff = (long) high - low - 1;
+      long size = diff / absStep + 1;
+      if ((int) size != size) {
+        throw Starlark.errorf("len(%s) exceeds signed 32-bit range", Starlark.repr(this));
+      }
+      this.size = (int) size;
     }
   }
 
@@ -151,7 +158,7 @@ final class RangeList extends AbstractList<StarlarkInt> implements Sequence<Star
   @Override
   public Iterator<StarlarkInt> iterator() {
     return new UnmodifiableIterator<StarlarkInt>() {
-      int cursor = start;
+      long cursor = start; // returned by next() if hasNext() is true
 
       @Override
       public boolean hasNext() {
@@ -163,7 +170,8 @@ final class RangeList extends AbstractList<StarlarkInt> implements Sequence<Star
         if (!hasNext()) {
           throw new NoSuchElementException();
         }
-        int current = cursor;
+        // If cursor is valid, it's guaranteed to be in [start, stop) range, thus a 32-bit value.
+        int current = (int) cursor;
         cursor += step;
         return StarlarkInt.of(current);
       }
@@ -171,8 +179,23 @@ final class RangeList extends AbstractList<StarlarkInt> implements Sequence<Star
   }
 
   @Override
-  public Sequence<StarlarkInt> getSlice(Mutability mu, int start, int stop, int step) {
-    return new RangeList(at(start), at(stop), step * this.step);
+  public Sequence<StarlarkInt> getSlice(Mutability mu, int start, int stop, int step)
+      throws EvalException {
+    long sliceStep = (long) step * (long) this.step;
+    if (sliceStep != (int) sliceStep) {
+      // It is not an error to take a slice of a RangeList such that the slice step * list step
+      // doesn't fit in a 32-bit int; the result ought to be a RangeList containing only one
+      // element (the start). Since difference between 2 successive elements of a RangeList must be
+      // a 32-bit int, clamping the step to Integer.MAX_VALUE or MIN_VALUE and moving stop to start
+      // +/- 1 gives us the 1-element RangeList we need.
+      sliceStep = sliceStep > 0 ? Integer.MAX_VALUE : Integer.MIN_VALUE; // note sliceStep != 0
+      if (stop > start) {
+        stop = start + 1;
+      } else if (stop < start) {
+        stop = start - 1;
+      }
+    }
+    return new RangeList(at(start), at(stop), (int) sliceStep);
   }
 
   // Like get, but without bounds check or Integer allocation.

--- a/libstarlark/src/main/java/net/starlark/java/eval/Sequence.java
+++ b/libstarlark/src/main/java/net/starlark/java/eval/Sequence.java
@@ -100,7 +100,7 @@ public interface Sequence<E>
    * For negative strides ({@code step < 0}), {@code -1 <= stop <= start < size()}. <br>
    * The caller must ensure that the start and stop indices are valid and that step is non-zero.
    */
-  Sequence<E> getSlice(Mutability mu, int start, int stop, int step);
+  Sequence<E> getSlice(Mutability mu, int start, int stop, int step) throws EvalException;
 
   /**
    * Casts a non-null Starlark value {@code x} to a {@code Sequence<T>}, after checking that each

--- a/libstarlark/src/main/java/net/starlark/java/eval/Starlark.java
+++ b/libstarlark/src/main/java/net/starlark/java/eval/Starlark.java
@@ -30,7 +30,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
-
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
 import net.starlark.java.annot.StarlarkAnnotations;
 import net.starlark.java.annot.StarlarkBuiltin;
 import net.starlark.java.annot.StarlarkMethod;
@@ -42,9 +43,6 @@ import net.starlark.java.syntax.Program;
 import net.starlark.java.syntax.Resolver;
 import net.starlark.java.syntax.StarlarkFile;
 import net.starlark.java.syntax.SyntaxError;
-
-import javax.annotation.Nullable;
-import javax.annotation.concurrent.Immutable;
 
 /**
  * The Starlark class defines the most important entry points, constants, and functions needed by
@@ -949,7 +947,7 @@ public final class Starlark {
    */
   private static StarlarkFunction newExprFunction(
       ParserInput input, FileOptions options, Module module) throws SyntaxError.Exception {
-    Expression expr = Expression.parse(input, options);
+    Expression expr = Expression.parse(input);
     Program prog = Program.compileExpr(expr, module, options);
     Resolver.Function rfn = prog.getResolvedFunction();
     int[] globalIndex = module.getIndicesOfGlobals(rfn.getGlobals()); // see execFileProgram
@@ -965,8 +963,8 @@ public final class Starlark {
    * @throws IllegalStateException exception if the Starlark profiler is already running or if the
    *     operating system's profiling resources for this process are already in use.
    */
-  public static void startCpuProfile(OutputStream out, Duration period) {
-    CpuProfiler.start(out, period);
+  public static boolean startCpuProfile(OutputStream out, Duration period) {
+    return CpuProfiler.start(out, period);
   }
 
   /**

--- a/libstarlark/src/main/java/net/starlark/java/eval/StarlarkBytes.java
+++ b/libstarlark/src/main/java/net/starlark/java/eval/StarlarkBytes.java
@@ -853,7 +853,7 @@ public class StarlarkBytes implements ByteStringModuleApi,
   }
 
   @Override
-  public StarlarkBytes getSlice(Mutability mu, int start, int stop, int step) {
+  public StarlarkBytes getSlice(Mutability mu, int start, int stop, int step) throws EvalException {
     RangeList indices = new RangeList(start, stop, step);
     int n = indices.size();
     if (step == 1) { // common case
@@ -1350,7 +1350,7 @@ public class StarlarkBytes implements ByteStringModuleApi,
     }
 
     @Override
-    public Sequence<StarlarkInt> getSlice(Mutability mu, int start, int stop, int step) {
+    public Sequence<StarlarkInt> getSlice(Mutability mu, int start, int stop, int step) throws EvalException {
       int[] unsignedBytes = this.bytes.getSlice(mu, start, stop, step).getUnsignedBytes();
       return StarlarkList.copyOf(mu, Arrays
                                        .stream(unsignedBytes)

--- a/libstarlark/src/main/java/net/starlark/java/eval/StarlarkFloat.java
+++ b/libstarlark/src/main/java/net/starlark/java/eval/StarlarkFloat.java
@@ -15,6 +15,7 @@
 package net.starlark.java.eval;
 
 import java.math.BigInteger;
+import java.util.Locale;
 import net.starlark.java.annot.StarlarkBuiltin;
 
 /** The Starlark float data type. */
@@ -124,20 +125,20 @@ public final class StarlarkFloat implements StarlarkValue, Comparable<StarlarkFl
     String s;
     switch (conv) {
       case 'e':
-        s = String.format("%e", v);
+        s = String.format(Locale.US, "%e", v);
         break;
       case 'E':
-        s = String.format("%E", v);
+        s = String.format(Locale.US, "%E", v);
         break;
       case 'f':
       case 'F': // an alias
-        s = String.format("%f", v);
+        s = String.format(Locale.US, "%f", v);
         break;
       case 'g':
-        s = String.format("%.17g", v); // use DBL_DECIMAL_DIG places
+        s = String.format(Locale.US, "%.17g", v); // use DBL_DECIMAL_DIG places
         break;
       case 'G':
-        s = String.format("%.17G", v);
+        s = String.format(Locale.US, "%.17G", v);
         break;
       default:
         throw new IllegalArgumentException("unsupported conversion: " + conv);

--- a/libstarlark/src/main/java/net/starlark/java/eval/StarlarkInt.java
+++ b/libstarlark/src/main/java/net/starlark/java/eval/StarlarkInt.java
@@ -380,7 +380,7 @@ public abstract class StarlarkInt implements StarlarkValue, Comparable<StarlarkI
   public abstract BigInteger toBigInteger();
 
   /**
-   * Returns the the value of this StarlarkInt as a Java signed 32-bit int.
+   * Returns the value of this StarlarkInt as a Java signed 32-bit int.
    *
    * @throws IllegalArgumentException if this int is not in that value range.
    */

--- a/libstarlark/src/main/java/net/starlark/java/eval/StarlarkList.java
+++ b/libstarlark/src/main/java/net/starlark/java/eval/StarlarkList.java
@@ -315,7 +315,8 @@ public final class StarlarkList<E> extends AbstractList<E>
   }
 
   @Override
-  public StarlarkList<E> getSlice(Mutability mu, int start, int stop, int step) {
+  public StarlarkList<E> getSlice(Mutability mu, int start, int stop, int step)
+      throws EvalException {
     RangeList indices = new RangeList(start, stop, step);
     int n = indices.size();
     Object[] res = new Object[n];

--- a/libstarlark/src/main/java/net/starlark/java/eval/StarlarkSemantics.java
+++ b/libstarlark/src/main/java/net/starlark/java/eval/StarlarkSemantics.java
@@ -42,7 +42,16 @@ import java.util.TreeMap;
  */
 public final class StarlarkSemantics {
 
-  /** Returns the empty semantics, in which every option has its default value. */
+  /**
+   * Returns the empty semantics, in which every option has its default value.
+   *
+   * <p><i>Usage note:</i> Usually all Starlark evaluation contexts (i.e., {@link StarlarkThread}s
+   * or other interpreter APIs that accept a {@code StarlarkSemantics}) within the same application
+   * should use the same semantics. Otherwise, different pieces of code -- or even the same code
+   * when executed in different capacities -- could produce diverging results. It is therefore
+   * generally a code smell to use the {@code DEFAULT} semantics rather than propagating a {@code
+   * StarlarkSemantics} from another context.
+   */
   public static final StarlarkSemantics DEFAULT = new StarlarkSemantics(ImmutableMap.of());
 
   // A map entry must be accessed by Key iff its name has no [+-] prefix.

--- a/libstarlark/src/main/java/net/starlark/java/eval/StarlarkThread.java
+++ b/libstarlark/src/main/java/net/starlark/java/eval/StarlarkThread.java
@@ -396,7 +396,10 @@ public final class StarlarkThread {
    * Constructs a StarlarkThread.
    *
    * @param mu the (non-frozen) mutability of values created by this thread.
-   * @param semantics the StarlarkSemantics for this thread.
+   * @param semantics the StarlarkSemantics for this thread. Note that it is generally a code smell
+   *     to use {@link StarlarkSemantics#DEFAULT} if the application permits customizing the
+   *     semantics (e.g. via command line flags). Usually, all Starlark evaluation contexts within
+   *     the same application would use the same {@code StarlarkSemantics} instance.
    */
   public StarlarkThread(Mutability mu, StarlarkSemantics semantics) {
     Preconditions.checkArgument(!mu.isFrozen());

--- a/libstarlark/src/main/java/net/starlark/java/eval/StringModule.java
+++ b/libstarlark/src/main/java/net/starlark/java/eval/StringModule.java
@@ -66,7 +66,7 @@ final class StringModule implements StarlarkValue {
   private StringModule() {}
 
   // Returns s[start:stop:step], as if by Sequence.getSlice.
-  static String slice(String s, int start, int stop, int step) {
+  static String slice(String s, int start, int stop, int step) throws EvalException {
     RangeList indices = new RangeList(start, stop, step);
     int n = indices.size();
     if (n == 0) {
@@ -151,7 +151,8 @@ final class StringModule implements StarlarkValue {
     for (Object item : items) {
       if (!(item instanceof String)) {
         throw Starlark.errorf(
-            "expected string for sequence element %d, got '%s'", i, Starlark.type(item));
+            "expected string for sequence element %d, got '%s' of type %s",
+            i, Starlark.str(item), Starlark.type(item));
       }
       i++;
     }
@@ -948,16 +949,15 @@ final class StringModule implements StarlarkValue {
   @StarlarkMethod(
       name = "format",
       doc =
-          "Perform string interpolation. Format strings contain replacement fields "
-              + "surrounded by curly braces <code>{}</code>. Anything that is not contained "
-              + "in braces is considered literal text, which is copied unchanged to the output."
-              + "If you need to include a brace character in the literal text, it can be "
-              + "escaped by doubling: <code>{{</code> and <code>}}</code>"
-              + "A replacement field can be either a name, a number, or empty. Values are "
-              + "converted to strings using the <a href=\"globals.html#str\">str</a> function."
-              + "<pre class=\"language-python\">"
-              + "# Access in order:\n"
-              + "\"{} < {}\".format(4, 5) == \"4 < 5\"\n"
+          "Perform string interpolation. Format strings contain replacement fields surrounded by"
+              + " curly braces <code>&#123;&#125;</code>. Anything that is not contained in braces"
+              + " is considered literal text, which is copied unchanged to the output.If you need"
+              + " to include a brace character in the literal text, it can be escaped by doubling:"
+              + " <code>&#123;&#123;</code> and <code>&#125;&#125;</code>A replacement field can be"
+              + " either a name, a number, or empty. Values are converted to strings using the <a"
+              + " href=\"globals.html#str\">str</a> function.<pre class=\"language-python\">#"
+              + " Access in order:\n"
+              + "\"&#123;&#125; < &#123;&#125;\".format(4, 5) == \"4 < 5\"\n"
               + "# Access by position:\n"
               + "\"{1}, {0}\".format(2, 1) == \"1, 2\"\n"
               + "# Access by name:\n"
@@ -1021,5 +1021,37 @@ final class StringModule implements StarlarkValue {
   // Computes str.substring(start, end).startsWith(prefix) without allocation.
   private static boolean substringStartsWith(String str, int start, int end, String prefix) {
     return start + prefix.length() <= end && str.startsWith(prefix, start);
+  }
+
+  @StarlarkMethod(
+      name = "removeprefix",
+      doc =
+          "If the string starts with <code>prefix</code>, returns a new string with the prefix "
+              + "removed. Otherwise, returns the string.",
+      parameters = {
+        @Param(name = "self", doc = "This string."),
+        @Param(name = "prefix", doc = "The prefix to remove if present."),
+      })
+  public String removePrefix(String self, String prefix) {
+    if (self.startsWith(prefix)) {
+      return self.substring(prefix.length());
+    }
+    return self;
+  }
+
+  @StarlarkMethod(
+      name = "removesuffix",
+      doc =
+          "If the string ends with <code>suffix</code>, returns a new string with the suffix "
+              + "removed. Otherwise, returns the string.",
+      parameters = {
+        @Param(name = "self", doc = "This string."),
+        @Param(name = "suffix", doc = "The suffix to remove if present."),
+      })
+  public String removeSuffix(String self, String suffix) {
+    if (self.endsWith(suffix)) {
+      return self.substring(0, self.length() - suffix.length());
+    }
+    return self;
   }
 }

--- a/libstarlark/src/main/java/net/starlark/java/eval/Tuple.java
+++ b/libstarlark/src/main/java/net/starlark/java/eval/Tuple.java
@@ -226,7 +226,7 @@ public final class Tuple extends AbstractList<Object>
   }
 
   @Override
-  public Tuple getSlice(Mutability mu, int start, int stop, int step) {
+  public Tuple getSlice(Mutability mu, int start, int stop, int step) throws EvalException {
     RangeList indices = new RangeList(start, stop, step);
     int n = indices.size();
     if (step == 1) { // common case

--- a/libstarlark/src/main/java/net/starlark/java/lib/json/Json.java
+++ b/libstarlark/src/main/java/net/starlark/java/lib/json/Json.java
@@ -584,7 +584,7 @@ public final class Json implements StarlarkValue {
               + "The function accepts one required positional parameter, the JSON string,\n"
               + "and two optional keyword-only string parameters, prefix and indent,\n"
               + "that specify a prefix of each new line, and the unit of indentation.\n"
-              + "If the input is not valid, the funtion may fail or return invalid output.\n",
+              + "If the input is not valid, the function may fail or return invalid output.\n",
       parameters = {
         @Param(name = "s"),
         @Param(name = "prefix", positional = false, named = true, defaultValue = "''"),

--- a/libstarlark/src/main/java/net/starlark/java/syntax/Expression.java
+++ b/libstarlark/src/main/java/net/starlark/java/syntax/Expression.java
@@ -57,15 +57,9 @@ public abstract class Expression extends Node {
    */
   public abstract Kind kind();
 
-  /** Parses an expression with the default options. */
-  public static Expression parse(ParserInput input) throws SyntaxError.Exception {
-    return parse(input, FileOptions.DEFAULT);
-  }
-
   /** Parses an expression. */
-  public static Expression parse(ParserInput input, FileOptions options)
-      throws SyntaxError.Exception {
-    return Parser.parseExpression(input, options);
+  public static Expression parse(ParserInput input) throws SyntaxError.Exception {
+    return Parser.parseExpression(input);
   }
 
 }

--- a/libstarlark/src/main/java/net/starlark/java/syntax/FileOptions.java
+++ b/libstarlark/src/main/java/net/starlark/java/syntax/FileOptions.java
@@ -41,15 +41,6 @@ public abstract class FileOptions {
   /** The default options for Starlark static processing. New clients should use these defaults. */
   public static final FileOptions DEFAULT = builder().build();
 
-  // Options are presented in phase order: scanner, parser, resolver, compiler.
-
-  // --- scanner options ---
-
-  /** Disallow ineffective escape sequences such as {@code \a} when scanning string literals. */
-  public abstract boolean restrictStringEscapes();
-
-  // --- resolver options ---
-
   /**
    * During resolution, permit load statements to access private names such as {@code _x}. <br>
    * (Required for continued support of Bazel "WORKSPACE.resolved" files.)
@@ -82,7 +73,6 @@ public abstract class FileOptions {
   public static Builder builder() {
     // These are the DEFAULT values.
     return new AutoValue_FileOptions.Builder()
-        .restrictStringEscapes(true)
         .allowLoadPrivateSymbols(false)
         .allowToplevelRebinding(false)
         .loadBindsGlobally(false)
@@ -95,8 +85,6 @@ public abstract class FileOptions {
   @AutoValue.Builder
   public abstract static class Builder {
     // AutoValue why u make me say it 3 times?
-    public abstract Builder restrictStringEscapes(boolean value);
-
     public abstract Builder allowLoadPrivateSymbols(boolean value);
 
     public abstract Builder allowToplevelRebinding(boolean value);

--- a/libstarlark/src/main/java/net/starlark/java/syntax/Lexer.java
+++ b/libstarlark/src/main/java/net/starlark/java/syntax/Lexer.java
@@ -54,8 +54,6 @@ final class Lexer {
   private final char[] buffer;
   private int pos;
 
-  private final FileOptions options;
-
   // The stack of enclosing indentation levels in spaces.
   // The first (outermost) element is always zero.
   private final Stack<Integer> indentStack = new Stack<>();
@@ -89,13 +87,12 @@ final class Lexer {
           .put('^', TokenKind.CARET_EQUALS)
           .put('&', TokenKind.AMPERSAND_EQUALS)
           .put('|', TokenKind.PIPE_EQUALS)
-          .build();
+          .buildOrThrow();
 
   // Constructs a lexer which tokenizes the parser input.
   // Errors are appended to errors.
-  Lexer(ParserInput input, FileOptions options, List<SyntaxError> errors) {
+  Lexer(ParserInput input, List<SyntaxError> errors) {
     this.locs = FileLocations.create(input.getContent(), input.getFile());
-    this.options = options;
     this.buffer = input.getContent();
     this.pos = 0;
     this.errors = errors;
@@ -368,7 +365,7 @@ final class Lexer {
                   setValue(literal.toString());
                   break;
                 }
-                literal.append((char)(octal & 0xff));
+                literal.append((char) (octal & 0xff));
                 break;
               }
             case 'a':
@@ -468,14 +465,7 @@ final class Lexer {
               break;
             default:
               // unknown char escape => "\literal"
-              if (options.restrictStringEscapes()) {
-                error(
-                    "invalid escape sequence: \\"
-                        + c
-                        + ". You can enable unknown escape sequences by passing the flag"
-                        + " --incompatible_restrict_string_escapes=false",
-                    pos - 1);
-              }
+              error("invalid escape sequence: \\" + c + ". Use '\\\\' to insert '\\'.", pos - 1);
               literal.append('\\');
               literal.append(c);
               break;

--- a/libstarlark/src/main/java/net/starlark/java/syntax/Location.java
+++ b/libstarlark/src/main/java/net/starlark/java/syntax/Location.java
@@ -15,7 +15,6 @@
 package net.starlark.java.syntax;
 
 import com.google.common.base.Preconditions;
-import java.io.Serializable;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -28,7 +27,7 @@ import javax.annotation.concurrent.Immutable;
  * file as a whole.
  */
 @Immutable
-public final class Location implements Serializable, Comparable<Location> {
+public final class Location implements Comparable<Location> {
 
   private final String file;
   private final int line;
@@ -88,7 +87,7 @@ public final class Location implements Serializable, Comparable<Location> {
 
   /** Returns a three-valued lexicographical comparison of two Locations. */
   @Override
-  public final int compareTo(Location that) {
+  public int compareTo(Location that) {
     int cmp = this.file().compareTo(that.file());
     if (cmp != 0) {
       return cmp;

--- a/libstarlark/src/main/java/net/starlark/java/syntax/Parser.java
+++ b/libstarlark/src/main/java/net/starlark/java/syntax/Parser.java
@@ -113,7 +113,7 @@ final class Parser {
           .put(TokenKind.PIPE_EQUALS, TokenKind.PIPE)
           .put(TokenKind.GREATER_GREATER_EQUALS, TokenKind.GREATER_GREATER)
           .put(TokenKind.LESS_LESS_EQUALS, TokenKind.LESS_LESS)
-          .build();
+          .buildOrThrow();
 
   /**
    * Highest precedence goes last. Based on:
@@ -171,9 +171,9 @@ final class Parser {
   }
 
   // Main entry point for parsing a file.
-  static ParseResult parseFile(ParserInput input, FileOptions options) {
+  static ParseResult parseFile(ParserInput input) {
     List<SyntaxError> errors = new ArrayList<>();
-    Lexer lexer = new Lexer(input, options, errors);
+    Lexer lexer = new Lexer(input, errors);
     Parser parser = new Parser(lexer, errors);
 
     StarlarkFile.ParseProfiler profiler = Parser.profiler;
@@ -207,10 +207,9 @@ final class Parser {
   }
 
   /** Parses an expression, possibly followed by newline tokens. */
-  static Expression parseExpression(ParserInput input, FileOptions options)
-      throws SyntaxError.Exception {
+  static Expression parseExpression(ParserInput input) throws SyntaxError.Exception {
     List<SyntaxError> errors = new ArrayList<>();
-    Lexer lexer = new Lexer(input, options, errors);
+    Lexer lexer = new Lexer(input, errors);
     Parser parser = new Parser(lexer, errors);
     Expression result = null;
     try {
@@ -989,7 +988,7 @@ final class Parser {
     return new LambdaExpression(locs, lambdaOffset, params, body);
   }
 
-  // parseTestNoCond parses a a single-component expression without
+  // parseTestNoCond parses a single-component expression without
   // consuming a trailing 'if expr else expr'.
   private Expression parseTestNoCond() {
     if (token.kind == TokenKind.LAMBDA) {

--- a/libstarlark/src/main/java/net/starlark/java/syntax/Program.java
+++ b/libstarlark/src/main/java/net/starlark/java/syntax/Program.java
@@ -13,6 +13,7 @@
 // limitations under the License.
 package net.starlark.java.syntax;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
 /**
@@ -28,6 +29,9 @@ public final class Program {
 
   private Program(
       Resolver.Function body, ImmutableList<String> loads, ImmutableList<Location> loadLocations) {
+    Preconditions.checkArgument(
+        loads.size() == loadLocations.size(), "each load must have a corresponding location");
+
     // TODO(adonovan): compile here.
     this.body = body;
     this.loads = loads;

--- a/libstarlark/src/main/java/net/starlark/java/syntax/StarlarkFile.java
+++ b/libstarlark/src/main/java/net/starlark/java/syntax/StarlarkFile.java
@@ -134,7 +134,7 @@ public final class StarlarkFile extends Node {
    * </pre>
    */
   public static StarlarkFile parse(ParserInput input, FileOptions options) {
-    Parser.ParseResult result = Parser.parseFile(input, options);
+    Parser.ParseResult result = Parser.parseFile(input);
     return new StarlarkFile(
         result.locs, result.statements, options, result.comments, result.errors);
   }

--- a/libstarlark/src/main/java/net/starlark/java/syntax/StringLiteral.java
+++ b/libstarlark/src/main/java/net/starlark/java/syntax/StringLiteral.java
@@ -81,7 +81,7 @@ public final class StringLiteral extends Expression {
     // independent of the Lexer, which should only validate string literals
     // but not unquote them. Clients (e.g. the compiler) can unquote on demand.
     ArrayList<SyntaxError> errors = new ArrayList<>();
-    Lexer lexer = new Lexer(ParserInput.fromLines(s), FileOptions.DEFAULT, errors);
+    Lexer lexer = new Lexer(ParserInput.fromLines(s), errors);
     lexer.nextToken();
     if (!errors.isEmpty()) {
       throw new IllegalArgumentException(errors.get(0).message());

--- a/libstarlark/src/test/java/net/starlark/java/eval/Benchmarks.java
+++ b/libstarlark/src/test/java/net/starlark/java/eval/Benchmarks.java
@@ -158,7 +158,7 @@ public final class Benchmarks {
       ImmutableMap.Builder<String, Object> predeclared = ImmutableMap.builder();
       predeclared.put("json", Json.INSTANCE);
 
-      Module module = Module.withPredeclared(semantics, predeclared.build());
+      Module module = Module.withPredeclared(semantics, predeclared.buildOrThrow());
       try (Mutability mu = Mutability.create("test")) {
         StarlarkThread thread = new StarlarkThread(mu, semantics);
         Starlark.execFile(input, FileOptions.DEFAULT, module, thread);

--- a/libstarlark/src/test/java/net/starlark/java/eval/CpuProfilerTest.java
+++ b/libstarlark/src/test/java/net/starlark/java/eval/CpuProfilerTest.java
@@ -45,7 +45,12 @@ public final class CpuProfilerTest {
     // Start writing profile to temporary file.
     File profile = java.io.File.createTempFile("pprof", ".gz", null);
     OutputStream prof = new FileOutputStream(profile);
-    Starlark.startCpuProfile(prof, Duration.ofMillis(10));
+    boolean success = Starlark.startCpuProfile(prof, Duration.ofMillis(10));
+
+    if (!success) {
+      System.err.println("Failed to start cpu profiler");
+      System.exit(1);
+    }
 
     // This program consumes about 3s of CPU.
     ParserInput input =

--- a/libstarlark/src/test/java/net/starlark/java/eval/EvalTests.java
+++ b/libstarlark/src/test/java/net/starlark/java/eval/EvalTests.java
@@ -22,6 +22,7 @@ import org.junit.runners.Suite;
   EvaluationTest.class,
   EvalUtilsTest.class,
   FunctionTest.class,
+  ImmutableKeyTrackingDictTest.class,
   MethodLibraryTest.class,
   MutabilityTest.class,
   PrinterTest.class,

--- a/libstarlark/src/test/java/net/starlark/java/eval/EvaluationTestCase.java
+++ b/libstarlark/src/test/java/net/starlark/java/eval/EvaluationTestCase.java
@@ -97,7 +97,7 @@ class EvaluationTestCase {
     if (this.module == null) {
       ImmutableMap.Builder<String, Object> predeclared = ImmutableMap.builder();
       newModuleHook(predeclared); // see StarlarkFlagGuardingTest
-      this.module = Module.withPredeclared(semantics, predeclared.build());
+      this.module = Module.withPredeclared(semantics, predeclared.buildOrThrow());
     }
     return this.module;
   }

--- a/libstarlark/src/test/java/net/starlark/java/eval/Examples.java
+++ b/libstarlark/src/test/java/net/starlark/java/eval/Examples.java
@@ -114,7 +114,7 @@ final class Examples {
     ImmutableMap.Builder<String, Object> env = ImmutableMap.builder();
     env.put("zero", 0);
     Starlark.addMethods(env, new MyFunctions(), StarlarkSemantics.DEFAULT); // adds 'square'
-    return env.build();
+    return env.buildOrThrow();
   }
 
   /**

--- a/libstarlark/src/test/java/net/starlark/java/eval/ImmutableKeyTrackingDictTest.java
+++ b/libstarlark/src/test/java/net/starlark/java/eval/ImmutableKeyTrackingDictTest.java
@@ -1,0 +1,108 @@
+// Copyright 2021 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package net.starlark.java.eval;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import java.util.Map;
+import net.starlark.java.eval.Dict.ImmutableKeyTrackingDict;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link ImmutableKeyTrackingDict}. */
+@RunWith(JUnit4.class)
+public final class ImmutableKeyTrackingDictTest {
+
+  private final ImmutableKeyTrackingDict<String, StarlarkInt> dict =
+      Dict.<String, StarlarkInt>builder()
+          .put("a", StarlarkInt.of(1))
+          .put("b", StarlarkInt.of(2))
+          .put("c", StarlarkInt.of(3))
+          .put("d", StarlarkInt.of(4))
+          .buildImmutableWithKeyTracking();
+
+  @Test
+  public void isImmutable() throws Exception {
+    assertThat(dict.mutability()).isEqualTo(Mutability.IMMUTABLE);
+    assertThrows(EvalException.class, () -> dict.putEntry("e", StarlarkInt.of(5)));
+    assertThat(dict.containsKey("e")).isFalse();
+    assertThat(dict.getAccessedKeys()).isEmpty();
+  }
+
+  @Test
+  public void containsKey_tracksPresentKeys() {
+    assertThat(dict.containsKey("a")).isTrue();
+    assertThat(dict.containsKey("b")).isTrue();
+    assertThat(dict.getAccessedKeys()).containsExactly("a", "b");
+  }
+
+  @Test
+  public void containsKey_ignoresAbsentKeys() {
+    assertThat(dict.containsKey("absent")).isFalse();
+    assertThat(dict.containsKey(new Object())).isFalse();
+    assertThat(dict.getAccessedKeys()).isEmpty();
+  }
+
+  @Test
+  public void get_tracksPresentKeys() {
+    assertThat(dict.get("a")).isEqualTo(StarlarkInt.of(1));
+    assertThat(dict.get("b")).isEqualTo(StarlarkInt.of(2));
+    assertThat(dict.getAccessedKeys()).containsExactly("a", "b");
+  }
+
+  @Test
+  public void get_ignoresAbsentKeys() {
+    assertThat(dict.get("absent")).isNull();
+    assertThat(dict.get(new Object())).isNull();
+    assertThat(dict.getAccessedKeys()).isEmpty();
+  }
+
+  @Test
+  public void keySet_reportsAllKeys() {
+    assertThat(dict.keySet()).containsExactly("a", "b", "c", "d").inOrder();
+    assertThat(dict.getAccessedKeys()).isEqualTo(dict.keySet());
+  }
+
+  @Test
+  public void entrySet_reportsAllKeys() {
+    assertThat(dict.entrySet()).hasSize(4);
+    assertThat(dict.getAccessedKeys()).isEqualTo(dict.keySet());
+  }
+
+  @Test
+  public void iteration_reportsAllKeys() {
+    for (String key : dict) {
+      assertThat(key).isAnyOf("a", "b", "c", "d");
+    }
+    assertThat(dict.getAccessedKeys()).isEqualTo(dict.keySet());
+  }
+
+  @Test
+  public void repr_reportsAllKeys() {
+    StringBuilder sb = new StringBuilder();
+    dict.repr(new Printer(sb));
+    assertThat(sb.toString()).isEqualTo("{\"a\": 1, \"b\": 2, \"c\": 3, \"d\": 4}");
+    assertThat(dict.getAccessedKeys()).isEqualTo(dict.keySet());
+  }
+
+  @Test
+  public void mutableCopy_reportsAllKeys() {
+    Map<String, StarlarkInt> copy = Dict.copyOf(Mutability.create("mutable"), dict);
+    assertThat(copy).isNotSameInstanceAs(dict);
+    assertThat(dict.getAccessedKeys()).isEqualTo(dict.keySet());
+  }
+}

--- a/libstarlark/src/test/java/net/starlark/java/eval/MethodLibraryTest.java
+++ b/libstarlark/src/test/java/net/starlark/java/eval/MethodLibraryTest.java
@@ -760,6 +760,6 @@ public final class MethodLibraryTest {
   public void testStringJoinRequiresStrings() throws Exception {
     ev.new Scenario()
         .testIfErrorContains(
-            "expected string for sequence element 1, got 'int'", "', '.join(['foo', 2])");
+            "expected string for sequence element 1, got '2' of type int", "', '.join(['foo', 2])");
   }
 }

--- a/libstarlark/src/test/java/net/starlark/java/eval/ScriptTest.java
+++ b/libstarlark/src/test/java/net/starlark/java/eval/ScriptTest.java
@@ -229,7 +229,7 @@ public final class ScriptTest {
         predeclared.put("json", Json.INSTANCE);
 
         StarlarkSemantics semantics = StarlarkSemantics.DEFAULT;
-        Module module = Module.withPredeclared(semantics, predeclared.build());
+        Module module = Module.withPredeclared(semantics, predeclared.buildOrThrow());
         try (Mutability mu = Mutability.createAllowingShallowFreeze("test")) {
           StarlarkThread thread = new StarlarkThread(mu, semantics);
           thread.setThreadLocal(Reporter.class, ScriptTest::reportError);

--- a/libstarlark/src/test/java/net/starlark/java/eval/StarlarkEvaluationTest.java
+++ b/libstarlark/src/test/java/net/starlark/java/eval/StarlarkEvaluationTest.java
@@ -26,7 +26,7 @@ import com.google.errorprone.annotations.DoNotCall;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-
+import javax.annotation.Nullable;
 import net.starlark.java.annot.Param;
 import net.starlark.java.annot.ParamType;
 import net.starlark.java.annot.StarlarkBuiltin;
@@ -34,12 +34,9 @@ import net.starlark.java.annot.StarlarkMethod;
 import net.starlark.java.syntax.FileOptions;
 import net.starlark.java.syntax.ParserInput;
 import net.starlark.java.syntax.SyntaxError;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-
-import javax.annotation.Nullable;
 
 /** Tests of Starlark evaluation. */
 // There is no clear distinction between this and EvaluationTest.
@@ -366,7 +363,7 @@ public final class StarlarkEvaluationTest {
         Object v = Starlark.getattr(thread.mutability(), thread.getSemantics(), this, name, null);
         builder.put(name, v);
       }
-      return new SimpleStruct(builder.build());
+      return new SimpleStruct(builder.buildOrThrow());
     }
 
     @StarlarkMethod(

--- a/libstarlark/src/test/java/net/starlark/java/eval/StarlarkMutableTest.java
+++ b/libstarlark/src/test/java/net/starlark/java/eval/StarlarkMutableTest.java
@@ -125,19 +125,21 @@ public final class StarlarkMutableTest {
 
     // builder reuse and mutability
     Dict.Builder<String, String> builder = Dict.<String, String>builder().putAll(dict1);
+    builder.put("three", "33"); // overwrites previous entry
     Mutability mu = Mutability.create("test");
     Dict<String, String> dict3 = builder.build(mu);
-    dict3.putEntry("four", "4");
+    dict3.putEntry("four", "4"); // new entry
+    dict3.putEntry("two", "22"); // overwrites previous entry
     assertThat(dict3.toString())
-        .isEqualTo("{\"one\": \"1\", \"two\": \"2\", \"three\": \"3\", \"four\": \"4\"}");
+        .isEqualTo("{\"one\": \"1\", \"two\": \"22\", \"three\": \"33\", \"four\": \"4\"}");
     mu.close();
     assertThrows(EvalException.class, dict1::clearEntries); // frozen
     builder.put("five", "5"); // keep building
     Dict<String, String> dict4 = builder.buildImmutable();
     assertThat(dict4.toString())
-        .isEqualTo("{\"one\": \"1\", \"two\": \"2\", \"three\": \"3\", \"five\": \"5\"}");
+        .isEqualTo("{\"one\": \"1\", \"two\": \"2\", \"three\": \"33\", \"five\": \"5\"}");
     assertThat(dict3.toString())
         .isEqualTo(
-            "{\"one\": \"1\", \"two\": \"2\", \"three\": \"3\", \"four\": \"4\"}"); // unchanged
+            "{\"one\": \"1\", \"two\": \"22\", \"three\": \"33\", \"four\": \"4\"}"); // unchanged
   }
 }

--- a/libstarlark/src/test/java/net/starlark/java/eval/testdata/dict.star
+++ b/libstarlark/src/test/java/net/starlark/java/eval/testdata/dict.star
@@ -75,6 +75,63 @@ d.update((["f", 0],), f = 6)
 expected = {"a": 1, "b": 2, "c": 3, "d": 4, "e": 5, "f": 6}
 assert_eq(d, expected)
 
+# dict union operator |
+
+empty_dict = dict()
+dict_with_a_b = dict(a=1, b=[1, 2])
+dict_with_b = dict(b=[1, 2])
+dict_with_other_b = dict(b=[3, 4])
+
+assert_eq(empty_dict | dict_with_a_b, dict_with_a_b)
+# Verify iteration order.
+assert_eq((empty_dict | dict_with_a_b).items(), dict_with_a_b.items())
+assert_eq(dict_with_a_b | empty_dict, dict_with_a_b)
+assert_eq((dict_with_a_b | empty_dict).items(), dict_with_a_b.items())
+assert_eq(dict_with_b | dict_with_a_b, dict_with_a_b)
+assert_eq((dict_with_b | dict_with_a_b).items(), dict(b=[1, 2], a=1).items())
+assert_eq(dict_with_a_b | dict_with_b, dict_with_a_b)
+assert_eq((dict_with_a_b | dict_with_b).items(), dict_with_a_b.items())
+assert_eq(dict_with_b | dict_with_other_b, dict_with_other_b)
+assert_eq((dict_with_b | dict_with_other_b).items(), dict_with_other_b.items())
+assert_eq(dict_with_other_b | dict_with_b, dict_with_b)
+assert_eq((dict_with_other_b | dict_with_b).items(), dict_with_b.items())
+
+assert_eq(empty_dict, dict())
+assert_eq(dict_with_b, dict(b=[1,2]))
+
+assert_fails(lambda: dict() | [], "unsupported binary operation")
+
+# dict union assignment operator |=
+
+def test_dict_union_assignment():
+    empty_dict = dict()
+    empty_dict |= {"a": 1}
+    empty_dict |= {"b": 2}
+    empty_dict |= {"c": "3", 7: 4}
+    empty_dict |= {"b": "5", "e": 6}
+    expected_1 = {"a": 1, "b": "5", "c": "3", 7: 4, "e": 6}
+    assert_eq(empty_dict, expected_1)
+    assert_eq(empty_dict.items(), expected_1.items())
+
+    dict_a = {8: 1, "b": 2}
+    dict_b = {"b": 1, "c": 6}
+    dict_c = {"d": 7}
+    dict_tuple = {(5, "a"): ("c", 8)}
+    dict_a |= dict_b
+    dict_c |= dict_a
+    dict_c |= dict_tuple
+    expected_2 = {"d": 7, 8: 1, "b": 1, "c": 6, (5, "a"): ("c", 8)}
+    assert_eq(dict_c, expected_2)
+    assert_eq(dict_c.items(), expected_2.items())
+    assert_eq(dict_b, {"b": 1, "c": 6})
+
+test_dict_union_assignment()
+
+def dict_union_assignment_type_mismatch():
+    some_dict = dict()
+    some_dict |= []
+
+assert_fails(dict_union_assignment_type_mismatch, "unsupported binary operation")
 
 # creation with repeated keys
 

--- a/libstarlark/src/test/java/net/starlark/java/eval/testdata/range.star
+++ b/libstarlark/src/test/java/net/starlark/java/eval/testdata/range.star
@@ -13,3 +13,37 @@ assert_eq(list(range(5, 0, -1)), [5, 4, 3, 2, 1])
 assert_eq(list(range(5, 0, -10)), [5])
 assert_eq(list(range(0, -3, -2)), [0, -2])
 assert_fails(lambda: range(2, 3, 0), "step cannot be 0")
+
+maxint = (1 << 31) - 1
+minint = (-1) << 31
+
+assert_eq(maxint, len(range(0, maxint)))
+assert_eq(maxint, len(range(minint, maxint - 1, 2)))
+assert_fails(lambda: range(-1, maxint), "len\\(range\\(-1, 2147483647\\)\\) exceeds signed 32-bit range")
+assert_fails(lambda: range(minint - 1, minint), "got -2147483649 for start, want value in signed 32-bit range")
+assert_fails(lambda: range(maxint, maxint + 1), "got 2147483648 for stop, want value in signed 32-bit range")
+assert_fails(lambda: range(-1, maxint, maxint + 1), "got 2147483648 for step, want value in signed 32-bit range")
+
+# Correct behavior when first out-of-bounds step would not be in 32-bit range
+assert_eq(len(range(1, 2, maxint)), 1)
+assert_eq(list(range(1, 2, maxint)), [1])
+assert_eq(len(range(-1, -2, minint)), 1)
+assert_eq(list(range(-1, -2, minint)), [-1])
+assert_eq(len(range(minint, maxint, maxint)), 3)
+assert_eq(list(range(minint, maxint, maxint)), [minint, -1, maxint - 1])
+assert_eq(len(range(maxint, minint, minint)), 2)
+assert_eq(list(range(maxint, minint, minint)), [maxint, -1])
+
+# Range subslices
+assert_eq(list(range(0, 10, 2)[0:]), [0, 2, 4, 6, 8])
+assert_eq(list(range(0, 10, 2)[1:5]), [2, 4, 6, 8])
+assert_eq(list(range(0, 10, 2)[1:5:2]), [2, 6])
+assert_eq(list(range(0, 10, 2)[1:5:maxint]), [2])
+assert_eq(list(range(0, 10, 2)[4:1:minint]), [8])
+assert_eq(list(range(minint, maxint, maxint)[0:2:2]), [minint])
+assert_eq(list(range(-1, -10, -2)[0:]), [-1, -3, -5, -7, -9])
+assert_eq(list(range(-1, -10, -2)[1:5]), [-3, -5, -7, -9])
+assert_eq(list(range(-1, -10, -2)[1:5:2]), [-3, -7])
+assert_eq(list(range(-1, -10, -2)[1:5:maxint]), [-3])
+assert_eq(list(range(-1, -10, -2)[4:1:minint]), [-9])
+assert_eq(list(range(maxint, minint, minint)[0:2:2]), [maxint])

--- a/libstarlark/src/test/java/net/starlark/java/eval/testdata/string_misc.star
+++ b/libstarlark/src/test/java/net/starlark/java/eval/testdata/string_misc.star
@@ -177,3 +177,35 @@ assert_eq("abc" * 0, "")
 assert_eq("abc" * -1, "")
 assert_fails(lambda: "abc" * (1 << 35), "got 34359738368 for repeat, want value in signed 32-bit range")
 assert_fails(lambda: "abc" * (1 << 30), "excessive repeat \\(3 \\* 1073741824 characters\\)")
+
+# removeprefix
+assert_eq("Apricot".removeprefix("Apr"), "icot")
+assert_eq("Apricot".removeprefix("apr"), "Apricot")
+assert_eq("Apricot".removeprefix("A"), "pricot")
+assert_eq("a".removeprefix(""), "a")
+assert_eq("".removeprefix(""), "")
+assert_eq("".removeprefix("a"), "")
+assert_eq("Apricot".removeprefix("pr"), "Apricot")
+assert_eq("AprApricot".removeprefix("Apr"), "Apricot")
+def removeprefix_self_unmodified():
+    original_string = "Apricot"
+    assert_eq(original_string.removeprefix("Apr"), "icot")
+    assert_eq(original_string, "Apricot")
+removeprefix_self_unmodified()
+assert_fails(lambda: "1234".removeprefix(1), "got value of type 'int', want 'string")
+
+# removesuffix
+assert_eq("Apricot".removesuffix("cot"), "Apri")
+assert_eq("Apricot".removesuffix("Cot"), "Apricot")
+assert_eq("Apricot".removesuffix("t"), "Aprico")
+assert_eq("a".removesuffix(""), "a")
+assert_eq("".removesuffix(""), "")
+assert_eq("".removesuffix("a"), "")
+assert_eq("Apricot".removesuffix("co"), "Apricot")
+assert_eq("Apricotcot".removesuffix("cot"), "Apricot")
+def removesuffix_self_unmodified():
+    original_string = "Apricot"
+    assert_eq(original_string.removesuffix("cot"), "Apri")
+    assert_eq(original_string, "Apricot")
+removesuffix_self_unmodified()
+assert_fails(lambda: "1234".removesuffix(4), "got value of type 'int', want 'string")

--- a/libstarlark/src/test/java/net/starlark/java/syntax/LexerTest.java
+++ b/libstarlark/src/test/java/net/starlark/java/syntax/LexerTest.java
@@ -20,7 +20,6 @@ import com.google.common.base.Joiner;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -42,7 +41,7 @@ public class LexerTest {
   private Lexer createLexer(String input) {
     ParserInput inputSource = ParserInput.fromString(input, "");
     errors.clear();
-    return new Lexer(inputSource, FileOptions.DEFAULT, errors);
+    return new Lexer(inputSource, errors);
   }
 
   private static class Token {
@@ -354,19 +353,21 @@ public class LexerTest {
 
   @Test
   public void testStringEscapes() throws Exception {
-    check("'a\\tb\\nc\\rd'", "STRING(a\tb\nc\rd) NEWLINE EOF"); // \t \r \n
+    check(
+        "'a\\tb\\nc\\rd\\fe\\vf\\ag\\bh'",
+        "STRING(a\tb\nc\rd\fe\u000bf\u0007g\bh) NEWLINE EOF"); // \t \r \n \f \v \a \b
     checkErrors(
         "'x\\hx'", //
         "STRING(x\\hx) NEWLINE EOF",
-        "   ^ invalid escape sequence: \\h. You can enable unknown escape sequences by passing the"
-            + " flag --incompatible_restrict_string_escapes=false");
+        "   ^ invalid escape sequence: \\h. Use '\\\\' to insert '\\'.");
     checkErrors(
         "'\\$$'", //
         "STRING(\\$$) NEWLINE EOF",
-        "  ^ invalid escape sequence: \\$. You can enable unknown escape sequences by passing the"
-            + " flag --incompatible_restrict_string_escapes=false");
+        "  ^ invalid escape sequence: \\$. Use '\\\\' to insert '\\'.");
     check("'a\\\nb'", "STRING(ab) NEWLINE EOF"); // escape end of line
-    checkErrors("\"ab\\ucd\"", "STRING(abcd) NEWLINE EOF", "    ^ truncated escape sequence \\ucd");
+    checkErrors("\"ab\\ucd\"",
+      "STRING(abcd) NEWLINE EOF",
+      "    ^ truncated escape sequence \\ucd");
 
     // hex escapes
     check("'\\x00\\x20\\x09\\x41\\x7e\\x7f'", "STRING(\u0000 \tA~\u007F) NEWLINE EOF"); // DEL is non-printable
@@ -394,6 +395,7 @@ public class LexerTest {
     check("'\\U0001F63F'", "STRING(\uD83D\uDE3F) NEWLINE EOF");
     checkErrors("'\\U0000dc00'", "STRING(0000dc00) NEWLINE EOF", "  ^ invalid Unicode code point U+DC00"); // surrogate
   }
+
 
   @Test
   public void testEscapedCrlfInString() throws Exception {
@@ -691,10 +693,7 @@ public class LexerTest {
     assertUnquoteError("'", "unclosed string literal");
     assertUnquoteError("\"", "unclosed string literal");
     assertUnquoteError("'abc", "unclosed string literal");
-    assertUnquoteError(
-        "'\\g'",
-        "invalid escape sequence: \\g. You can enable unknown escape sequences by passing the flag"
-            + " --incompatible_restrict_string_escapes=false"); // this temporary hint is a lie
+    assertUnquoteError("'\\g'", "invalid escape sequence: \\g. Use '\\\\' to insert '\\'.");
   }
 
   private static void assertUnquoteEquals(String literal, String value) {

--- a/libstarlark/src/test/java/net/starlark/java/syntax/NodePrinterTest.java
+++ b/libstarlark/src/test/java/net/starlark/java/syntax/NodePrinterTest.java
@@ -396,7 +396,7 @@ public final class NodePrinterTest {
         ParserInput.fromLines(
             "# foo", //
             "expr # bar");
-    Parser.ParseResult r = Parser.parseFile(input, FileOptions.DEFAULT);
+    Parser.ParseResult r = Parser.parseFile(input);
     Comment c0 = r.comments.get(0);
     assertIndentedPrettyMatches(c0, "  # foo");
     assertTostringMatches(c0, "# foo");


### PR DESCRIPTION
# Update libstarlark to tip of bazel

Update libstarlark to tip of bazel's [master](036564590d91ba445d3683abae8a7885c1d32d52) branch

## Description of changes in release / Impact of release:

- Document the tradeoffs of the `Dict` memory optimization opportunity in a code comment. ~> [#036564590](bazelbuild/bazel@036564590)
- Automated rollback of commit 5576979669383c2380c11b59beaa2f8263ff1f56. ~> [#a42128856](bazelbuild/bazel@a42128856)
- Have `Dict#contents` switch to an `ImmutableMap` when the `Dict` is frozen. ~> [#557697966](bazelbuild/bazel@557697966)
- Bazel DocGen (3/3): Update links in code comments. ~> [#2ee79b894](bazelbuild/bazel@2ee79b894)
- Fix up broken javadoc in `Mutability.java`. ~> [#a92487ee9](bazelbuild/bazel@a92487ee9)
- Two minor memory improvements to `Dict`. ~> [#24ec91093](bazelbuild/bazel@24ec91093)
- Starlark: Add dict union operators | and |= ~> [#b1deea40a](bazelbuild/bazel@b1deea40a)
- Add removeprefix/removesuffix to Starlark strings ~> [#0b09e9e01](bazelbuild/bazel@0b09e9e01)
- Automatic code cleanup. ~> [#2fc3d3ffb](bazelbuild/bazel@2fc3d3ffb)
- Optimise parameter passing to Starlark calls. ~> [#af5f52202](bazelbuild/bazel@af5f52202)
- Starlark: fix integer overflows in sizing, iteration, and subslicing of RangeList ~> [#1e85cb3b4](bazelbuild/bazel@1e85cb3b4)
- Starlark: fail at range construction time if len exceeds maxint ~> [#14e4cc97a](bazelbuild/bazel@14e4cc97a)
- Starlark: assert Program.loads.size() == Program.loadLocations.size() ~> [#7e146dd68](bazelbuild/bazel@7e146dd68)
- Starlark: faster dict.keys ~> [#7d8d55ac8](bazelbuild/bazel@7d8d55ac8)
- str.join: Append `str`ed element to error message ~> [#98dab462a](bazelbuild/bazel@98dab462a)
- Add Starlark mechanism for default_copts and defaults_hdrs_check ~> [#ee38b6302](bazelbuild/bazel@ee38b6302)
- Allow \a \b \f \v escape sequences in Starlark. ~> [#d0fde1345](bazelbuild/bazel@d0fde1345)
- Add advice about use of StarlarkSemantics.DEFAULT ~> [#47ad531f1](bazelbuild/bazel@47ad531f1)
- Fix typos ~> [#1e85125ce](bazelbuild/bazel@1e85125ce)
- Delete unused native Java serialization code. ~> [#5149408a6](bazelbuild/bazel@5149408a6)
- Ignore --starlark_cpu_profile on Windows. ~> [#2255ce416](bazelbuild/bazel@2255ce416)
- Migrate from `Strings#repeat(String, int)` to `String#repeat(int)`. ~> [#c37bd0d02](bazelbuild/bazel@c37bd0d02)
- Remove the flag --incompatible_restrict_string_escapes ~> [#21b4b1a48](bazelbuild/bazel@21b4b1a48)
- Make various decimal formatting independent of Java locale. ~> [#e4f1c8361](bazelbuild/bazel@e4f1c8361)
- Track variables accessed through `ctx.var` and report them as required. ~> [#09e3c53d3](bazelbuild/bazel@09e3c53d3)
- Fix invalid javadoc ~> [#d21b4d049](bazelbuild/bazel@d21b4d049)
- Add some documentation on StarlarkMethod about exception handling ~> [#7c7f50e40](bazelbuild/bazel@7c7f50e40)

commit-id:601103aa

## Risks of this release

### Is this a breaking change?
- [ ] Yes
- [x] No

### Is there a way to disable the change?
- [x] Use previous release
- [ ] Use a feature flag
- [ ] No
