### PR TITLE
Allows setting of environment variables in ModuleSupplier so that we can control instantiation of builtins.

### DIFF
--- a/larky/pom.xml
+++ b/larky/pom.xml
@@ -44,11 +44,11 @@
         <google.re2j.version>1.6</google.re2j.version>
         <google.truth.version>1.1.3</google.truth.version>
         <javax.xml.bind.jaxb-api.version>2.3.1</javax.xml.bind.jaxb-api.version>
-        <org.bouncycastle.version>1.70</org.bouncycastle.version>
+        <org.bouncycastle.version>1.71</org.bouncycastle.version>
         <org.conscrypt.version>2.5.2</org.conscrypt.version>
         <org.jetbrains.annotations.version>22.0.0</org.jetbrains.annotations.version>
         <org.junit.version>4.13.2</org.junit.version>
-        <org.mockito.version>3.12.4</org.mockito.version>
+        <org.mockito.version>4.4.0</org.mockito.version>
         <org.projectlombok.version>1.18.22</org.projectlombok.version>
         <org.slf4j.version>1.7.32</org.slf4j.version>
         <os-maven-plugin.version>1.7.0</os-maven-plugin.version>
@@ -103,9 +103,9 @@
         </dependency>
 
         <dependency>
-           <groupId>org.apache.commons</groupId>
-           <artifactId>commons-text</artifactId>
-           <version>${apache.commons-text.version}</version>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>${apache.commons-text.version}</version>
         </dependency>
 
         <!-- cryptography -->
@@ -113,6 +113,18 @@
             <groupId>com.google.crypto.tink</groupId>
             <artifactId>tink</artifactId>
             <version>${google.crypto.tink}</version>
+            <exclusions>
+                  <!-- https://cwe.mitre.org/data/definitions/502.html -->
+                  <exclusion>
+                      <groupId>com.google.code.gson</groupId>
+                      <artifactId>gson</artifactId>
+                  </exclusion>
+                  <!-- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-22569 -->
+                  <exclusion>
+                      <groupId>com.google.protobuf</groupId>
+                      <artifactId>protobuf-java</artifactId>
+                  </exclusion>
+              </exclusions>
         </dependency>
 
         <!-- bouncy castle differences are:
@@ -194,37 +206,20 @@
 
         <!-- test -->
         <dependency>
-              <groupId>org.junit.jupiter</groupId>
-              <artifactId>junit-jupiter-api</artifactId>
-              <version>5.8.1</version>
-              <scope>test</scope>
-          </dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.8.2</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.junit.vintage</groupId>
             <artifactId>junit-vintage-engine</artifactId>
-            <version>5.8.1</version>
+            <version>5.8.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
 
     <build>
-        <resources>
-            <resource>
-                <directory>src/main/java</directory>
-            </resource>
-            <resource>
-                <directory>src/main/resources</directory>
-            </resource>
-            <resource>
-                <directory>src/test/java</directory>
-            </resource>
-            <resource>
-                <directory>src/test/resources</directory>
-                <excludes>
-                    <exclude>META-INF/services/*</exclude>
-                </excludes>
-            </resource>
-        </resources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/larky/src/test/java/com/verygood/security/larky/LarkyQuickTests.java
+++ b/larky/src/test/java/com/verygood/security/larky/LarkyQuickTests.java
@@ -3,22 +3,6 @@ package com.verygood.security.larky;
 import static com.verygood.security.larky.ModuleSupplier.CORE_MODULES;
 
 import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableSet;
-
-import com.verygood.security.larky.console.testing.TestingConsole;
-import com.verygood.security.larky.modules.testing.AssertionsModule;
-import com.verygood.security.larky.modules.testing.UnittestModule;
-import com.verygood.security.larky.parser.LarkyScript;
-import com.verygood.security.larky.parser.PathBasedStarFile;
-
-import net.starlark.java.eval.EvalException;
-import net.starlark.java.eval.StarlarkValue;
-
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DynamicTest;
-import org.junit.jupiter.api.TestFactory;
-
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -29,6 +13,17 @@ import java.util.List;
 import java.util.Locale;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import com.verygood.security.larky.console.testing.TestingConsole;
+import com.verygood.security.larky.parser.LarkyScript;
+import com.verygood.security.larky.parser.PathBasedStarFile;
+
+import net.starlark.java.eval.EvalException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
 
 
 public class LarkyQuickTests {
@@ -44,10 +39,6 @@ public class LarkyQuickTests {
 
   @BeforeEach
   public void setUp() {
-    ImmutableSet<StarlarkValue> testModules = ImmutableSet.of(
-        new UnittestModule(),
-        new AssertionsModule()
-    );
     moduleSet = new ModuleSupplier().modulesToVariableMap(true);
     interpreter = new LarkyScript(CORE_MODULES, LarkyScript.StarlarkMode.STRICT);
     scratchTestFiles = enumerateTests();

--- a/larky/src/test/java/com/verygood/security/larky/StdLibTests.java
+++ b/larky/src/test/java/com/verygood/security/larky/StdLibTests.java
@@ -1,9 +1,20 @@
 package com.verygood.security.larky;
 
+import static com.verygood.security.larky.ModuleSupplier.CORE_ENVIRONMENT;
 import static com.verygood.security.larky.ModuleSupplier.CORE_MODULES;
 
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.text.Collator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import com.verygood.security.larky.console.testing.TestingConsole;
 import com.verygood.security.larky.modules.testing.AssertionsModule;
@@ -18,17 +29,6 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.TestFactory;
-
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.text.Collator;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Locale;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 
 public class StdLibTests {
@@ -49,7 +49,11 @@ public class StdLibTests {
         new AssertionsModule()
     );
     moduleSet = new ModuleSupplier().modulesToVariableMap(true);
-    interpreter = new LarkyScript(CORE_MODULES, LarkyScript.StarlarkMode.STRICT);
+    interpreter = new LarkyScript(
+      CORE_MODULES,
+      LarkyScript.StarlarkMode.STRICT,
+      CORE_ENVIRONMENT
+    );
     stdLibTestFiles = enumerateTests();
   }
 

--- a/larky/src/test/java/com/verygood/security/larky/VGSLibTests.java
+++ b/larky/src/test/java/com/verygood/security/larky/VGSLibTests.java
@@ -1,15 +1,9 @@
 package com.verygood.security.larky;
 
-import com.google.common.base.Strings;
-import com.verygood.security.larky.console.testing.TestingConsole;
-import com.verygood.security.larky.parser.LarkyScript;
-import com.verygood.security.larky.parser.PathBasedStarFile;
-import net.starlark.java.eval.EvalException;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DynamicTest;
-import org.junit.jupiter.api.TestFactory;
+import static com.verygood.security.larky.ModuleSupplier.CORE_ENVIRONMENT;
+import static com.verygood.security.larky.ModuleSupplier.CORE_MODULES;
 
+import com.google.common.base.Strings;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -21,7 +15,16 @@ import java.util.Locale;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import static com.verygood.security.larky.ModuleSupplier.CORE_MODULES;
+import com.verygood.security.larky.console.testing.TestingConsole;
+import com.verygood.security.larky.parser.LarkyScript;
+import com.verygood.security.larky.parser.PathBasedStarFile;
+
+import net.starlark.java.eval.EvalException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
 
 
 public class VGSLibTests {
@@ -38,7 +41,11 @@ public class VGSLibTests {
     @BeforeEach
     public void setUp() {
         moduleSet = new ModuleSupplier().modulesToVariableMap(true);
-        interpreter = new LarkyScript(CORE_MODULES, LarkyScript.StarlarkMode.STRICT);
+        interpreter = new LarkyScript(
+          CORE_MODULES,
+          LarkyScript.StarlarkMode.STRICT,
+          CORE_ENVIRONMENT
+        );
         vgsDefaultTestFiles = enumerateTests();
     }
 

--- a/larky/src/test/java/com/verygood/security/larky/VendorLibTests.java
+++ b/larky/src/test/java/com/verygood/security/larky/VendorLibTests.java
@@ -1,5 +1,6 @@
 package com.verygood.security.larky;
 
+import static com.verygood.security.larky.ModuleSupplier.CORE_ENVIRONMENT;
 import static com.verygood.security.larky.ModuleSupplier.CORE_MODULES;
 
 import com.google.common.base.Strings;
@@ -49,7 +50,11 @@ public class VendorLibTests {
         new AssertionsModule()
     );
     moduleSet = new ModuleSupplier().modulesToVariableMap(true);
-    interpreter = new LarkyScript(CORE_MODULES, LarkyScript.StarlarkMode.STRICT);
+    interpreter = new LarkyScript(
+      CORE_MODULES,
+      LarkyScript.StarlarkMode.STRICT,
+      CORE_ENVIRONMENT
+    );
     vendorTestFiles = enumerateTests();
   }
 


### PR DESCRIPTION
This allows us to put global variables in environments. This PR is necessary for the types / classes PR that is to follow.

commit-id:e0fdeae8

## Description of changes in release / Impact of release:

Allows us to set globals and predeclared bindings from ModuleSupplier to the Larky environment. 

## Documentation

```java
  public static final ImmutableMap<String, Object> CORE_ENVIRONMENT = ImmutableMap.of(
//    "type", LarkyTypeClass.getInstance() // you can put anything here and it will appear as a predeclared binding in the starlark environment
  );
```

## Risks of this release

None.

### Is this a breaking change?
- [ ] Yes
- [x] No
