### PR TITLE
Fix indeterminism and issues introduced by #250

### DIFF
--- a/larky/src/main/java/com/verygood/security/larky/modules/crypto/Hash/LarkyDigest.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/crypto/Hash/LarkyDigest.java
@@ -10,7 +10,6 @@ import net.starlark.java.eval.StarlarkValue;
 import net.starlark.java.ext.ByteList;
 
 import org.bouncycastle.crypto.ExtendedDigest;
-import org.bouncycastle.crypto.digests.GeneralDigest;
 import org.bouncycastle.util.Memoable;
 
 public abstract class LarkyDigest implements StarlarkValue {
@@ -44,8 +43,8 @@ public abstract class LarkyDigest implements StarlarkValue {
   protected byte[] reuseDigestIfPossible() {
     byte[] resBuf = new byte[this.getDigest().getDigestSize()];
     final ExtendedDigest copy;
-    if(this instanceof Memoable) {
-      copy = (ExtendedDigest) ((GeneralDigest) this.getDigest()).copy();
+    if(this.getDigest() instanceof Memoable) {
+      copy = (ExtendedDigest) ((Memoable)this.getDigest()).copy();
     } else {
       copy = this.getDigest();
     }

--- a/larky/src/main/java/com/verygood/security/larky/modules/crypto/PublicKey/LarkyDigitalSignatureAlgorithm.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/crypto/PublicKey/LarkyDigitalSignatureAlgorithm.java
@@ -1,0 +1,112 @@
+package com.verygood.security.larky.modules.crypto.PublicKey;
+
+import java.security.SecureRandom;
+
+import net.starlark.java.annot.Param;
+import net.starlark.java.annot.ParamType;
+import net.starlark.java.annot.StarlarkMethod;
+import net.starlark.java.eval.Dict;
+import net.starlark.java.eval.EvalException;
+import net.starlark.java.eval.NoneType;
+import net.starlark.java.eval.Starlark;
+import net.starlark.java.eval.StarlarkInt;
+import net.starlark.java.eval.StarlarkThread;
+import net.starlark.java.eval.StarlarkValue;
+import net.starlark.java.eval.Tuple;
+
+import org.bouncycastle.crypto.AsymmetricCipherKeyPair;
+import org.bouncycastle.crypto.CryptoServicesRegistrar;
+import org.bouncycastle.crypto.digests.SHA256Digest;
+import org.bouncycastle.crypto.generators.DSAKeyPairGenerator;
+import org.bouncycastle.crypto.generators.DSAParametersGenerator;
+import org.bouncycastle.crypto.params.DSAKeyGenerationParameters;
+import org.bouncycastle.crypto.params.DSAParameterGenerationParameters;
+import org.bouncycastle.crypto.params.DSAParameters;
+import org.bouncycastle.crypto.params.DSAPrivateKeyParameters;
+import org.bouncycastle.crypto.params.DSAPublicKeyParameters;
+import org.bouncycastle.jcajce.provider.asymmetric.util.PrimeCertaintyCalculator;
+
+public class LarkyDigitalSignatureAlgorithm implements StarlarkValue {
+  public static LarkyDigitalSignatureAlgorithm INSTANCE = new LarkyDigitalSignatureAlgorithm();
+
+  @StarlarkMethod(
+    name = "generate",
+    parameters = {
+      @Param(name = "bits"),
+      @Param(name = "randfunc", defaultValue = "None"),
+      @Param(name = "domain", allowedTypes = {
+        @ParamType(type= Tuple.class),
+        @ParamType(type= NoneType.class)
+      }, defaultValue = "None"),
+    }, useStarlarkThread = true)
+  public Dict<String, StarlarkInt> DSA_generate(StarlarkInt bits_, Object randomFuncO, Object domainO, StarlarkThread thread) throws EvalException {
+    int bits = bits_.toIntUnchecked();
+    if (bits != 1024 && bits != 2048 && bits != 3072) {
+      throw Starlark.errorf("ValueError: Invalid modulus length (%d). Must be one of: 1024, 2048, or 3072.", bits);
+    }
+    SecureRandom secureRandom = CryptoServicesRegistrar.getSecureRandom();
+    DSAKeyPairGenerator dsaKeyPairGenerator = new DSAKeyPairGenerator();
+    DSAKeyGenerationParameters dsaKeyGenerationParameters;
+    if(!Starlark.isNullOrNone(domainO)) {
+      Tuple domain = (Tuple) domainO;
+      dsaKeyGenerationParameters = new DSAKeyGenerationParameters(
+        secureRandom,
+        new DSAParameters(
+          ((StarlarkInt) domain.get(0)).toBigInteger(),
+          ((StarlarkInt) domain.get(1)).toBigInteger(),
+          ((StarlarkInt) domain.get(2)).toBigInteger()
+        )
+      );
+    } else {
+      final DSAParametersGenerator dsaParametersGenerator = new DSAParametersGenerator(new SHA256Digest());
+      final int N;
+      switch(bits) {
+        case 1024:
+          N = 160;
+          break;
+        case 2048:
+          N = 224;
+          break;
+        case 3072:
+          N = 256;
+          break;
+        default:
+          throw Starlark.errorf("Should absolutely never get here!");
+      }
+      DSAParameterGenerationParameters params = new DSAParameterGenerationParameters(bits, N, PrimeCertaintyCalculator.getDefaultCertainty(bits), secureRandom);
+      dsaParametersGenerator.init(params);
+      dsaKeyGenerationParameters =  new DSAKeyGenerationParameters(
+        secureRandom,
+        dsaParametersGenerator.generateParameters()
+      );
+    }
+    dsaKeyPairGenerator.init(dsaKeyGenerationParameters);
+    AsymmetricCipherKeyPair asymKeyPair;
+    try {
+      asymKeyPair = dsaKeyPairGenerator.generateKeyPair();
+    }catch(IllegalArgumentException ex) {
+      throw Starlark.errorf("ValueError: Invalid DSA domain parameters (%s)", ex.getMessage());
+    }
+    /*
+      y : integer
+        Public key.
+      g : integer
+        Generator
+      p : integer
+        DSA modulus
+      q : integer
+        Order of the subgroup
+      x : integer
+        Private key.
+     */
+    DSAPublicKeyParameters pubKey = ((DSAPublicKeyParameters) asymKeyPair.getPublic());
+    DSAPrivateKeyParameters privateKey = ((DSAPrivateKeyParameters) asymKeyPair.getPrivate());
+    return Dict.<String, StarlarkInt>builder()
+        .put("y", StarlarkInt.of(pubKey.getY()))
+        .put("g", StarlarkInt.of(pubKey.getParameters().getG()))
+        .put("p", StarlarkInt.of(pubKey.getParameters().getP()))
+        .put("q", StarlarkInt.of(pubKey.getParameters().getQ()))
+        .put("x", StarlarkInt.of(privateKey.getX()))
+        .build(thread.mutability());
+  }
+}

--- a/larky/src/main/java/com/verygood/security/larky/modules/crypto/Util/ASN1Utils.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/crypto/Util/ASN1Utils.java
@@ -172,7 +172,6 @@ public class ASN1Utils {
             StarlarkBytes value3 = (StarlarkBytes) lobj.getField("payload");
             Objects.requireNonNull(value3);
             return new ASN1.LarkyOctetString(new DEROctetString(value3.toByteArray()));
-            // fall through
           case "DerUTF8String":
             String value4 = (String) lobj.getField("value");
             Objects.requireNonNull(value4);

--- a/larky/src/main/java/com/verygood/security/larky/modules/types/results/LarkyAttributeError.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/types/results/LarkyAttributeError.java
@@ -1,0 +1,47 @@
+package com.verygood.security.larky.modules.types.results;
+
+import net.starlark.java.annot.StarlarkBuiltin;
+import net.starlark.java.eval.EvalException;
+import net.starlark.java.eval.StarlarkValue;
+
+@StarlarkBuiltin(name="AttributeError")
+public final class LarkyAttributeError extends Error implements StarlarkValue {
+
+  private LarkyAttributeError(EvalException exc) {
+    super(exc);
+  }
+
+  private static final EvalException ATTRIBUTE_ERROR = new EvalException("AttributeError");
+
+  public static final LarkyAttributeError INSTANCE = new LarkyAttributeError(ATTRIBUTE_ERROR);
+
+  public static LarkyAttributeError getInstance() {
+    return INSTANCE;
+  }
+
+  @Override
+  public boolean isImmutable() {
+    return true;
+  }
+
+  @Override
+  public Object getValue() {
+    return this;
+  }
+
+  @Override
+  public Error getError() {
+    return this;
+  }
+
+  @Override
+  public boolean isOk() {
+    return false;
+  }
+
+  @Override
+  public boolean isError() {
+    return true;
+  }
+
+}

--- a/larky/src/main/java/com/verygood/security/larky/modules/types/structs/SimpleStruct.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/types/structs/SimpleStruct.java
@@ -6,7 +6,9 @@ import java.util.Map;
 
 import com.verygood.security.larky.modules.types.LarkyCallable;
 import com.verygood.security.larky.modules.types.LarkyCollection;
+import com.verygood.security.larky.modules.types.LarkyObject;
 import com.verygood.security.larky.modules.types.PyProtocols;
+import com.verygood.security.larky.parser.StarlarkUtil;
 
 import net.starlark.java.annot.StarlarkMethod;
 import net.starlark.java.eval.Dict;
@@ -16,6 +18,8 @@ import net.starlark.java.eval.Mutability;
 import net.starlark.java.eval.Printer;
 import net.starlark.java.eval.Starlark;
 import net.starlark.java.eval.StarlarkCallable;
+import net.starlark.java.eval.StarlarkEvalWrapper;
+import net.starlark.java.eval.StarlarkInt;
 import net.starlark.java.eval.StarlarkList;
 import net.starlark.java.eval.StarlarkThread;
 import net.starlark.java.eval.Tuple;
@@ -68,12 +72,24 @@ public class SimpleStruct implements LarkyCallable, LarkyCollection, HasBinary, 
 
   @Override
   public Object getField(String name, StarlarkThread thread) {
-    if (name == null
-          || !fields.containsKey(name)
-          || fields.getOrDefault(name, null) == null) {
+    if (
+      (name == null
+         // we do not support null as field values, signifying does not exist
+         || this.fields.getOrDefault(name, null) == null
+      ) && this.fields.get(PyProtocols.__GETATTR__) == null) {
       return null;
     }
 
+    if (!fields.containsKey(name)) {
+      // if there's an object with a __getattr__, it will be invoked..
+      Object getAttrMethod = this.fields.get(PyProtocols.__GETATTR__);
+      StarlarkThread evalThread = thread == null ? getCurrentThread() : thread;
+      try {
+        return Starlark.call(evalThread, getAttrMethod, Tuple.of(name), Dict.empty());
+      } catch (EvalException | InterruptedException e) {
+        throw new StarlarkEvalWrapper.Exc.RuntimeEvalException(e, evalThread);
+      }
+    }
     return fields.get(name);
   }
 
@@ -132,6 +148,65 @@ public class SimpleStruct implements LarkyCallable, LarkyCollection, HasBinary, 
 
     return builder;
   }
+  @Override
+  public boolean truth() {
+    // __bool__() is used to implement truth value testing and the built-in operation bool();
+    final Object dunderBool = getField(PyProtocols.__BOOL__, getCurrentThread());
+    final Object dunderLen = getField(PyProtocols.__LEN__, getCurrentThread());
+    final Object res;
+    if(dunderBool != null) {
+      try {
+        res = invoke(dunderBool);
+      } catch (EvalException e) {
+        throw new RuntimeException(e);
+      }
+      // it should return False or True.
+      if(!(res instanceof Boolean)) {
+        throw new RuntimeException("TypeError: __bool__ should return bool, returned " + StarlarkUtil.richType(res));
+      }
+      return (boolean) res;
+    }
+    else if(dunderLen != null/*false*/) {
+      try {
+         res = invoke(dunderLen);
+       } catch (EvalException e) {
+        throw new RuntimeException(e);
+      }
+      // it should return non-zero integer (or boolean)
+      if(res instanceof Boolean) {
+        return Starlark.truth(res);
+      }
+      else if(res instanceof StarlarkInt
+                || (res instanceof LarkyObject && ((LarkyObject)res).isCoerceableToInt())) {
+        final StarlarkInt asInt;
+        if(res instanceof LarkyObject) {
+          try {
+            asInt = ((LarkyObject) res).coerceToInt(getCurrentThread());
+          } catch (EvalException e) {
+            throw new RuntimeException(e);
+          }
+        } else {
+          asInt = (StarlarkInt) res;
+        }
+        switch(asInt.signum()) {
+          case 0:
+            return false;
+          case 1:
+            return true;
+          case -1: // if it's a negative number
+            // fallthrough
+          default:
+            throw new RuntimeException("ValueError: __len__() of " + typeName() + "should return >= 0, returned: " + asInt);
+        }
+      }
+      throw new RuntimeException("TypeError: '" + StarlarkUtil.richType(res) + "' object cannot be interpreted as an integer");
+    }
+    /*
+      If a class defines neither __len__() nor __bool__(), all its instances
+      are considered true.
+    */
+    return true;
+  }
 
   @Override
   public boolean equals(Object obj) {
@@ -145,7 +220,7 @@ public class SimpleStruct implements LarkyCallable, LarkyCollection, HasBinary, 
     boolean result;
     try {
       result = StructBinOp.richComparison(
-        this, obj, PyProtocols.__EQ__, PyProtocols.__NE__, this.getCurrentThread()
+        this, obj, PyProtocols.__EQ__, PyProtocols.__EQ__, this.getCurrentThread()
       );
     } catch (EvalException e) {
       result = false;

--- a/larky/src/main/resources/stdlib/sets.star
+++ b/larky/src/main/resources/stdlib/sets.star
@@ -324,6 +324,10 @@ def Set(iterable=None):
     self._length = _set_length
     self.__len__ = _set_length  # alias
 
+    def __bool__():
+        return self._length() != 0
+    self.__bool__ = __bool__
+
     def __repr__():
         return _repr(self)
     self.__repr__ = __repr__

--- a/larky/src/main/resources/vendor/Crypto/Math/Numbers.star
+++ b/larky/src/main/resources/vendor/Crypto/Math/Numbers.star
@@ -213,8 +213,8 @@ def _Integer(value):
     def get_bit(n):
         if self._value < 0:
             fail('ValueError: no bit representation for negative values')
-        result = (self._value >> n._value) & 1
-        if n._value < 0:
+        result = (self._value >> int(n)) & 1
+        if operator.lt(n, 0):
             fail('ValueError: negative bit count')
 
         # result = (_value >> n) & 1
@@ -427,6 +427,18 @@ def _Integer(value):
     return self
 
 
+def _jacobi_symbol(a, n):
+    a = int(a)
+    n = int(n)
+
+    if n <= 0:
+        fail('ValueError: n must be a positive integer')
+
+    if (n & 1) == 0:
+        fail('ValueError: n must be even for the Jacobi symbol')
+    return _Integer(_JCrypto.Math.jacobi_number(a, n))
+
+
 def _from_bytes(byte_string):
     return _Integer(bytes_to_long(byte_string))
 
@@ -530,7 +542,8 @@ Numbers = larky.struct(
         __name__='Integer',
         from_bytes=_from_bytes,
         random_range=_random_range,
-        random=_random
+        random=_random,
+        jacobi_symbol=_jacobi_symbol,
     )
 )
 

--- a/larky/src/main/resources/vendor/Crypto/PublicKey/DSA.star
+++ b/larky/src/main/resources/vendor/Crypto/PublicKey/DSA.star
@@ -22,13 +22,14 @@
 # SOFTWARE.
 # ===================================================================
 load("@stdlib//binascii", binascii="binascii")
+load("@stdlib//builtins", builtins="builtins")
 load("@stdlib//codecs", codecs="codecs")
 load("@stdlib//itertools", itertools="itertools")
+load("@stdlib//jcrypto", _JCrypto="jcrypto")
 load("@stdlib//larky", WHILE_LOOP_EMULATION_ITERATION="WHILE_LOOP_EMULATION_ITERATION", larky="larky")
-# load("@stdlib//pickle", PicklingError="PicklingError")
-load("@stdlib//struct", struct="struct")
+load("@stdlib//operator", operator="operator")
 load("@stdlib//sets", sets="sets")
-load("@stdlib//builtins", builtins="builtins")
+load("@stdlib//struct", struct="struct")
 load("@stdlib//types", types="types")
 load("@vendor//Crypto/Random", Random="Random")
 load("@vendor//Crypto/Hash", SHA256="SHA256")
@@ -38,12 +39,40 @@ load("@vendor//Crypto/Math/Primality", test_probable_prime="test_probable_prime"
 load("@vendor//Crypto/PublicKey", _expand_subject_public_key_info="expand_subject_public_key_info", _create_subject_public_key_info="create_subject_public_key_info", _extract_subject_public_key_info="extract_subject_public_key_info")
 load("@vendor//Crypto/Util/asn1", DerObject="DerObject", DerSequence="DerSequence", DerInteger="DerInteger", DerObjectId="DerObjectId", DerBitString="DerBitString")
 load("@vendor//Crypto/Util/py3compat", bchr="bchr", bord="bord", tobytes="tobytes", tostr="tostr", iter_range="iter_range")
-load("@vendor//option/result", Error="Error")
+load("@vendor//option/result", Result="Result", Error="Error")
 
 __all__ = ['generate', 'construct', 'DsaKey', 'import_key']
 
 map = builtins.map
 sum = builtins.sum
+
+#   ; The following ASN.1 types are relevant for DSA
+#
+#   SubjectPublicKeyInfo    ::=     SEQUENCE {
+#       algorithm   AlgorithmIdentifier,
+#       subjectPublicKey BIT STRING
+#   }
+#
+#   id-dsa ID ::= { iso(1) member-body(2) us(840) x9-57(10040) x9cm(4) 1 }
+#
+#   ; See RFC3279
+#   Dss-Parms  ::=  SEQUENCE  {
+#       p INTEGER,
+#       q INTEGER,
+#       g INTEGER
+#   }
+#
+#   DSAPublicKey ::= INTEGER
+#
+#   DSSPrivatKey_OpenSSL ::= SEQUENCE
+#       version INTEGER,
+#       p INTEGER,
+#       q INTEGER,
+#       g INTEGER,
+#       y INTEGER,
+#       x INTEGER
+#   }
+#
 
 def DsaKey(key_dict):
     r"""Class defining an actual DSA key.
@@ -88,7 +117,7 @@ def DsaKey(key_dict):
     def _sign(m, k):
         if not self.has_private():
             fail("TypeError: DSA public key cannot be used for signing")
-        if not (1 < k._value) and (k < self._key["q"]):
+        if not (operator.le(1, k) and operator.le(k, self.q)):
             fail("ValueError: k is not between 2 and q-1")
 
         x, q, p, g = [self._key[comp] for comp in ['x', 'q', 'p', 'g']]
@@ -98,7 +127,7 @@ def DsaKey(key_dict):
         inv_blind_k = (blind_factor * k).inverse(q)
         blind_x = x * blind_factor
 
-        r = pow(g, k._value, p._value) % q._value  # r = (g**k mod p) mod q
+        r = pow(int(g), int(k), int(p)) % int(q)  # r = (g**k mod p) mod q
         s = (inv_blind_k * (blind_factor * m + blind_x * r)) % q
         return map(int, (r, s))
     self._sign = _sign
@@ -106,33 +135,25 @@ def DsaKey(key_dict):
     def _verify(m, sig):
         r, s = sig
         y, q, p, g = [self._key[comp] for comp in ['y', 'q', 'p', 'g']]
-        if not (0 < r._value) and (r < q) or not (0 < s._value) and (s < q):
+        if not (operator.lt(0, r) and operator.lt(r, q)) or not (operator.lt(0, s) and operator.lt(s, q)):
             return False
         w = Integer(s).inverse(q)
         u1 = (w * m) % q
         u2 = (w * r) % q
-        g_san = g
-        y_san = y
-        u1_san = u1
-        u2_san = u2
-        p_san = p
-        if types.is_instance(g, Integer):
-            g_san = g._value
-        if types.is_instance(y, Integer):
-            y_san = y._value
-        if types.is_instance(u1, Integer):
-            u1_san = u1._value
-        if types.is_instance(p, Integer):
-            p_san = p._value
-        if types.is_instance(u2, Integer):
-            u2_san = u2._value
-        v = (pow(g_san, u1_san, p_san) * pow(y_san, u2_san, p_san) % p_san) % q
-        return v == r
+        d= {
+            'g': int(g),
+            'u1': int(u1),
+            'p': int(p),
+            'y': int(y),
+            'u2': int(u2),
+            'q': int(q)
+        }
+        v = (pow(d['g'], d['u1'], d['p']) * pow(d['y'], d['u2'], d['p']) % d['p']) % d['q']
+        return operator.eq(v, r)
     self._verify = _verify
 
     def has_private():
         """Whether this is a DSA private key"""
-
         return 'x' in self._key
     self.has_private = has_private
 
@@ -156,13 +177,14 @@ def DsaKey(key_dict):
     self.public_key = public_key
 
     def __eq__(other):
+        # print(self.has_private(), other.has_private())
         if bool(self.has_private()) != bool(other.has_private()):
             return False
 
         result = True
         for comp in self._keydata:
-            result = result and (getattr(self._key, comp, None) ==
-                                 getattr(other._key, comp, None))
+            result = result and (self._key.get(comp, None) ==
+                                 other._key.get(comp, None))
         return result
     self.__eq__ = __eq__
 
@@ -172,10 +194,7 @@ def DsaKey(key_dict):
 
     def __getstate__():
         # DSA key is not pickable
-        # load("@stdlib//pickle", PicklingError="PicklingError")
-        # PY2LARKY: pay attention to this!
-        # return PicklingError
-        return Error()
+        fail("DSA key is not pickable")
     self.__getstate__ = __getstate__
 
     def domain():
@@ -199,15 +218,13 @@ def DsaKey(key_dict):
         if self.has_private():
             attrs.append("private")
         # PY3K: This is meant to be text, do not change to bytes (data)
-        # return "<%s @0x%x %s>" % (self.__class__.__name__, id(self), ",".join(attrs))
         return "<%s %s>" % (self.__name__, ",".join(attrs))
     self.__repr__ = __repr__
 
     def __getattr__(item):
-        # try:
+        if item not in self._key:
+            return AttributeError()
         return int(self._key[item])
-        # except KeyError:
-        #     fail()
     self.__getattr__ = __getattr__
 
     def export_key(format='PEM', pkcs8=None, passphrase=None,
@@ -283,7 +300,6 @@ def DsaKey(key_dict):
                     return bchr(0) + x
                 else:
                     return x
-            self.func = func
 
             tup2 = [func(x) for x in tup1]
             keyparts = [b'ssh-dss'] + tup2
@@ -301,7 +317,7 @@ def DsaKey(key_dict):
             if pkcs8:
                 if not protection:
                     protection = 'PBKDF2WithHMAC-SHA1AndDES-EDE3-CBC'
-                private_key = codecs.encode(DerInteger(self.x), encoding="utf-8")
+                private_key = DerInteger(self.x).encode()
                 binary_key = PKCS8.wrap(
                                 private_key, oid, passphrase,
                                 protection, key_params=params,
@@ -316,7 +332,7 @@ def DsaKey(key_dict):
                 if format != 'PEM' and passphrase:
                     fail("ValueError: DSA private key cannot be encrypted")
                 ints = [0, self.p, self.q, self.g, self.y, self.x]
-                binary_key = codecs.encode(DerSequence(ints), encoding="utf-8")
+                binary_key = DerSequence(ints).encode()
                 key_type = "DSA PRIVATE"
         else:
             if pkcs8:
@@ -329,14 +345,17 @@ def DsaKey(key_dict):
         if format == 'DER':
             return binary_key
         if format == 'PEM':
-            pem_str = codecs.encode(PEM, encoding=binary_key)
+            pem_str = PEM.encode(
+                                binary_key, key_type + " KEY",
+                                passphrase, randfunc
+                            )
             return tobytes(pem_str)
         fail("ValueError: " + "Unknown key format '%s'. Cannot export the DSA key." % format)
     self.export_key = export_key
 
     # Backward-compatibility
-    exportKey = export_key
-    publickey = public_key
+    self.exportKey = export_key
+    self.publickey = public_key
 
     # Methods defined in PyCrypto that we don't support anymore
 
@@ -349,37 +368,28 @@ def DsaKey(key_dict):
     self.verify = verify
 
     def encrypt(plaintext, K):
-        # PY2LARKY: pay attention to this!
-        # return NotImplementedError
-        return Error()
+        fail("NotImplementedError")
     self.encrypt = encrypt
 
     def decrypt(ciphertext):
-        # PY2LARKY: pay attention to this!
-        # return NotImplementedError
-        return Error()
+        fail("NotImplementedError")
     self.decrypt = decrypt
 
     def blind(M, B):
-        # PY2LARKY: pay attention to this!
-        # return NotImplementedError
-        return Error()
+        fail("NotImplementedError")
     self.blind = blind
 
     def unblind(M, B):
-        # PY2LARKY: pay attention to this!
-        # return NotImplementedError
-        return Error()
+        fail("NotImplementedError")
     self.unblind = unblind
 
     def size():
-        # PY2LARKY: pay attention to this!
-        # return NotImplementedError
-        return Error()
+        fail("NotImplementedError")
     self.size = size
     return self
 
 
+# Not used
 def _generate_domain(L, randfunc):
     """Generate a new set of DSA domain parameters"""
 
@@ -393,7 +403,8 @@ def _generate_domain(L, randfunc):
 
     # Generate q (A.1.1.2)
     q = Integer(4)
-    upper_bit = 1 << (N - 1)
+    # upper_bit = 1 << (N - 1)
+    upper_bit = pow(2, N - 1)
     for _while_ in range(WHILE_LOOP_EMULATION_ITERATION):
         if test_probable_prime(q, randfunc) == PROBABLY_PRIME:
             break
@@ -408,12 +419,10 @@ def _generate_domain(L, randfunc):
     # upper_bit = 1 << (L - 1)
     upper_bit = pow(2, L - 1)
     for _while_ in range(WHILE_LOOP_EMULATION_ITERATION):
-        if not True:
-            break
         V = [ SHA256.new(seed + Integer(offset + j).to_bytes()).digest()
               for j in iter_range(n + 1) ]
         V = [ Integer.from_bytes(v) for v in V ]
-        W = sum([V[i] * pow(1, i * outlen) for i in iter_range(n)],
+        W = sum([V[i] * pow(2, i * outlen) for i in iter_range(n)],
                 (V[n] & (pow(2, b_) - 1)) * pow(2, n * outlen))
 
         X = Integer(W + upper_bit) # 2^{L-1} < X < 2^{L}
@@ -429,13 +438,11 @@ def _generate_domain(L, randfunc):
 
     # Generate g (A.2.3, index=1)
     e = (p - 1) // q
-    counter = larky.utils.Counter()
-
     for _while_ in range(WHILE_LOOP_EMULATION_ITERATION):
-        count = counter.add_and_get()
+        count = _while_ + 1
         U = seed + b"ggen" + bchr(1) + Integer(count).to_bytes()
         W = Integer.from_bytes(SHA256.new(U).digest())
-        g = pow(W._value, e._value, p._value)
+        g = pow(int(W), int(e), int(p))
         if g != 1:
             break
 
@@ -476,23 +483,17 @@ def generate(bits, randfunc=None, domain=None):
         randfunc = Random.get_random_bytes
 
     if domain:
-        p, q, g = map(Integer, domain)
+        p, q, g = map(int, domain)
+        domain = (p, q, g)
 
-        ## Perform consistency check on domain parameters
-        # P and Q must be prime
-        fmt_error = test_probable_prime(p) == COMPOSITE
-        fmt_error |= test_probable_prime(q) == COMPOSITE
-        # Verify Lagrange's theorem for sub-group
-        fmt_error |= ((p - 1) % q) != 0
-        fmt_error |= g <= 1 or g >= p
-        fmt_error |= pow(g, q, p) != 1
-        if fmt_error:
-            fail("ValueError: Invalid DSA domain parameters")
-    else:
-        p, q, g, _ = _generate_domain(bits, randfunc)
+    _generated_key_dict = _JCrypto.PublicKey.DSA.generate(bits, randfunc, domain)
+    key_dict = {}
+    for __key, __key_value in _generated_key_dict.items():
+        key_dict[__key] = Integer(__key_value)
+    _generated_key_dict.clear()
 
-    L = p.size_in_bits()
-    N = q.size_in_bits()
+    L = key_dict['p'].size_in_bits()
+    N = key_dict['q'].size_in_bits()
 
     if L != bits:
         fail("ValueError: " + ("Mismatch between size of modulus (%d)" +
@@ -503,15 +504,9 @@ def generate(bits, randfunc=None, domain=None):
         fail("ValueError: " + ("Lengths of p and q (%d, %d) are not compatible" +
                          "to FIPS 186-3") % (L, N))
 
-    if not (1 < g) and (g < p):
-        fail("ValueError: Incorrent DSA generator")
+    if not (operator.lt(1, key_dict['g']) and operator.lt(key_dict['g'], key_dict['p'])):
+        fail("ValueError: Incorrect DSA generator")
 
-    # B.1.1
-    c = Integer.random(exact_bits=N + 64, randfunc=randfunc)
-    x = c % (q - 1) + 1 # 1 <= x <= q-1
-    y = pow(g, x._value, p._value)
-
-    key_dict = { 'y':y, 'g':g, 'p':p, 'q':q, 'x':x }
     return DsaKey(key_dict)
 
 
@@ -546,17 +541,17 @@ def construct(tup, consistency_check=True):
     fmt_error = False
     if consistency_check:
         # P and Q must be prime
-        fmt_error = test_probable_prime(key.p) == COMPOSITE
-        fmt_error |= test_probable_prime(key.q) == COMPOSITE
+        fmt_error = int(test_probable_prime(key.p) == COMPOSITE)
+        fmt_error |= int(test_probable_prime(key.q) == COMPOSITE)
         # Verify Lagrange's theorem for sub-group
-        fmt_error |= ((key.p - 1) % key.q) != 0
-        fmt_error |= key.g <= 1 or key.g >= key.p
-        fmt_error |= pow(key.g, key.q, key.p) != 1
+        fmt_error |= int(((key.p - 1) % key.q) != 0)
+        fmt_error |= int((int(key.g) <= 1 or int(key.g) >= int(key.p)))
+        fmt_error |= int(pow(int(key.g), int(key.q), int(key.p)) != 1)
         # Public key
-        fmt_error |= key.y <= 0 or key.y >= key.p
+        fmt_error |= int((int(key.y) <= 0) or (int(key.y) >= int(key.p)))
         if hasattr(key, 'x'):
-            fmt_error |= key.x <= 0 or key.x >= key.q
-            fmt_error |= pow(key.g, key.x, key.p) != key.y
+            fmt_error |= int((int(key.x) <= 0) or (int(key.x) >= int(key.q)))
+            fmt_error |= int(pow(int(key.g), int(key.x), int(key.p)) != int(key.y))
 
     if fmt_error:
         fail("ValueError: Invalid DSA key components")
@@ -591,7 +586,7 @@ def _import_subjectPublicKeyInfo(encoded, passphrase, params):
 
     y = DerInteger().decode(encoded_key).value
     p, q, g = list(DerSequence().decode(params or emb_params))
-    tup = (y, g, p, q)
+    tup = (int(y), int(g), int(p), int(q))
     return construct(tup)
 
 
@@ -609,23 +604,23 @@ def _import_pkcs8(encoded, passphrase, params):
         fail("ValueError: No PKCS#8 encoded DSA key")
     x = DerInteger().decode(k[1]).value
     p, q, g = list(DerSequence().decode(k[2]))
-    tup = (pow(g, x, p), g, p, q, x)
+    tup = (pow(int(g), int(x), int(p)), int(g), int(p), int(q), int(x))
     return construct(tup)
 
 
 def _import_key_der(key_data, passphrase, params):
     """Import a DSA key (public or private half), encoded in DER form."""
-
-    decodings = (_import_openssl_private,
-                 _import_subjectPublicKeyInfo,
-                 _import_x509_cert,
-                 _import_pkcs8)
+    decodings = (
+        Result.Ok(_import_openssl_private),
+        Result.Ok(_import_subjectPublicKeyInfo),
+        Result.Ok(_import_x509_cert),
+        Result.Ok(_import_pkcs8),
+    )
 
     for decoding in decodings:
-        # try:
-        return decoding(key_data, passphrase, params)
-        # except ValueError:
-        #     pass
+        rval = decoding.map(lambda x: x(key_data, passphrase, params))
+        if not rval.is_err:
+            return rval.unwrap()
 
     fail("ValueError: DSA key format is not supported")
 

--- a/larky/src/main/resources/vendor/Crypto/Util/asn1.star
+++ b/larky/src/main/resources/vendor/Crypto/Util/asn1.star
@@ -623,6 +623,8 @@ def DerSequence(startSeq=None, implicit=None):
 
         self._nr_elements = nr_elements
         i = _JCrypto.Util.ASN1.DerSequence(self._seq)
+        if not byte_string(der_encoded) and not types.is_bytearray(der_encoded):
+            fail('ValueError: Input is not a byte string')
         self._seq = i.decode(der_encoded)
         # result = self.derobject.decode(self, der_encoded, strict=strict)
         #
@@ -642,8 +644,8 @@ def DerSequence(startSeq=None, implicit=None):
         if not ok:
             # TODO(Hack)...until I introduce safetywrap
             if errors:
-                err = '"Unexpected number of members (%d) in the sequence"'
-                fail('ValueError(%s)' % (err % len(self._seq)))
+                err = 'Unexpected number of members (%d) in the sequence'
+                fail('ValueError: %s' % (err % len(self._seq)))
             return
         return self
 
@@ -867,9 +869,6 @@ def DerObjectId(value='', implicit=None, explicit=None):
         Raises:
             ValueError: in case of parsing errors.
         """
-        if type(der_encoded) == 'string':
-            #return der_encoded
-            der_encoded = DerObjectId(der_encoded).encode()
         return self.derobject.decode(self, der_encoded, strict)
 
     def _decodeFromStream(obj, s, strict):

--- a/larky/src/main/resources/vendor/cryptography/hazmat/primitives/asymmetric/utils.star
+++ b/larky/src/main/resources/vendor/cryptography/hazmat/primitives/asymmetric/utils.star
@@ -2,8 +2,6 @@
 # 2.0, and the BSD License. See the LICENSE file in the root of this repository
 # for complete details.
 load("@stdlib//builtins", builtins="builtins")
-load("@stdlib//base64", base64="base64")
-load("@stdlib//binascii", "binascii")
 load("@stdlib//larky", larky="larky")
 load("@vendor//cryptography/hazmat/_der", DERReader="DERReader", INTEGER="INTEGER", SEQUENCE="SEQUENCE", encode_der="encode_der", encode_der_integer="encode_der_integer")
 load("@vendor//cryptography/hazmat/primitives", hashes="hashes")

--- a/larky/src/main/resources/vendor/jose/backends/__init__.star
+++ b/larky/src/main/resources/vendor/jose/backends/__init__.star
@@ -2,7 +2,6 @@ load("@vendor//jose/backends/pycrypto_backend",
      _AESKey="AESKey",     # noqa: F401
      _RSAKey="RSAKey",     # noqa: F401
      get_random_bytes="get_random_bytes")  # noqa: F401
-# load("@vendor//jose/backends/ecdsa_backend", ECKey="ECKey")  # noqa: F401
 load("@vendor//jose/backends/native", _HMACKey="HMACKey")  # noqa: F401
 load("@vendor//jose/backends/base", _DIRKey="DIRKey")  # noqa: F401
 load("@vendor//jose/backends/pycrypto_backend", _ECKey="ECKey")  # noqa: F401

--- a/larky/src/main/resources/vendor/jose/backends/pycrypto_backend.star
+++ b/larky/src/main/resources/vendor/jose/backends/pycrypto_backend.star
@@ -20,6 +20,7 @@ load("@vendor//Crypto/Hash/SHA512", SHA512="SHA512")
 load("@vendor//Crypto/Hash/SHA1", SHA1="SHA1")
 load("@vendor//Crypto/PublicKey/RSA", RSA="RSA")
 load("@vendor//Crypto/PublicKey/ECC", ECC="ECC")
+load("@vendor//Crypto/Signature/DSS", DSS="DSS")
 load("@vendor//Crypto/Signature/PKCS1_v1_5", PKCS1_v1_5_Signature="PKCS1_v1_5")
 load("@vendor//Crypto/Util/asn1", DerSequence="DerSequence")
 load("@vendor//Crypto/Util/py3compat", tobytes="tobytes", tostr="tostr")
@@ -88,36 +89,21 @@ def ECKey(key, algorithm):
             ALGORITHMS.ES512: self.SHA512,
         }.get(algorithm)
         self._algorithm = algorithm
-        if hasattr(key, "public_bytes") or hasattr(key, "private_bytes"):
+        if builtins.isinstance(key, ECC.EccKey):
             self.prepared_key = key
-            return Ok(self)
-        if hasattr(key, "to_pem"):
-            # convert to PEM and let cryptography below load it as PEM
-            # key = key.to_pem().decode("utf-8")
-            return Error("To difficult to explain")
-        if builtins.isinstance(key, dict):
+            return self
+
+        if types.is_dict(key):
             self.prepared_key = self._process_jwk(key)
-        if builtins.isinstance(key, str):
-            key = builtins.bytes(key, encoding="utf-8")
-        if builtins.isinstance(key, bytes):
-            public_key = Ok(load_pem_public_key(key))
-            if public_key.is_err:
-                fail("Unable to parse an ECKey from key: %s" % key)
-            else:
-                self.prepared_key = public_key._val
 
-            private_key = Ok(load_pem_private_key(key,None))
-            if private_key.is_err:
-                pass
-            else:
-                self.prepared_key = private_key._val
+        if types.is_string(key):
+            key = tobytes(key)
 
-            ok = Ok(self)
-            if(ok.is_err):
-                fail("Unable to parse an ECKey from key: %s" % key)
-            else:
-                return ok._val
+        if types.is_bytelike(key):
+            self.prepared_key = ECC.import_key(key)
+            return self
 
+        fail('JWKError: Unable to parse an ECKey from key: %s' % key)
     self = __init__(key, algorithm)
 
     def _process_jwk(jwk_dict):
@@ -133,50 +119,26 @@ def ECKey(key, algorithm):
             "P-521": "secp521r1",
         }[jwk_dict["crv"]]
         if "d" in jwk_dict:
+            # private key
             d = base64_to_long(jwk_dict.get("d"))
-            return ECC.construct(point_x=x, point_y=y, d=d, curve=curve())
+            return ECC.construct(point_x=x, point_y=y, d=d, curve=curve)
         else:
-            return ECC.construct(point_x=x, point_y=y, curve=curve())
+            return ECC.construct(point_x=x, point_y=y, curve=curve)
     self._process_jwk = _process_jwk
 
-    def _sig_component_length():
-        """Determine the correct serialization length for an encoded signature component.
-            This is the number of bytes required to encode the maximum key value.
-        """
-        return int(ceil(self.prepared_key.key_size / 8.0))
-    self._sig_component_length = _sig_component_length
-
-    def _der_to_raw(der_signature):
-        """Convert signature from DER encoding to RAW encoding."""
-        r, s = decode_dss_signature(der_signature)
-        component_length = self._sig_component_length()
-        return int_to_bytes(r, component_length) + int_to_bytes(s, component_length)
-    self._der_to_raw = _der_to_raw
-
-    def _raw_to_der(raw_signature):
-        """Convert signature from RAW encoding to DER encoding."""
-        component_length = self._sig_component_length()
-        if len(raw_signature) != int(2 * component_length):
-            return Error("Invalid signature")
-
-        r_bytes = raw_signature[:component_length]
-        s_bytes = raw_signature[component_length:]
-        r = bytes_to_long(r_bytes, "big")
-        s = bytes_to_long(s_bytes, "big")
-        return encode_dss_signature(r, s)
-    self._raw_to_der = _raw_to_der
-
     def sign(msg):
-        if self.hash_alg.digest_size * 8 > self.prepared_key.key_size:
-            return Error(
-                "this curve (%s) is too short for your digest (%d)"
-                % (self.prepared_key.curve.name, 8 * self.hash_alg.digest_size)
-            )
-        signature = self.prepared_key.sign(msg, self.hash_alg)
-        if type(signature) == 'bytes':
-            return signature
-        return self._der_to_raw(signature)
+        hashed = self.hash_alg.new(msg)
+        signer = DSS.new(self.prepared_key, 'fips-186-3')
+        return signer.sign(hashed)
     self.sign = sign
+
+    def verify(msg, sig):
+        hashed = self.hash_alg.new(msg)
+        signer = DSS.new(self.prepared_key, 'fips-186-3')
+        result = Ok(signer.verify).map(lambda v: v(hashed, sig))
+        return True if result.is_ok else False
+    self.verify = verify
+
     return self
 
 

--- a/larky/src/main/resources/vendor/jose/jwk.star
+++ b/larky/src/main/resources/vendor/jose/jwk.star
@@ -21,7 +21,6 @@ def get_key(algorithm):
     elif operator.contains(ALGORITHMS.RSA, algorithm):
         return RSAKey
     elif operator.contains(ALGORITHMS.EC, algorithm):
-        # fail("ECKey is not supported!")
         return ECKey
     elif operator.contains(ALGORITHMS.AES, algorithm):
         return AESKey

--- a/larky/src/main/resources/vendor/lxml/_c14n.star
+++ b/larky/src/main/resources/vendor/lxml/_c14n.star
@@ -175,7 +175,7 @@ def _implementation(node, write, **kw):
         # Walk up and get all xml:XXX attributes we inherit.
         inherited, parent = [], node.getparent()
         for _while_ in range(WHILE_LOOP_EMULATION_ITERATION):
-            if not (parent and parent.nodetype() not in (
+            if not (parent != None and parent.nodetype() not in (
                 "Document",
                 'ProcessingInstruction',
                 'Comment',

--- a/larky/src/main/resources/vendor/lxml/_xmlwriter.star
+++ b/larky/src/main/resources/vendor/lxml/_xmlwriter.star
@@ -236,7 +236,7 @@ def XMLWriter(tree, namespaces=None, encoding="utf-8"):
 
         Writes a document type declaration to the stream.
         """
-        if not doctype or not hasattr(doctype, '_name'):
+        if doctype == None or not hasattr(doctype, '_name'):
             return
         # Name in document type declaration must match the root element tag.
         # For XML, case sensitive match, for HTML insensitive.
@@ -453,7 +453,7 @@ def XMLWriter(tree, namespaces=None, encoding="utf-8"):
             self.write_xml_header()
 
         # comments/processing instructions before doctype declaration
-        if write_complete_document and c_doc.docinfo:
+        if write_complete_document and c_doc.docinfo != None:
             if self.options.get('debug'):
                 print("DEBUG", "comments/processing instructions before doctype")
             # for n in c_doc:
@@ -466,12 +466,12 @@ def XMLWriter(tree, namespaces=None, encoding="utf-8"):
             #         with_tail=self.options["with_tail"],
             #         write_complete_document=write_complete_document)
             self.write_previous_siblings(c_doc.docinfo, namespaces)
-        if self.options['doctype']:
+        if self.options['doctype'] != None:
             self.write_content(self.options['doctype'])
             self.write_content('\n')
 
         # write internal DTD subset, preceding PIs/comments, etc.
-        if write_complete_document and not self.options['doctype']:
+        if write_complete_document and self.options['doctype'] == None:
             if self.options.get('debug'):
                 print("DEBUG", "write internal DTD subset")
             self.write_dtd(c_doc.docinfo)
@@ -524,7 +524,7 @@ def XMLWriter(tree, namespaces=None, encoding="utf-8"):
     self.write = write
 
     def write_previous_siblings(c_node, namespaces):
-        if c_node.getparent() and (
+        if c_node.getparent() != None and (
                 self._nodetype(c_node.getparent()) != 'Document'
         ):
             return
@@ -533,7 +533,7 @@ def XMLWriter(tree, namespaces=None, encoding="utf-8"):
         for _while_ in range(larky.WHILE_LOOP_EMULATION_ITERATION):
             c_prev_sibling = c_sibling.previous_sibling()
             # print(repr(c_node), repr(c_sibling.previous_sibling()))
-            if not c_prev_sibling or self._nodetype(c_prev_sibling) not in (
+            if c_prev_sibling == None or self._nodetype(c_prev_sibling) not in (
                 'Comment',
                 'ProcessingInstruction',
             ):
@@ -541,7 +541,7 @@ def XMLWriter(tree, namespaces=None, encoding="utf-8"):
             c_sibling = c_prev_sibling
 
         for _while_ in range(larky.WHILE_LOOP_EMULATION_ITERATION):
-            if not c_sibling or c_sibling == c_node:
+            if c_sibling == None or c_sibling == c_node:
                 break
             self.write_node(c_sibling, namespaces)
             if self.options['pretty_print']:
@@ -550,14 +550,14 @@ def XMLWriter(tree, namespaces=None, encoding="utf-8"):
     self.write_previous_siblings = write_previous_siblings
 
     def write_next_siblings(c_node, namespaces):
-        if c_node.getparent() and (
+        if c_node.getparent() != None and (
                 self._nodetype(c_node.getparent()) != 'Document'
         ):
             return
         # we are at a root node, so add PI and comment siblings
         c_sibling = c_node.next_sibling()
         for _while_ in range(larky.WHILE_LOOP_EMULATION_ITERATION):
-            if not c_sibling or self._nodetype(c_sibling) not in (
+            if c_sibling == None or self._nodetype(c_sibling) not in (
                 'Comment',
                 'ProcessingInstruction',
             ):
@@ -596,7 +596,7 @@ def XMLWriter(tree, namespaces=None, encoding="utf-8"):
                 elif tag_type == 'Comment':
                     # comments are not parsed by ElementTree!
                     self.write_comment(node)
-                    if (write_complete_document or with_tail) and node.tail:
+                    if (write_complete_document or with_tail) and node.tail != None:
                         self.write_content(node.tail)
                     continue
                 elif tag_type == 'Text':
@@ -604,21 +604,21 @@ def XMLWriter(tree, namespaces=None, encoding="utf-8"):
                     if self.options.get('debug'):
                         print("text node:", repr(node.text), repr(node.tail))
                     self.write_content(node.text)
-                    if (write_complete_document or with_tail) and node.tail:
+                    if (write_complete_document or with_tail) and node.tail != None:
                         self.write_content(node.tail)
                     continue
                 elif tag_type == 'ProcessingInstruction':
                     # PI's are not parsed by ElementTree!
                     self.write_pi(node)
-                    if (write_complete_document or with_tail) and node.tail:
+                    if (write_complete_document or with_tail) and node.tail != None:
                         self.write_content(node.tail)
                     continue
                 elif all((
                         tag_type == 'DocumentType',
-                        not self.options['doctype']
+                        self.options['doctype'] == None
                 )):
                     self.write_dtd(node)
-                    if (write_complete_document or with_tail) and node.tail:
+                    if (write_complete_document or with_tail) and node.tail != None:
                         self.write_content(node.tail)
                     continue
                 else:
@@ -637,31 +637,31 @@ def XMLWriter(tree, namespaces=None, encoding="utf-8"):
                         xmlns = self._add_node_namespaces_to_root(
                             node, xmlns, xmlns_items
                         )
-                    if xmlns:
+                    if xmlns != None:
                         xmlns_items.append(xmlns)
                     self.write_start_tag_open(tag)
                     # write attribute nodes
                     for attrname, value in attributes:
                         attrname, xmlns = self.add_prefix(attrname, namespaces)
-                        if xmlns:
+                        if xmlns != None:
                             xmlns_items.append(xmlns)
                         self.write_attr(attrname, value)
                     # write collected xmlns attributes
                     for attrname, value in xmlns_items:
                         self.write_attr(attrname, value)
 
-                    if not (node.text or len(node)):
+                    if node.text == None and len(node) == 0:
                         if self.options.get('short_empty_elements', True):
                             self.write_empty_tag_close()
                         else:
                             self.write_start_tag_close()
                             self.write_end_tag(tag)
 
-                        if (write_complete_document or with_tail) and node.tail:
+                        if (write_complete_document or with_tail) and node.tail != None:
                             self.write_content(node.tail)
                     else:
                         self.write_start_tag_close()
-                        if node.text:
+                        if node.text != None:
                             self.write_content(node.text)
 
                         # self.write(n, dict(**namespaces))

--- a/larky/src/main/resources/vendor/lxml/builder.star
+++ b/larky/src/main/resources/vendor/lxml/builder.star
@@ -161,7 +161,7 @@ def ElementMaker(typemap=None, namespace=None, nsmap=None, makeelement=None):
                 elem.text = (elem.text or "") + item
 
         def ElementMaker_add_cdata(elem, cdata):
-            if elem.text:
+            if elem.text != None:
                 fail("ValueError: Can't add a CDATA section. Element already has some text: %r" % elem.text)
             elem.text = cdata
 

--- a/larky/src/main/resources/vendor/lxml/etree.star
+++ b/larky/src/main/resources/vendor/lxml/etree.star
@@ -449,7 +449,7 @@ def XMLNode(tag, attrib=None, **extra):
     self.prefix = larky.property(lambda: split_qname(self.qname)[0])
     self.href = larky.property(lambda: self._href)
     self.parent = larky.property(lambda: self.__parent)
-    self._index = larky.property(lambda: self.parent.index(self) if self.parent else 0)
+    self._index = larky.property(lambda: self.parent.index(self) if self.parent != None else 0)
 
     def _owner_document():
         """Document: An associated document."""
@@ -1176,7 +1176,7 @@ def XMLNode(tag, attrib=None, **extra):
         Returns the following sibling of this element or None.
         """
         ix = self._index
-        if not self.parent or ix == (self.parent.numchildren() - 1):
+        if self.parent == None or ix == (self.parent.numchildren() - 1):
             return None
         return self.__parent[ix + 1]
 
@@ -1217,7 +1217,7 @@ def XMLNode(tag, attrib=None, **extra):
         @returns tree_cls(Root node instance) or None if not found
         """
         rootnode = self.getroot()
-        if rootnode:
+        if rootnode != None:
             return XMLTree(rootnode)
 
     self.getroottree = getroottree
@@ -1226,7 +1226,7 @@ def XMLNode(tag, attrib=None, **extra):
         """
         Find the position of the child within the parent.
         """
-        if not elem:
+        if elem == None:
             return -1
 
         if stop == None and start in (None, 0):
@@ -1629,11 +1629,6 @@ def XMLNode(tag, attrib=None, **extra):
         return len(self._children)
 
     self.__len__ = __len__
-
-    def __bool__():
-        return len(self._children)
-
-    self.__bool__ = __bool__
 
     def __reversed__():
         return builtins.reversed(self._children)

--- a/larky/src/test/java/com/verygood/security/larky/LarkyQuickTests.java
+++ b/larky/src/test/java/com/verygood/security/larky/LarkyQuickTests.java
@@ -48,8 +48,6 @@ public class LarkyQuickTests {
     // Did we pass in a specific filename?
     // -Dlarky.quick_test=test_base64.star
     String singleTestDesired = System.getProperty(PROPERTY_NAME);
-//    String singleTestDesired = "test_DSS.star";
-//    String singleTestDesired = "test_justin.star";
     try (Stream<Path> testFiles = Files.walk(QUICK_TEST_DIR)) {
       scratchTestFiles = testFiles
           .filter(Files::isRegularFile)

--- a/larky/src/test/resources/quick_tests/test_DSS.star
+++ b/larky/src/test/resources/quick_tests/test_DSS.star
@@ -1,25 +1,25 @@
-# load("@vendor//asserts", asserts="asserts")
-# load("@stdlib//unittest", unittest="unittest")
+load("@vendor//asserts", asserts="asserts")
+load("@stdlib//unittest", unittest="unittest")
 
-# load("@vendor//Crypto/Signature/DSS", DSS="DSS")
-# load("@vendor//Crypto/PublicKey/DSA", DSA="DSA")
-# load("@vendor//Crypto/Hash/SHA256", SHA256="SHA256")
-
-
-# def test_DSS():
-#     key = DSA.generate(2048)
-#     message = b"Hello"
-#     hash_obj = SHA256.new(message)
-#     signer = DSS.new(key, 'fips-186-3')
-#     signature = signer.sign(hash_obj)
-#     print(signer.verify(hash_obj, signature))
+load("@vendor//Crypto/Signature/DSS", DSS="DSS")
+load("@vendor//Crypto/PublicKey/DSA", DSA="DSA")
+load("@vendor//Crypto/Hash/SHA256", SHA256="SHA256")
 
 
-# def _testsuite():
-#     _suite = unittest.TestSuite()
-#     _suite.addTest(unittest.FunctionTestCase(test_DSS))
-#     return _suite
+def test_DSS():
+    key = DSA.generate(2048)
+    message = b"Hello"
+    hash_obj = SHA256.new(message)
+    signer = DSS.new(key, 'fips-186-3')
+    signature = signer.sign(hash_obj)
+    print(signer.verify(hash_obj, signature))
 
 
-# _runner = unittest.TextTestRunner()
-# _runner.run(_testsuite())
+def _testsuite():
+    _suite = unittest.TestSuite()
+    _suite.addTest(unittest.FunctionTestCase(test_DSS))
+    return _suite
+
+
+_runner = unittest.TextTestRunner()
+_runner.run(_testsuite())

--- a/larky/src/test/resources/quick_tests/test_justin.star
+++ b/larky/src/test/resources/quick_tests/test_justin.star
@@ -45,7 +45,6 @@ def _sign_header_and_claims(encoded_header, encoded_claims, algorithm, key):
     return encoded_string
 
 
-
 def sign(payload, key, headers=None, algorithm=ALGORITHMS.HS256):
     encoded_header = _encode_header(algorithm, additional_headers=headers)
     encoded_payload = _encode_payload(payload)

--- a/larky/src/test/resources/vendor_tests/Crypto/PublicKey/test_DSA.star
+++ b/larky/src/test/resources/vendor_tests/Crypto/PublicKey/test_DSA.star
@@ -1,0 +1,253 @@
+# -*- coding: utf-8 -*-
+#
+#  SelfTest/PublicKey/test_DSA.py: Self-test for the DSA primitive
+#
+# Written in 2008 by Dwayne C. Litzenberger <dlitz@dlitz.net>
+#
+# ===================================================================
+# The contents of this file are dedicated to the public domain.  To
+# the extent that dedication to the public domain is not available,
+# everyone is granted a worldwide, perpetual, royalty-free,
+# non-exclusive license to exercise all rights associated with the
+# contents of this file for any purpose whatsoever.
+# No rights are reserved.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# ===================================================================
+"""Self-test suite for Crypto.PublicKey.DSA"""
+load("@stdlib//builtins", builtins="builtins")
+load("@stdlib//types", types="types")
+load("@stdlib//operator", operator="operator")
+load("@stdlib//re", re="re")
+load("@stdlib//larky", WHILE_LOOP_EMULATION_ITERATION="WHILE_LOOP_EMULATION_ITERATION", larky="larky")
+load("@stdlib//unittest", unittest="unittest")
+load("@vendor//Crypto/Random", Random="Random")
+load("@vendor//Crypto/Math/Primality", Primality="Primality")
+load("@vendor//Crypto/Math/Numbers", Integer="Integer")
+load("@vendor//Crypto/PublicKey/DSA", DSA="DSA")
+load("@vendor//Crypto/st_common", a2b_hex="a2b_hex", b2a_hex="b2a_hex")
+load("@vendor//Crypto/Util/number", bytes_to_long="bytes_to_long", inverse="inverse", size="size")
+load("@vendor//Crypto/Util/py3compat", b="b", bchr="bchr", bstr="bstr", byte_string="byte_string", is_bytes="is_bytes", iter_range="iter_range", _copy_bytes="copy_bytes", tobytes="tobytes", bord="bord", tostr="tostr")
+load("@vendor//asserts", asserts="asserts")
+
+def _sws(s):
+    """Remove whitespace from a text or byte string"""
+    if types.is_string(s):
+        return bytes(re.sub(r'(\s|\x0B|\r?\n)+', '', s), encoding='utf-8')
+    else:
+        b = bytes('', encoding='utf-8')
+        return b.join(s.split())
+
+# Test vector from "Appendix 5. Example of the DSA" of
+# "Digital Signature Standard (DSS)",
+# U.S. Department of Commerce/National Institute of Standards and Technology
+# FIPS 186-2 (+Change Notice), 2000 January 27.
+# http://csrc.nist.gov/publications/fips/fips186-2/fips186-2-change1.pdf
+
+y = _sws("""19131871 d75b1612 a819f29d 78d1b0d7 346f7aa7 7bb62a85
+                9bfd6c56 75da9d21 2d3a36ef 1672ef66 0b8c7c25 5cc0ec74
+                858fba33 f44c0669 9630a76b 030ee333""")
+
+g = _sws("""626d0278 39ea0a13 413163a5 5b4cb500 299d5522 956cefcb
+                3bff10f3 99ce2c2e 71cb9de5 fa24babf 58e5b795 21925c9c
+                c42e9f6f 464b088c c572af53 e6d78802""")
+
+p = _sws("""8df2a494 492276aa 3d25759b b06869cb eac0d83a fb8d0cf7
+                cbb8324f 0d7882e5 d0762fc5 b7210eaf c2e9adac 32ab7aac
+                49693dfb f83724c2 ec0736ee 31c80291""")
+
+q = _sws("""c773218c 737ec8ee 993b4f2d ed30f48e dace915f""")
+
+x = _sws("""2070b322 3dba372f de1c0ffc 7b2e3b49 8b260614""")
+
+k = _sws("""358dad57 1462710f 50e254cf 1a376b2b deaadfbf""")
+k_inverse = _sws("""0d516729 8202e49b 4116ac10 4fc3f415 ae52f917""")
+m = b2a_hex(b("abc"))
+m_hash = _sws("""a9993e36 4706816a ba3e2571 7850c26c 9cd0d89d""")
+r = _sws("""8bac1ab6 6410435c b7181f95 b16ab97c 92b341c0""")
+s = _sws("""41e2345f 1f56df24 58f426d1 55b4ba2d b6dcd8c8""")
+
+dsa = DSA
+
+def DSATest_test_generate_1arg():
+    """DSA (default implementation) generated key (1 argument)"""
+    dsaObj = dsa.generate(1024)
+    _check_private_key(dsaObj)
+    pub = dsaObj.public_key()
+    _check_public_key(pub)
+
+def DSATest_test_generate_2arg():
+    """DSA (default implementation) generated key (2 arguments)"""
+    dsaObj = dsa.generate(1024, Random.new().read)
+    _check_private_key(dsaObj)
+    pub = dsaObj.public_key()
+    _check_public_key(pub)
+
+def DSATest_test_construct_4tuple():
+    """DSA (default implementation) constructed key (4-tuple)"""
+    (_y, _g, _p, _q) = [bytes_to_long(a2b_hex(param)) for param in (y, g, p, q)]
+    dsaObj = dsa.construct((_y, _g, _p, _q))
+    _test_verification(dsaObj)
+
+def DSATest_test_construct_5tuple():
+    """DSA (default implementation) constructed key (5-tuple)"""
+    (_y, _g, _p, _q, _x) = [bytes_to_long(a2b_hex(param)) for param in (y, g, p, q, x)]
+    dsaObj = dsa.construct((_y, _g, _p, _q, _x))
+    _test_signing(dsaObj)
+    _test_verification(dsaObj)
+
+def DSATest_test_construct_bad_key4():
+    (_y, _g, _p, _q) = [bytes_to_long(a2b_hex(param)) for param in (y, g, p, q)]
+    tup = (_y, _g, _p+1, _q)
+    asserts.assert_fails(lambda: dsa.construct(tup), ".*?ValueError")
+
+    tup = (_y, _g, _p, _q+1)
+    asserts.assert_fails(lambda: dsa.construct(tup), ".*?ValueError")
+
+    tup = (_y, 1, _p, _q)
+    asserts.assert_fails(lambda: dsa.construct(tup), ".*?ValueError")
+
+def DSATest_test_construct_bad_key5():
+    (_y, _g, _p, _q, _x) = [bytes_to_long(a2b_hex(param)) for param in (y, g, p, q, x)]
+    tup = (_y, _g, _p, _q, _x+1)
+    asserts.assert_fails(lambda: dsa.construct(tup), ".*?ValueError")
+
+    tup =  (_y, _g, _p, _q, _q+10)
+    asserts.assert_fails(lambda: dsa.construct(tup), ".*?ValueError")
+
+def _check_private_key(dsaObj):
+    # Check capabilities
+    asserts.assert_that(True).is_equal_to(dsaObj.has_private())
+    asserts.assert_that(True).is_equal_to(dsaObj.can_sign())
+    asserts.assert_that(False).is_equal_to(dsaObj.can_encrypt())
+
+    # Sanity check key data
+    asserts.assert_that(True).is_equal_to(dsaObj.p > dsaObj.q)            # p > q
+    asserts.assert_that(160).is_equal_to(size(dsaObj.q))               # size(q) == 160 bits
+    asserts.assert_that(0).is_equal_to((dsaObj.p - 1) % dsaObj.q)      # q is a divisor of p-1
+    asserts.assert_that(dsaObj.y).is_equal_to(pow(dsaObj.g, dsaObj.x, dsaObj.p))     # y == g**x mod p
+    asserts.assert_that(True).is_equal_to((0 < dsaObj.x) and (dsaObj.x < dsaObj.q))       # 0 < x < q
+
+def _check_public_key(dsaObj):
+    _k = bytes_to_long(a2b_hex(k))
+    _m_hash = bytes_to_long(a2b_hex(m_hash))
+
+    # Check capabilities
+    asserts.assert_that(False).is_equal_to(dsaObj.has_private())
+    asserts.assert_that(True).is_equal_to(dsaObj.can_sign())
+    asserts.assert_that(False).is_equal_to(dsaObj.can_encrypt())
+
+    # Check that private parameters are all missing
+    asserts.assert_that(False).is_equal_to(hasattr(dsaObj, 'x'))
+
+    # Sanity check key data
+    asserts.assert_that(True).is_equal_to(dsaObj.p > dsaObj.q)            # p > q
+    asserts.assert_that(160).is_equal_to(size(dsaObj.q))               # size(q) == 160 bits
+    asserts.assert_that(0).is_equal_to((dsaObj.p - 1) % dsaObj.q)      # q is a divisor of p-1
+
+    # Public-only key objects should raise an error when .sign() is called
+    asserts.assert_fails(lambda: dsaObj._sign(_m_hash, _k), ".*?TypeError")
+
+    # Check __eq__ and __ne__
+    asserts.assert_that(dsaObj.public_key() == dsaObj.public_key()).is_equal_to(True) # assert_
+    asserts.assert_that(dsaObj.public_key() != dsaObj.public_key()).is_equal_to(False) # assertFalse
+
+    asserts.assert_that(dsaObj.public_key()).is_equal_to(dsaObj.publickey())
+
+def _test_signing(dsaObj):
+    _k = bytes_to_long(a2b_hex(k))
+    _m_hash = bytes_to_long(a2b_hex(m_hash))
+    _r = bytes_to_long(a2b_hex(r))
+    _s = bytes_to_long(a2b_hex(s))
+    (r_out, s_out) = dsaObj._sign(_m_hash, _k)
+    asserts.assert_that((_r, _s)).is_equal_to((r_out, s_out))
+
+def _test_verification(dsaObj):
+    _m_hash = bytes_to_long(a2b_hex(m_hash))
+    _r = bytes_to_long(a2b_hex(r))
+    _s = bytes_to_long(a2b_hex(s))
+    asserts.assert_that(dsaObj._verify(_m_hash, (_r, _s))).is_true()
+    asserts.assert_that(dsaObj._verify(_m_hash + 1, (_r, _s))).is_false()
+
+def DSATest_test_repr():
+    (_y, _g, _p, _q) = [bytes_to_long(a2b_hex(param)) for param in (y, g, p, q)]
+    dsaObj = dsa.construct((_y, _g, _p, _q))
+    repr(dsaObj)
+
+def DSADomainTest_test_domain1():
+    """Verify we can generate new keys in a given domain"""
+    dsa_key_1 = DSA.generate(1024)
+    domain_params = dsa_key_1.domain()
+
+    dsa_key_2 = DSA.generate(1024, domain=domain_params)
+    asserts.assert_that(dsa_key_1.p).is_equal_to(dsa_key_2.p)
+    asserts.assert_that(dsa_key_1.q).is_equal_to(dsa_key_2.q)
+    asserts.assert_that(dsa_key_1.g).is_equal_to(dsa_key_2.g)
+
+    asserts.assert_that(dsa_key_1.domain()).is_equal_to(dsa_key_2.domain())
+
+def _get_weak_domain():
+    p = Integer(4)
+    for _while_ in range(WHILE_LOOP_EMULATION_ITERATION):
+        if not (p.size_in_bits() != 1024 or Primality.test_probable_prime(p) != Primality.PROBABLY_PRIME):
+            break
+        q1 = Integer.random(exact_bits=80)
+        q2 = Integer.random(exact_bits=80)
+        q = q1 * q2
+        z = Integer.random(exact_bits=1024-160)
+        p = z * q + 1
+
+    h = Integer(2)
+    g = 1
+    for _while_ in range(WHILE_LOOP_EMULATION_ITERATION):
+        if g != 1:
+            break
+        g = pow(int(h), int(z), int(p))
+        h += 1
+
+    return (p, q, g)
+
+
+def DSADomainTest_test_generate_error_weak_domain():
+    """Verify that domain parameters with composite q are rejected"""
+
+    domain_params = _get_weak_domain()
+    asserts.assert_fails(
+        lambda: DSA.generate(1024, domain=domain_params),
+        ".*?ValueError: Invalid DSA domain parameters"
+    )
+
+
+def DSADomainTest_test_construct_error_weak_domain():
+    """Verify that domain parameters with composite q are rejected"""
+    p, q, g = _get_weak_domain()
+    y =  pow(int(g), 89, int(p))
+    asserts.assert_fails(
+        lambda: DSA.construct((y, g, p, q)),
+        ".*?ValueError: Invalid DSA key components"
+    )
+
+
+def _testsuite():
+    _suite = unittest.TestSuite()
+    _suite.addTest(unittest.FunctionTestCase(DSATest_test_generate_1arg))
+    _suite.addTest(unittest.FunctionTestCase(DSATest_test_generate_2arg))
+    _suite.addTest(unittest.FunctionTestCase(DSATest_test_construct_4tuple))
+    _suite.addTest(unittest.FunctionTestCase(DSATest_test_construct_5tuple))
+    _suite.addTest(unittest.FunctionTestCase(DSATest_test_construct_bad_key4))
+    _suite.addTest(unittest.FunctionTestCase(DSATest_test_construct_bad_key5))
+    _suite.addTest(unittest.FunctionTestCase(DSATest_test_repr))
+    _suite.addTest(unittest.FunctionTestCase(DSADomainTest_test_domain1))
+    _suite.addTest(unittest.FunctionTestCase(DSADomainTest_test_generate_error_weak_domain))
+    _suite.addTest(unittest.FunctionTestCase(DSADomainTest_test_construct_error_weak_domain))
+    return _suite
+
+_runner = unittest.TextTestRunner()
+_runner.run(_testsuite())

--- a/larky/src/test/resources/vendor_tests/OpenPGP/test_initial_test.star
+++ b/larky/src/test/resources/vendor_tests/OpenPGP/test_initial_test.star
@@ -23,7 +23,11 @@ load("data_test_fixtures", get_file_contents="get_file_contents")
 
 WHILE_LOOP_EMULATION_ITERATION = larky.WHILE_LOOP_EMULATION_ITERATION
 
-
+# TODO(mahmoudimus): OCCASIONALLY - THIS TEST WILL FAIL BECAUSE OF
+#  LINE 397 (key = Random.new().read(key_bytes)) in OpenPGP/Crypto.star
+#  which reads a random string.
+#  The fix requires a loop to re-generate the key that would not fail the
+#  bitlength check.
 def simple_PGP_test():
     # the test key below contains both private key and public key data
     key = OpenPGP.Message.parse(get_file_contents("helloKey.gpg"))

--- a/larky/src/test/resources/vendor_tests/jose/test_jose.star
+++ b/larky/src/test/resources/vendor_tests/jose/test_jose.star
@@ -15,7 +15,6 @@ load("@vendor//jose/jwk", jwk="jwk")
 load("@vendor//jose/utils", base64url_encode="base64url_encode")
 
 
-
 def test_encrypt_and_decrypt_jwe_with_defaults():
     key = b'b11444485bd146cc823ae1bf3fa42209'
     data = jwe.encrypt(b'533', key)
@@ -170,8 +169,9 @@ def test_sign_with_rsa():
     k = jwk.construct(rsa_private_key, 'RS256')
     sign = k.sign(signing_input)
     encoded_signature = base64url_encode(sign)
-    
+
     encoded_string = b".".join([headers, encoded_payload, encoded_signature])
+
 
 def test_sign_with_ecc():
     es_private_key = """-----BEGIN EC PRIVATE KEY-----
@@ -193,7 +193,7 @@ def test_sign_with_ecc():
     k = jwk.construct(es_private_key, 'ES256')
     sign = k.sign(signing_input)
     encoded_signature = base64url_encode(sign)
-    
+
     encoded_string = b".".join([headers, encoded_payload, encoded_signature])
 
 

--- a/larky/src/test/resources/vendor_tests/lxml/test_c14n.star
+++ b/larky/src/test/resources/vendor_tests/lxml/test_c14n.star
@@ -232,8 +232,8 @@ def test_c14n_eg3():
     # print("--" * 50)
     actual = etree.tostring(tree, method='c14n').strip()
     expected = base64.b64decode((test_results[eg3])).decode('utf-8')
-    print(repr(actual))
-    print(repr(expected))
+    # print(repr(actual))
+    # print(repr(expected))
     asserts.assert_that(actual).is_equal_to(expected)
 
 


### PR DESCRIPTION
## Description of changes in release / Impact of release:

1. fix: Do not copy cryptography but use a similar implementation of the ecdsa one instead.
1. fix: Make all the tests pass
   The key issue was just sloppy porting to Larky. Comparisons can be done via the `operator` module.
   In this commit, is a fix for a *HUGE* issue in `LarkyDigest` that was checking to see if `LarkyDigest` was of instance `Memoable` *INSTEAD* of the underlying `ExtendedDigest` from bouncycastle. This caused a failure where repeated invocations of `hexdigest()` or `digest()` would produce the wrong digest value. The first attempt to fix this was in https://github.com/verygoodsecurity/starlarky/commit/020fde286b4fca6e16cbbb44b81fd3584833f07a for reported issue #179.
1. chore: Add failing tests that were ported from pycryptodome regarding implementation of the DSA algorithm
1. chore: Revert the commits and changes that were introduced due to the ASN1 encoding issues solved in the previous commit.
1. fix: Fix `toStarlark()` to always return an *encoded* version instead of `toString()`
    This was the reason that Josh needed to do all of these string hacks and repacking of OIDs, etc.
1. chore: Comment on a particular test that fails 2 times in 100 runs. This in-determinism is due to `Random.new().read...` and can be fixed by going through a loop
1. chore: Uncomment failing test
1. chore: Remove comments
1. chore: Fix the prime searching code but use the Java `miller_rabin_test` implementation *instead*.
    We probably should also implement the `Lucas Lehmer` primality test at some point in Java, but that's not needed as of now.
1. chore: Expose the `jacobi_symbol` as a "classmethod" on the `Integer` "class"
    FWIW, this `Crypto.Numbers.Integer` class will need to be re-written at some point.
1. chore: dutifully replicate expand_subject_public_key_info from `Crypto/PublicKey/__init__.py`
    We've made some big strides in Larky and now we can use `operator` to mimic the upstream code
1. Following on the previous diffs, we use the newly introduced `coerceToInt` for the built-in function `int()` as well as introduce `AttributeError`.
    This allows us to use `hasattr()` on a "class" that implements `__getattr__`, but throws an exception to signal that the attribute does not exist. We follow it up with an implementation of `hasattr()` that DOES respect `AttributeError`.
1. chore: With the previous diff, we explicitly check for None-ness to respect the `__bool__()` implementation (for truthy-ness).
1. feature: Respect `__getattr__` when looking up a field on `SimpleStruct` and implement the `__bool__()` protocol for truth.
    This is two features in one.

    1. Enhance field lookup to respect `__getattr__` if it exists (which only was respected if you used `getattr()`, not the `.`. When getting a field, check to see if the class implements `__getattr__` and if the field is not found, then invoke the function.
    1. `truth()` should implement the same semantics as python's `__bool__()`. `__bool__()` is used to implement truth value testing and the built-in operation `bool()` and it should return `False` or `True`. If the class does not define `__bool__()`, then check to see if the class defines `__len__()` and it returns non-zero integer (or boolean). If a class defines neither `__len__()` nor `__bool__()`, all its instances are considered true.

    An unrelated bug fix: the reflective property of `__eq__` is `__eq__`, not `__ne__` (this diff is included for ease of merging).
1. feature: Implement coerceToInt as per python's `__index__` and `__int__` (deprecated since 3.8) protocol
1. feature: Introduce the LarkyDigitalSignatureAlgorithm (DSA) implementation.
1. chore: Clean up test output print and clean up the whitespace in some of the test files.

### Is this a breaking change?
- [ ] Yes
- [X] No

### Is there a way to disable the change?
- [x] Use previous release
- [ ] Use a feature flag
- [ ] No
