### PR TITLE
🌈 Python-JOSE's jwe is now ported to Larky with passing tests from #296 💪

### DIFF
--- a/larky/src/main/java/com/verygood/security/larky/modules/crypto/PublicKey/LarkyEllipticCurveCryptography.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/crypto/PublicKey/LarkyEllipticCurveCryptography.java
@@ -5,6 +5,7 @@ import com.verygood.security.larky.modules.crypto.PublicKey.ECC.LarkyECCurve;
 import net.starlark.java.annot.StarlarkMethod;
 import net.starlark.java.eval.StarlarkValue;
 
+import org.bouncycastle.math.ec.custom.sec.SecP256K1Curve;
 import org.bouncycastle.math.ec.custom.sec.SecP256R1Curve;
 import org.bouncycastle.math.ec.custom.sec.SecP384R1Curve;
 import org.bouncycastle.math.ec.custom.sec.SecP521R1Curve;
@@ -15,6 +16,11 @@ public class LarkyEllipticCurveCryptography implements StarlarkValue {
   @StarlarkMethod(name = "P256R1Curve")
   public LarkyECCurve P256R1Curve() {
     return new LarkyECCurve(new SecP256R1Curve());
+  }
+
+  @StarlarkMethod(name = "P256K1Curve")
+  public LarkyECCurve P256K1Curve() {
+    return new LarkyECCurve(new SecP256K1Curve());
   }
 
   @StarlarkMethod(name = "P384R1Curve")

--- a/larky/src/main/java/com/verygood/security/larky/objects/LarkyFunction.java
+++ b/larky/src/main/java/com/verygood/security/larky/objects/LarkyFunction.java
@@ -92,6 +92,11 @@ public class LarkyFunction extends LarkyDescriptor implements ForwardingLarkyTyp
       return this;
     } else {
       final PyObject self = check(obj, thread);
+      // A possible optimization here would be to cache the LarkyMethod
+      // creation based on the this.fget and this.im_class.
+      //
+      // This would reduce memory allocation, as this will probably be a
+      // hot codepath.
       return LarkyMethod.create(
         this.fget, self,
         thread != null ? thread : self.getCurrentThread()

--- a/larky/src/main/java/com/verygood/security/larky/objects/descriptor/LarkyDescriptor.java
+++ b/larky/src/main/java/com/verygood/security/larky/objects/descriptor/LarkyDescriptor.java
@@ -110,6 +110,11 @@ public abstract class LarkyDescriptor extends LarkyPyObject implements LarkyBind
     return (PyObject) obj;
   }
 
+  /**
+   * Compare with <a href="https://github.com/python/cpython/blob/3.10/Objects/classobject.c#L245-L272">classobject.c#method_richcompare</a>
+   * @param obj
+   * @return equal
+   */
   @Override
   public boolean equals(Object obj) {
     if (!(obj instanceof LarkyDescriptor)) {

--- a/larky/src/main/resources/vendor/Crypto/Signature/PKCS1_v1_5.star
+++ b/larky/src/main/resources/vendor/Crypto/Signature/PKCS1_v1_5.star
@@ -36,11 +36,11 @@ Legacy module for PKCS#1 v1.5 signatures.
 load("@stdlib//larky", larky="larky")
 load("@stdlib//types", types="types")
 load("@vendor//Crypto/Signature/pkcs1_15", pkcs1_15="pkcs1_15")
-load("@vendor//option/result", safe="safe")
+load("@vendor//option/result", Result="Result")
 
 
 def _pycrypto_verify(self, hash_object, signature):
-    rval = safe(self._verify)(hash_object, signature)
+    rval = Result.Ok(self._verify).map(lambda v: v(hash_object, signature))
     return False if rval.is_err else True
 
 

--- a/larky/src/main/resources/vendor/Crypto/Util/asn1.star
+++ b/larky/src/main/resources/vendor/Crypto/Util/asn1.star
@@ -281,7 +281,9 @@ def DerObject(asn1Id=None,
         idOctet = s.read_byte()
         if obj._tag_octet != None:
             if idOctet != obj._tag_octet:
-                fail('ValueError("Unexpected DER tag")')
+                fail('ValueError: Unexpected DER tag (idOctet: %s) - expected %s' % (
+                     hex(idOctet),
+                     hex(obj._tag_octet)))
         else:
             obj._tag_octet = idOctet
         length = _decodeLen(s)
@@ -293,7 +295,9 @@ def DerObject(asn1Id=None,
             p = BytesIO_EOF(obj.payload)
             inner_octet = p.read_byte()
             if inner_octet != obj._inner_tag_octet:
-                fail('ValueError("Unexpected internal DER tag")')
+                fail('ValueError: Unexpected internal DER tag (idOctet: %s) - expected %s' % (
+                     hex(idOctet),
+                     hex(obj._tag_octet)))
             length = _decodeLen(p)
             obj.payload = p.read(length)
 
@@ -981,7 +985,6 @@ def DerBitString(value=bytes(), implicit=None, explicit=None):
         Raises:
             ValueError: in case of parsing errors.
         """
-
         return self.derobject.decode(self, der_encoded, strict)
 
     def _decodeFromStream(obj, s, strict):
@@ -995,10 +998,10 @@ def DerBitString(value=bytes(), implicit=None, explicit=None):
             fail('ValueError("Not a valid BIT STRING")')
 
         # Fill-up obj.value
-        self.value = bytearray(r'', encoding='utf-8')
+        obj.value = b''
         # Remove padding count byte
         if obj.payload:
-            self.value = obj.payload[1:]
+            obj.value = obj.payload[1:]
 
     self = __init__(value, implicit, explicit)
     self.encode = encode

--- a/larky/src/main/resources/vendor/jose/backends/pycrypto_backend.star
+++ b/larky/src/main/resources/vendor/jose/backends/pycrypto_backend.star
@@ -253,8 +253,10 @@ def RSAKey(key, algorithm):
             print(
                 "Attempting to verify a message with a private key. " +
                 "This is not recommended.")
-        pkcs1_vfy =  safe(PKCS1_v1_5_Signature.new(self.prepared_key).verify)
-        return pkcs1_vfy(self.hash_alg.new(msg), sig).unwrap_or(False)
+        _pkcs_inst = PKCS1_v1_5_Signature.new(self.prepared_key)
+        _res = (Ok(_pkcs_inst.verify)
+                .map(lambda v: v(self.hash_alg.new(msg), sig)))
+        return _res.unwrap_or(False)
     self.verify = verify
 
     def is_public():

--- a/larky/src/main/resources/vendor/jose/constants/algorithms.star
+++ b/larky/src/main/resources/vendor/jose/constants/algorithms.star
@@ -64,9 +64,18 @@ PBES2_KW = sets.Set([PBES2_HS256_A128KW, PBES2_HS384_A192KW, PBES2_HS512_A256KW]
 HMAC_AUTH_TAG = sets.Set([A128CBC_HS256, A192CBC_HS384, A256CBC_HS512])
 GCM = sets.Set([A128GCM, A192GCM, A256GCM])
 
-SUPPORTED = HMAC.union(RSA_DS).union(sets.Set([DIR])).union(AES_JWE_ENC).union(RSA_KW).union(AES_KW).union(AEC_GCM_KW)
+SUPPORTED = (
+    HMAC
+     .union(RSA_DS)
+     .union(sets.Set([DIR]))
+     .union(AES_JWE_ENC)
+     .union(RSA_KW)
+     .union(AES_KW)
+     .union(AEC_GCM_KW)
+     .union(EC_DS)
+)
 
-ALL = SUPPORTED.union(sets.Set([NONE])).union(EC_DS).union(EC_KW).union(PBES2_KW)
+ALL = SUPPORTED.union(sets.Set([NONE])).union(EC_KW).union(PBES2_KW)
 
 HASHES = {
     HS256: hashlib.sha256,

--- a/larky/src/main/resources/vendor/jose/jwk.star
+++ b/larky/src/main/resources/vendor/jose/jwk.star
@@ -9,7 +9,7 @@ load("@vendor//jose/backends",
      AESKey="AESKey",    # noqa: F401
      DIRKey="DIRKey",    # noqa: F401
      HMACKey="HMACKey",  # noqa: F401
-     ECKey="ECKey",  # noqa: F401
+     ECKey="ECKey",      # noqa: F401
 )
 
 
@@ -30,8 +30,6 @@ def get_key(algorithm):
 
 
 def register_key(algorithm, key_class):
-    # if not issubclass(key_class, Key):
-    #     fail(" TypeError(\"Key class is not a subclass of jwk.Key\")")
     ALGORITHMS.KEYS[algorithm] = key_class
     ALGORITHMS.SUPPORTED.add(algorithm)
     return True
@@ -57,6 +55,7 @@ def construct(key_data, algorithm=None):
 
 
 jwk = larky.struct(
+    __name__='jwk',
     construct=construct,
     register_key=register_key,
     get_key=get_key,

--- a/larky/src/main/resources/vendor/jose/jws.star
+++ b/larky/src/main/resources/vendor/jose/jws.star
@@ -1,22 +1,16 @@
-
 load("@stdlib//binascii", binascii="binascii")
- 
-load("@vendor//six", six="six")
-load("@stdlib//builtins","builtins")
-load("@stdlib//json","json")
-
-try:
-    load("@stdlib//collections/abc", Mapping="Mapping", Iterable="Iterable")  # Python 3
-except ImportError:
-    load("@stdlib//collections", Mapping="Mapping", Iterable="Iterable")  # Python 2, will be deprecated in Python 3.8
-
-load("@vendor//jose", jwk="jwk")
+load("@stdlib//builtins", builtins="builtins")
+load("@stdlib//codecs", codecs="codecs")
+load("@stdlib//json", json="json")
+load("@stdlib//larky", larky="larky")
+load("@stdlib//types", types="types")
+load("@vendor//jose/jwk", jwk="jwk")
 load("@vendor//jose/backends/base", Key="Key")
 load("@vendor//jose/constants", ALGORITHMS="ALGORITHMS")
-load("@vendor//jose/exceptions", JWSError="JWSError")
-load("@vendor//jose/exceptions", JWSSignatureError="JWSSignatureError")
-load("@vendor//jose/utils", base64url_encode="base64url_encode")
-load("@vendor//jose/utils", base64url_decode="base64url_decode")
+load("@vendor//jose/exceptions", JWSError="JWSError", JWSSignatureError="JWSSignatureError")
+load("@vendor//jose/utils", base64url_encode="base64url_encode", base64url_decode="base64url_decode")
+load("@vendor//option/result", Result="Result", Error="Error")
+load("@vendor//six", six="six")
 
 
 def sign(payload, key, headers=None, algorithm=ALGORITHMS.HS256):
@@ -46,7 +40,7 @@ def sign(payload, key, headers=None, algorithm=ALGORITHMS.HS256):
     """
 
     if algorithm not in ALGORITHMS.SUPPORTED:
-        fail(" JWSError('Algorithm %s not supported.' % algorithm)")
+        fail("JWSError: 'Algorithm %s not supported.'" % algorithm)
 
     encoded_header = _encode_header(algorithm, additional_headers=headers)
     encoded_payload = _encode_payload(payload)
@@ -144,100 +138,105 @@ def _encode_header(algorithm, additional_headers=None):
     if additional_headers:
         header.update(additional_headers)
 
-    json_header = json.dumps(
-        header,
-        separators=(',', ':'),
-        sort_keys=True,
-    ).encode('utf-8')
+    sorted_keys = sorted(header.keys())
+    sorted_headers = {}
+    for sk in sorted_keys:
+        sorted_headers[sk] = header[sk]
+
+    json_header = bytes(
+        Result.Ok(json.dumps)
+            .map(lambda x: x(sorted_headers))
+            .unwrap()
+            .replace(', ', ',')
+            .replace(': ', ':'),
+        encoding='utf-8'
+    )
 
     return base64url_encode(json_header)
 
 
 def _encode_payload(payload):
-    if types.is_instance(payload, Mapping):
-        try:
-            payload = json.dumps(
-                payload,
-                separators=(',', ':'),
-            ).encode('utf-8')
-        except ValueError:
-            pass
+    if types.is_dict(payload):
+        payload = bytes(
+            Result.Ok(json.dumps)
+                .map(lambda x: x(payload))
+                .unwrap()
+                .replace(': ', ':')
+                .replace(', ', ','),
+            encoding='utf-8'
+        )
 
     return base64url_encode(payload)
 
 
 def _sign_header_and_claims(encoded_header, encoded_claims, algorithm, key):
-    signing_input = bytes([0x2e]).join([encoded_header, encoded_claims])
-    try:
-        if not types.is_instance(key, Key):
-            key = jwk.construct(key, algorithm)
-        signature = key.sign(signing_input)
-    except Exception as e:
-        fail(" JWSError(e)")
+    signing_input = b'.'.join([encoded_header, encoded_claims])
+    if not builtins.isinstance(key, Key):
+        key = Result.Ok(jwk.construct).map(lambda x: x(key, algorithm)).unwrap()
+    signature = Result.Ok(key.sign).map(lambda x: x(signing_input)).unwrap()
 
     encoded_signature = base64url_encode(signature)
 
-    encoded_string = bytes([0x2e]).join([encoded_header, encoded_claims, encoded_signature])
+    encoded_string = b'.'.join([encoded_header, encoded_claims, encoded_signature])
 
     return encoded_string.decode('utf-8')
 
 
 def _load(jwt):
-    if types.is_instance(jwt, six.text_type):
-        jwt = jwt.encode('utf-8')
-    try:
-        signing_input, crypto_segment = jwt.rsplit(bytes([0x2e]), 1)
-        header_segment, claims_segment = signing_input.split(bytes([0x2e]), 1)
-        header_data = base64url_decode(header_segment)
-    except ValueError:
-        fail(" JWSError('Not enough segments')")
-    except (TypeError, binascii.Error):
-        fail(" JWSError('Invalid header padding')")
+    if types.is_string(jwt):
+        jwt = bytes(jwt, encoding='utf-8')
+    signing_input, crypto_segment = (
+        Result.Ok(jwt.rsplit)
+            .map(lambda x: x(b'.', 1))
+            .expect("JWSError: Not enough segments"))
+    header_segment, claims_segment = (
+        Result.Ok(signing_input.split)
+            .map(lambda x: x(b'.', 1))
+            .expect("JWSError: Not enough segments"))
+    header_data = (
+        Result.Ok(base64url_decode)
+            .map(lambda x: x(header_segment))
+            .expect("JWSError: Invalid header padding"))
 
-    try:
-        header = json.loads(header_data.decode('utf-8'))
-    except ValueError as e:
-        fail(" JWSError('Invalid header string: %s' % e)")
+    header = (Result.Ok(json.loads)
+              .map(lambda x: x(header_data.decode('utf-8')))
+              .expect("JWSError: 'Invalid header string: %r'" % header_data))
 
-    if not types.is_instance(header, Mapping):
-        fail(" JWSError('Invalid header string: must be a json object')")
+    if not types.is_dict(header):
+        fail("JWSError: Invalid header string: must be a json object")
 
-    try:
-        payload = base64url_decode(claims_segment)
-    except (TypeError, binascii.Error):
-        fail(" JWSError('Invalid payload padding')")
+    payload = (Result.Ok(base64url_decode)
+               .map(lambda x: x(claims_segment))
+               .expect("JWSError: Invalid payload padding"))
 
-    try:
-        signature = base64url_decode(crypto_segment)
-    except (TypeError, binascii.Error):
-        fail(" JWSError('Invalid crypto padding')")
+    signature = (Result.Ok(base64url_decode)
+                 .map(lambda x: x(crypto_segment))
+                 .expect("JWSError: Invalid crypto padding"))
 
     return (header, payload, signing_input, signature)
 
 
 def _sig_matches_keys(keys, signing_input, signature, alg):
     for key in keys:
-        if not types.is_instance(key, Key):
+        if not builtins.isinstance(key, Key):
             key = jwk.construct(key, alg)
-        try:
-            if key.verify(signing_input, signature):
-                return True
-        except Exception:
-            pass
+        res = Result.Ok(key.verify).map(lambda x: x(signing_input, signature))
+        if res.is_ok and res.unwrap():
+            return True
+
     return False
 
 
 def _get_keys(key):
 
-    if types.is_instance(key, Key):
+    if builtins.isinstance(key, Key):
         return (key,)
 
-    try:
-        key = json.loads(key, parse_int=str, parse_float=str)
-    except Exception:
-        pass
+    rval = Result.Ok(json.loads).map(lambda loads: loads(key))
+    if rval.is_ok:
+        key = rval.unwrap()
 
-    if types.is_instance(key, Mapping):
+    if types.is_dict(key):
         if 'keys' in key:
             # JWK Set per RFC 7517
             return key['keys']
@@ -252,8 +251,8 @@ def _get_keys(key):
             return (key,)
 
     # Iterable but not text or mapping => list- or tuple-like
-    elif (types.is_instance(key, Iterable) and
-          not (types.is_instance(key, six.string_types) or types.is_instance(key, six.binary_type))):
+    elif (types.is_iterable(key) and
+          not (types.is_string(key) or types.is_bytelike(key))):
         return key
 
     # Scalar value, wrap in tuple.
@@ -265,17 +264,25 @@ def _verify_signature(signing_input, header, signature, key='', algorithms=None)
 
     alg = header.get('alg')
     if not alg:
-        fail(" JWSError('No algorithm was specified in the JWS header.')")
+        fail("JWSError: No algorithm was specified in the JWS header.")
 
     if algorithms != None and alg not in algorithms:
-        fail(" JWSError('The specified alg value is not allowed')")
+        fail("JWSError: The specified alg value is not allowed")
 
     keys = _get_keys(key)
-    try:
-        if not _sig_matches_keys(keys, signing_input, signature, alg):
-            fail(" JWSSignatureError()")
-    except JWSSignatureError:
-        fail(" JWSError('Signature verification failed.')")
-    except JWSError:
-        fail(" JWSError('Invalid or unsupported algorithm: %s' % alg)")
+    rval = Result.Ok(_sig_matches_keys).map(lambda x: x(keys, signing_input, signature, alg))
+    if rval.is_ok:
+        if rval.unwrap():
+            return
+        fail("JWSError: Signature verification failed.")
+    fail("JWSError: " + 'Invalid or unsupported algorithm: %s (%s)' % (alg, rval._val))
 
+
+jws = larky.struct(
+    __name__='jws',
+    get_unverified_claims=get_unverified_claims,
+    get_unverified_header=get_unverified_header,
+    get_unverified_headers=get_unverified_headers,
+    sign=sign,
+    verify=verify
+)

--- a/larky/src/test/resources/vendor_tests/jose/test_jws.star
+++ b/larky/src/test/resources/vendor_tests/jose/test_jws.star
@@ -1,0 +1,71 @@
+load("@stdlib//re", re="re")
+load("@stdlib//unittest", unittest="unittest")
+load("@vendor//asserts", asserts="asserts")
+load("@vendor//jose/jws", jws="jws")
+
+
+ecc_public_key = b"-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE7l9S5znW4VsHl3XXM1cFPXzkJ17QTX+H\nE4gS/P/0EgxJtkpIuKFNwjZnetGKCkJmIjdsVxtzQV3GPOTsi/Btzg==\n-----END PUBLIC KEY-----"
+ecc_private_key = b"-----BEGIN EC PRIVATE KEY-----\nMHQCAQEEIPjfg99RGAgLkIWU+Ell5EWzQMXJ99C++CYaZ8DN4wmfoAcGBSuBBAAK\noUQDQgAE7l9S5znW4VsHl3XXM1cFPXzkJ17QTX+HE4gS/P/0EgxJtkpIuKFNwjZn\netGKCkJmIjdsVxtzQV3GPOTsi/Btzg==\n-----END EC PRIVATE KEY-----"
+rsa_public_key = b"-----BEGIN PUBLIC KEY-----\nMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCQouotdvmxpjokxe5GZxNQbWVQ\n6ip3T7k5xbU37jJheojRJm0wtTSbtIetDXr5vHp0/SnuxzMvEccB7/UrWWGOabVx\nHas4edX2X7Ie9JTDg9G9smkcCDlQLD6cvxgIy7afH5rG//SoBgMPwnAicHXaEuWp\nu+MaeJm1BAg6MND/2QIDAQAB\n-----END PUBLIC KEY-----"
+rsa_private_key = b"-----BEGIN RSA PRIVATE KEY-----\nMIICXAIBAAKBgQCQouotdvmxpjokxe5GZxNQbWVQ6ip3T7k5xbU37jJheojRJm0w\ntTSbtIetDXr5vHp0/SnuxzMvEccB7/UrWWGOabVxHas4edX2X7Ie9JTDg9G9smkc\nCDlQLD6cvxgIy7afH5rG//SoBgMPwnAicHXaEuWpu+MaeJm1BAg6MND/2QIDAQAB\nAoGAbJKfD7n7/is2AlzCXP8LNJiqMW9WqXGjLYcIXg/kqd/9zGL4HFQqRafjITi5\nU7b0hdV1INVPysmhhgbHF99kpw3ee31mSQtenn//SGQFJeOn+QE+R63FH8icrod/\nNsXqR4w/61RS07wiYOtfzN/7czczi6WQV4W3xnugG6971vECQQDKCHyJ9W4xuYMl\nKcuQwokFsDKR1s9UpUPOCLeaQJFmW3hCHrWsFic2AH1oWxUrJdaAYL/DFTmtzpXJ\nz+a6heCHAkEAt0V/zqCWjG0+OIZopTaGS6/0Rtp67kAy2GlFLpg9hnIqTqgtHS1+\noeT9D0qQrNKGu5fR14WFQltTPxkWNOAUnwJABR7T8TcsNMxr23xEsYWMrX06uuGD\n3bRWlJk59gne5YY59QsMNbFWCxNWGlf8oFxUJGrPUWVvUc1jlHrVcTLFbwJBAJTD\nYDwMFEgGgMQHLjg1KwuS1tkQjUqJZ/xMbvCkeQSB9R+F2aDehfTJ2DQqVYdDGER7\ntsSXyBSV5tvH9EOVRIcCQFktF/V6TW6X3I3XmQjEuie4W0UT8tpWUcgkwO8slvra\nQ7aSCBe5pLlVT0SorTqH3ywozGy2uzGyaigjtIFbgcM=\n-----END RSA PRIVATE KEY-----"
+
+
+def test_sign_rsa():
+    algorithm = "RS256"
+    payload = {"a": "b"}
+    jwe = jws.sign(payload, rsa_private_key, algorithm=algorithm)
+    asserts.assert_true(re.match(r"[^-\s]+\.[^-\s]+\.[^-\s]+", jwe))
+
+
+def test_verify_rsa():
+    algorithm = "RS256"
+    jwe = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoiYiJ9.cfJ0k9bqQ8d36WJb3CSexeVWcBGAJKx7AmEis7G1sb162ehtEs2ZRe3S5LEKzKbBaI_wQKXHonMv8bQrzrjDZeAYkeW8nc0gyUkeyqw42lNdmj2BFu8f_jkSYqTqlD31MsGafSyfvxW1lYOO_porBQ3WWDt3-G-QUEw1y-x7lGg"
+    verified = jws.verify(jwe, rsa_public_key, algorithms=[algorithm])
+    asserts.assert_true(verified)
+
+
+def test_sign_and_verify_rsa():
+    algorithm = "RS256"
+    payload = {"a": "b"}
+    jwe = jws.sign(payload, rsa_private_key, algorithm=algorithm)
+    asserts.assert_true(re.match(r"[^-\s]+\.[^-\s]+\.[^-\s]+", jwe))
+    verified = jws.verify(jwe, rsa_public_key, algorithms=[algorithm])
+    asserts.assert_true(verified)
+
+
+def test_sign_ecc():
+    algorithm = "ES256"
+    payload = {"a": "b"}
+    jwe = jws.sign(payload, ecc_private_key, algorithm=algorithm)
+    asserts.assert_true(re.match(r"[^-\s]+\.[^-\s]+\.[^-\s]+", jwe))
+
+
+def test_verify_ecc():
+    algorithm = "ES256"
+    jwe = "eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.eyJhIjoiYiJ9.aag1Do5YHBFQHnW2UaUblLR5BxhSdORo2pWIvr3mKr3MyFoZIZnRrKEgwETfcT0W-Nk2zD7y5xz0dpWD2ZPSnw"
+    verified = jws.verify(jwe, ecc_public_key, algorithms=[algorithm])
+    asserts.assert_true(verified)
+
+
+def test_sign_and_verify_ecc():
+    algorithm = "ES256"
+    payload = {"a": "b"}
+    jwe = jws.sign(payload, ecc_private_key, algorithm=algorithm)
+    asserts.assert_true(re.match(r"[^-\s]+\.[^-\s]+\.[^-\s]+", jwe))
+    verified = jws.verify(jwe, ecc_public_key, algorithms=[algorithm])
+    asserts.assert_true(verified)
+
+
+def _testsuite():
+    _suite = unittest.TestSuite()
+    _suite.addTest(unittest.FunctionTestCase(test_sign_rsa))
+    _suite.addTest(unittest.FunctionTestCase(test_verify_rsa))
+    _suite.addTest(unittest.FunctionTestCase(test_sign_and_verify_rsa))
+    _suite.addTest(unittest.FunctionTestCase(test_sign_ecc))
+    _suite.addTest(unittest.FunctionTestCase(test_verify_ecc))
+    _suite.addTest(unittest.FunctionTestCase(test_sign_and_verify_ecc))
+    return _suite
+
+
+_runner = unittest.TextTestRunner()
+_runner.run(_testsuite())

--- a/larky/src/test/resources/vendor_tests/jose/test_signatures_no_jws.star
+++ b/larky/src/test/resources/vendor_tests/jose/test_signatures_no_jws.star
@@ -1,0 +1,119 @@
+load("@stdlib//base64", base64="base64")
+load("@stdlib//json", json="json")
+load("@stdlib//re", re="re")
+load("@stdlib//unittest", unittest="unittest")
+load("@vendor//asserts", asserts="asserts")
+load("@vendor//jose/jwk", jwk="jwk")
+load("@vendor//jose/jws", jws="jws")
+
+ecc_public_key = b"""-----BEGIN PUBLIC KEY-----\nMFYwEAYHKoZIzj0CAQYFK4EEAAoDQgAE7l9S5znW4VsHl3XXM1cFPXzkJ17QTX+H\nE4gS/P/0EgxJtkpIuKFNwjZnetGKCkJmIjdsVxtzQV3GPOTsi/Btzg==\n-----END PUBLIC KEY-----"""
+ecc_private_key = b"""-----BEGIN EC PRIVATE KEY-----\nMHQCAQEEIPjfg99RGAgLkIWU+Ell5EWzQMXJ99C++CYaZ8DN4wmfoAcGBSuBBAAK\noUQDQgAE7l9S5znW4VsHl3XXM1cFPXzkJ17QTX+HE4gS/P/0EgxJtkpIuKFNwjZn\netGKCkJmIjdsVxtzQV3GPOTsi/Btzg==\n-----END EC PRIVATE KEY-----"""
+rsa_public_key = b"""-----BEGIN PUBLIC KEY-----\nMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCQouotdvmxpjokxe5GZxNQbWVQ\n6ip3T7k5xbU37jJheojRJm0wtTSbtIetDXr5vHp0/SnuxzMvEccB7/UrWWGOabVx\nHas4edX2X7Ie9JTDg9G9smkcCDlQLD6cvxgIy7afH5rG//SoBgMPwnAicHXaEuWp\nu+MaeJm1BAg6MND/2QIDAQAB\n-----END PUBLIC KEY-----"""
+rsa_private_key = b"""-----BEGIN RSA PRIVATE KEY-----\nMIICXAIBAAKBgQCQouotdvmxpjokxe5GZxNQbWVQ6ip3T7k5xbU37jJheojRJm0w\ntTSbtIetDXr5vHp0/SnuxzMvEccB7/UrWWGOabVxHas4edX2X7Ie9JTDg9G9smkc\nCDlQLD6cvxgIy7afH5rG//SoBgMPwnAicHXaEuWpu+MaeJm1BAg6MND/2QIDAQAB\nAoGAbJKfD7n7/is2AlzCXP8LNJiqMW9WqXGjLYcIXg/kqd/9zGL4HFQqRafjITi5\nU7b0hdV1INVPysmhhgbHF99kpw3ee31mSQtenn//SGQFJeOn+QE+R63FH8icrod/\nNsXqR4w/61RS07wiYOtfzN/7czczi6WQV4W3xnugG6971vECQQDKCHyJ9W4xuYMl\nKcuQwokFsDKR1s9UpUPOCLeaQJFmW3hCHrWsFic2AH1oWxUrJdaAYL/DFTmtzpXJ\nz+a6heCHAkEAt0V/zqCWjG0+OIZopTaGS6/0Rtp67kAy2GlFLpg9hnIqTqgtHS1+\noeT9D0qQrNKGu5fR14WFQltTPxkWNOAUnwJABR7T8TcsNMxr23xEsYWMrX06uuGD\n3bRWlJk59gne5YY59QsMNbFWCxNWGlf8oFxUJGrPUWVvUc1jlHrVcTLFbwJBAJTD\nYDwMFEgGgMQHLjg1KwuS1tkQjUqJZ/xMbvCkeQSB9R+F2aDehfTJ2DQqVYdDGER7\ntsSXyBSV5tvH9EOVRIcCQFktF/V6TW6X3I3XmQjEuie4W0UT8tpWUcgkwO8slvra\nQ7aSCBe5pLlVT0SorTqH3ywozGy2uzGyaigjtIFbgcM=\n-----END RSA PRIVATE KEY-----"""
+
+
+def build_jwe(body, alg, private_key, public_key):
+    header = {"typ": "JWT", "alg": alg}
+    json_header = bytes(
+        json.dumps(
+            header,
+        ),
+        "utf-8",
+    )
+    headers = base64.urlsafe_b64encode(json_header)
+    encoded_payload = base64.urlsafe_b64encode(bytes(body, "utf-8"))
+    signing_input = bytes([0x2E]).join([headers, encoded_payload])
+    priv_jwk = jwk.construct(private_key, alg)
+    sign = priv_jwk.sign(signing_input)
+    pub_jwk = jwk.construct(public_key, alg)
+    pub_jwk.verify(signing_input, sign)
+    encoded_signature = base64.urlsafe_b64encode(sign)
+
+    encoded_string = b".".join([headers, encoded_payload, encoded_signature])
+    return encoded_string
+
+
+## Attempt to build and sign a JWE without using the JWS module. Verify it is valid by using JWS.verify
+def test_sign_rsa_without_jws():
+    alg = "RS256"
+    jwe = build_jwe(
+        json.dumps({"a": "b"}), alg, rsa_private_key, rsa_public_key
+    ).decode()
+    asserts.assert_true(re.match(r"[^-\s]+\.[^-\s]+\.[^-\s]+", jwe))
+    # Commenting out because currently breaks on load...
+    # verified = jws.verify(jwe, rsa_public_key, algorithms=[alg])
+    # asserts.assert_true(verified)
+
+
+## Verify an RSA encrypted JWE without the JWS module
+def test_verify_rsa_without_jws():
+    alg = "RS256"
+    jwe = b"eyJ0eXAiOiAiSldUIiwgImFsZyI6ICJSUzI1NiJ9.eyJhIjogImIifQ==.erMoTS3F5-vNRaY9RAaNWv8vDNnu63O7CmhOC-tbOuqfkg8tQs0nIch3wHbU04aCa_9wjU8QKVLcGJYXC8BG8EJX0t2Em71_9zTiv8J-W6gNctG1xDAldQVWVfFKBpfiDQqNnGlmwmwnsWIsW-AtGE3L3KeDcKkVY5eBh7paLDQ="
+    headers, encoded_payload, encoded_signature = jwe.split(b".")
+    signed = bytes([0x2E]).join([headers, encoded_payload])
+    pub_jwk = jwk.construct(rsa_public_key, alg)
+    decoded_sig = base64.urlsafe_b64decode(encoded_signature)
+    verified = pub_jwk.verify(signed, decoded_sig)
+    asserts.assert_true(verified)
+
+
+## Sign and verify an RSA encrypted JWE without the JWS module
+def test_sign_and_verify_rsa_without_jws():
+    alg = "RS256"
+    jwe = build_jwe(json.dumps({"a": "b"}), alg, rsa_private_key, rsa_public_key)
+    headers, encoded_payload, encoded_signature = jwe.split(b".")
+    signed = bytes([0x2E]).join([headers, encoded_payload])
+    pub_jwk = jwk.construct(rsa_public_key, alg)
+    decoded_sig = base64.urlsafe_b64decode(encoded_signature)
+    verified = pub_jwk.verify(signed, decoded_sig)
+    asserts.assert_true(verified)
+
+
+def test_sign_ecc_without_jws():
+    alg = "ES256"
+    jwe = build_jwe(
+        json.dumps({"a": "b"}), alg, ecc_private_key, ecc_public_key
+    ).decode()
+    asserts.assert_true(re.match(r"[^-\s]+\.[^-\s]+\.[^-\s]+", jwe))
+    # Commenting out because currently breaks on load...
+    # verified = jws.verify(jwe, ecc_public_key, algorithms=[alg])
+    # asserts.assert_true(verified)
+
+
+## Sign and verify an RSA encrypted JWE without the JWS module
+def test_verify_ecc_without_jws():
+    alg = "ES256"
+    jwe = b"eyJ0eXAiOiAiSldUIiwgImFsZyI6ICJFUzI1NiJ9.eyJhIjogImIifQ==.CZTOELuTxFw03E1R7fwRK4lqJPAzQXpzNY4dte4OOiu3McVAQioCkMlPRBN7c0tgCfqTmWH6UD-gqe1WgsNQTQ=="
+    headers, encoded_payload, encoded_signature = jwe.split(b".")
+    signed = bytes([0x2E]).join([headers, encoded_payload])
+    pub_jwk = jwk.construct(ecc_public_key, alg)
+    decoded_sig = base64.urlsafe_b64decode(encoded_signature)
+    verified = pub_jwk.verify(signed, decoded_sig)
+    asserts.assert_true(verified)
+
+
+## Sign and verify an RSA encrypted JWE without the JWS module
+def test_sign_and_verify_ecc_without_jws():
+    alg = "ES256"
+    jwe = build_jwe(json.dumps({"a": "b"}), alg, ecc_private_key, ecc_public_key)
+    headers, encoded_payload, encoded_signature = jwe.split(b".")
+    signed = bytes([0x2E]).join([headers, encoded_payload])
+    pub_jwk = jwk.construct(ecc_public_key, alg)
+    decoded_sig = base64.urlsafe_b64decode(encoded_signature)
+    verified = pub_jwk.verify(signed, decoded_sig)
+    asserts.assert_true(verified)
+
+
+def _testsuite():
+    _suite = unittest.TestSuite()
+    _suite.addTest(unittest.FunctionTestCase(test_sign_rsa_without_jws))
+    _suite.addTest(unittest.FunctionTestCase(test_verify_rsa_without_jws))
+    _suite.addTest(unittest.FunctionTestCase(test_sign_and_verify_rsa_without_jws))
+    _suite.addTest(unittest.FunctionTestCase(test_sign_ecc_without_jws))
+    _suite.addTest(unittest.FunctionTestCase(test_verify_ecc_without_jws))
+    _suite.addTest(unittest.FunctionTestCase(test_sign_and_verify_ecc_without_jws))
+    return _suite
+
+
+_runner = unittest.TextTestRunner()
+_runner.run(_testsuite())


### PR DESCRIPTION
## Description of changes in release / Impact of release:
- chore: whitespace cleanup, better error messages and more conversions from `safe()` to using the `Result.Ok().map()` pattern.

- chore: update comments on LarkyDescriptor and LarkyFunction to describe a possible optimization.

- feature: introduce failing jws test from @mottersheadt

- feature: port python-jose's jws.py to jws.star for larky

- feature: fix first test in `test_jws.star`

  It was failing because in PR #295 or PR #250, we did not update the SUPPORTED algorithms.


- feature: introduce a non-pycryptodome compatible ECC curve, a Koblitz curve, SecP256K1Curve to fix the ECC test.

  The ECC key was generated by @mottersheadt from
  https://cloud.google.com/iot/docs/how-tos/credentials/keys via:

  - `openssl ecparam -genkey -name prime256v1 -noout -out ec_private.pem`
  - `openssl ec -in ec_private.pem -pubout -out ec_public.pem`

  The "k" in `sepc256k1` stands for Koblitz and the "r" in sepc256r1 stands for
  random. A Koblitz elliptic curve has some special properties that make it
  possible to implement the group operation more efficiently.

  `secp256k1` was almost never used before Bitcoin became popular, but it is now
  gaining in popularity due to its several nice properties. Most commonly-used
  curves have a random structure, but `secp256k1` was constructed in a special
  non-random way which allows for especially efficient computation. As a result,
  it is often more than 30% faster than other curves if the implementation is
  sufficiently optimized.

  Also, unlike the popular NIST curves, `secp256k1's` constants were selected in
  a predictable way, which significantly reduces the possibility that the
  curve's creator inserted any sort of backdoor into the curve.

- fix: in our ASN1 implementation, all `toStarlark()` should return `getEncoded()`

  This is a continuation of the fixes introduced in #295, but this fixes the *last failing test* in `test_jws.star`. 🍾🎆

## Documentation

See `larky/src/test/resources/vendor_tests/jose/test_jws.star` for examples on how to use.  This follows the exact API examples from the official `python-jose` documentation @ https://python-jose.readthedocs.io/en/latest/.

## Risks of this release
N/A

### Is this a breaking change?
- [ ] Yes
- [X] No

### Is there a way to disable the change?
- [x] Use previous release
- [ ] Use a feature flag
- [ ] No
