### PR TITLE
Compute padding manually to mimic python's binascii behavior

### DIFF
--- a/larky/src/test/resources/stdlib_tests/test_binascii.star
+++ b/larky/src/test/resources/stdlib_tests/test_binascii.star
@@ -36,3 +36,6 @@ asserts.assert_that(repr(bin_data)).is_equal_to("b\"Blinka\"")
 # print("Converted b64 ASCII->Binary Data: ", repr(bin_data))
 asserts.assert_that(type(bin_data)).is_equal_to("bytes")
 asserts.assert_(bin_data == data, "Expected binary data does not match.")
+
+asserts.assert_that(a2b_base64("AQAB=="), b'\x01\x00\x01')
+asserts.assert_that(a2b_base64("AQAB==="), b'\x01\x00\x01')


### PR DESCRIPTION
The JDK decoder behaves differently in particularly two corner cases:

- It is more restrictive regarding superfluous padding.
- It is more permissive regarding lack of padding.

 To counter this, we manually compute the expected padding to cover for these
 two cases.

This is very similar to CPython: https://github.com/python/cpython/blob/1bf9cc509326bc42cd8cb1650eb9bf64550d817e/Modules/binascii.c#L468-L473

commit-id:8e8eef5c

## Fixes #289 

### Is this a breaking change?
- [ ] Yes
- [x] No


### Is there a way to disable the change?
- [x] Use previous release
- [ ] Use a feature flag
- [ ] No
