### PR TITLE
Expose AES CTR

### DIFF
--- a/larky/src/main/resources/vendor/Crypto/Cipher/__init__.star
+++ b/larky/src/main/resources/vendor/Crypto/Cipher/__init__.star
@@ -26,7 +26,7 @@ load("@vendor//Crypto/Cipher/_mode_ecb", EcbMode="EcbMode")
 load("@vendor//Crypto/Cipher/_mode_cbc", CbcMode="CbcMode")
 load("@vendor//Crypto/Cipher/_mode_cfb", CfbMode="CfbMode")
 # load("@vendor//Crypto/Cipher/_mode_ofb", _create_ofb_cipher="_create_ofb_cipher")
-load("@vendor//Crypto/Cipher/_mode_ctr", _create_ctr_cipher="_create_ctr_cipher")
+load("@vendor//Crypto/Cipher/_mode_ctr", CtrMode="CtrMode")
 # load("@vendor//Crypto/Cipher/_mode_openpgp", _create_openpgp_cipher="_create_openpgp_cipher")
 load("@vendor//Crypto/Cipher/_mode_ccm", CcmMode="CcmMode")
 # load("@vendor//Crypto/Cipher/_mode_eax", _create_eax_cipher="_create_eax_cipher")
@@ -38,7 +38,7 @@ _modes = { 1: EcbMode._create_ecb_cipher,
            2: CbcMode._create_cbc_cipher,
            3: CfbMode._create_cfb_cipher,
            # 5:_create_ofb_cipher,
-           6:_create_ctr_cipher,
+           6: CtrMode._create_ctr_cipher,
            # 7:_create_openpgp_cipher,
            # 9:_create_eax_cipher
            }

--- a/larky/src/main/resources/vendor/Crypto/Cipher/__init__.star
+++ b/larky/src/main/resources/vendor/Crypto/Cipher/__init__.star
@@ -26,7 +26,7 @@ load("@vendor//Crypto/Cipher/_mode_ecb", EcbMode="EcbMode")
 load("@vendor//Crypto/Cipher/_mode_cbc", CbcMode="CbcMode")
 load("@vendor//Crypto/Cipher/_mode_cfb", CfbMode="CfbMode")
 # load("@vendor//Crypto/Cipher/_mode_ofb", _create_ofb_cipher="_create_ofb_cipher")
-# load("@vendor//Crypto/Cipher/_mode_ctr", _create_ctr_cipher="_create_ctr_cipher")
+load("@vendor//Crypto/Cipher/_mode_ctr", _create_ctr_cipher="_create_ctr_cipher")
 # load("@vendor//Crypto/Cipher/_mode_openpgp", _create_openpgp_cipher="_create_openpgp_cipher")
 load("@vendor//Crypto/Cipher/_mode_ccm", CcmMode="CcmMode")
 # load("@vendor//Crypto/Cipher/_mode_eax", _create_eax_cipher="_create_eax_cipher")
@@ -38,7 +38,7 @@ _modes = { 1: EcbMode._create_ecb_cipher,
            2: CbcMode._create_cbc_cipher,
            3: CfbMode._create_cfb_cipher,
            # 5:_create_ofb_cipher,
-           # 6:_create_ctr_cipher,
+           6:_create_ctr_cipher,
            # 7:_create_openpgp_cipher,
            # 9:_create_eax_cipher
            }

--- a/larky/src/main/resources/vendor/Crypto/Cipher/_mode_ctr.star
+++ b/larky/src/main/resources/vendor/Crypto/Cipher/_mode_ctr.star
@@ -349,7 +349,7 @@ def _create_ctr_cipher(factory, **kwargs):
         initial_value >>= 8
     words += [bytes([0x00])] * max(0, counter_len - len(words))
     if not little_endian:
-        words.reverse()
+        words = reversed(words)
     initial_counter_block = prefix + bytearray(r"", encoding='utf-8').join(words) + suffix
 
     if len(initial_counter_block) != factory.block_size:

--- a/larky/src/main/resources/vendor/Crypto/Util/Counter.star
+++ b/larky/src/main/resources/vendor/Crypto/Util/Counter.star
@@ -22,6 +22,7 @@
 # SOFTWARE.
 # ===================================================================
 load("@stdlib//jcrypto", _JCrypto="jcrypto")
+load("@stdlib//larky", larky="larky")
 
 
 _empty = bytes(r"", encoding='utf-8')
@@ -66,7 +67,7 @@ def new(nbits, prefix=_empty, suffix=_empty, initial_value=1, little_endian=Fals
 
     """
     if (nbits % 8) != 0:
-        raise ValueError("'nbits' must be a multiple of 8")
+        fail("'nbits' must be a multiple of 8")
 
     iv_bl = _JCrypto.Math.bit_length(initial_value)
     if iv_bl > nbits:
@@ -80,3 +81,7 @@ def new(nbits, prefix=_empty, suffix=_empty, initial_value=1, little_endian=Fals
             "initial_value": initial_value,
             "little_endian": little_endian
             }
+
+Counter = larky.struct(
+  new = new
+)

--- a/larky/src/test/resources/quick_tests/test_kateryna.star
+++ b/larky/src/test/resources/quick_tests/test_kateryna.star
@@ -1,4 +1,5 @@
 load("@stdlib//unittest","unittest")
+load("@stdlib//base64", "base64")
 load("@stdlib//json","json")
 load("@stdlib//types", "types")
 load("@stdlib//random", "random")
@@ -7,16 +8,25 @@ load("@vendor//Crypto/Cipher/AES", AES="AES")
 load("@vendor//Crypto/Util/Counter", Counter="Counter")
 load("@vendor//asserts","asserts")
     
-def test_kateryna_stuff():
+def test_ctr():
     key = b'Sixteen byte key'
     ctr = Counter.new(AES.block_size * 8)
-    crypto = AES.new(key, AES.MODE_CTR, counter=ctr)
-    encrypted = crypto.encrypt(b"TEST PAYLOAD!")
+    crypto = AES.new(key, AES.MODE_CTR)
+    nonce = base64.b64encode(crypto.nonce).decode('utf-8')
+    encrypted = base64.b64encode(crypto.encrypt(b"TEST PAYLOAD!")).decode('utf-8')
+    result = json.dumps({"nonce":nonce,"ciphertext":encrypted})
 
+    b64 = json.loads(result)
+    nonce = base64.b64decode(b64['nonce'])
+    ct = base64.b64decode(b64['ciphertext'])
+    cipher = AES.new(key, AES.MODE_CTR, nonce=nonce)
+    pt = cipher.decrypt(ct).decode('utf-8')
+    asserts.assert_that(pt).is_equal_to("TEST PAYLOAD!")
 
 def _testsuite():
     _suite = unittest.TestSuite()
-    _suite.addTest(unittest.FunctionTestCase(test_kateryna_stuff))
+    _suite.addTest(unittest.FunctionTestCase(test_ctr))
+    #_suite.addTest(unittest.FunctionTestCase(test_oppdateringer))
     return _suite
 
 

--- a/larky/src/test/resources/quick_tests/test_kateryna.star
+++ b/larky/src/test/resources/quick_tests/test_kateryna.star
@@ -26,7 +26,6 @@ def test_ctr():
 def _testsuite():
     _suite = unittest.TestSuite()
     _suite.addTest(unittest.FunctionTestCase(test_ctr))
-    #_suite.addTest(unittest.FunctionTestCase(test_oppdateringer))
     return _suite
 
 

--- a/larky/src/test/resources/quick_tests/test_kateryna.star
+++ b/larky/src/test/resources/quick_tests/test_kateryna.star
@@ -1,0 +1,24 @@
+load("@stdlib//unittest","unittest")
+load("@stdlib//json","json")
+load("@stdlib//types", "types")
+load("@stdlib//random", "random")
+
+load("@vendor//Crypto/Cipher/AES", AES="AES")
+load("@vendor//Crypto/Util/Counter", Counter="Counter")
+load("@vendor//asserts","asserts")
+    
+def test_kateryna_stuff():
+    key = b'Sixteen byte key'
+    ctr = Counter.new(AES.block_size * 8)
+    crypto = AES.new(key, AES.MODE_CTR, counter=ctr)
+    encrypted = crypto.encrypt(b"TEST PAYLOAD!")
+
+
+def _testsuite():
+    _suite = unittest.TestSuite()
+    _suite.addTest(unittest.FunctionTestCase(test_kateryna_stuff))
+    return _suite
+
+
+_runner = unittest.TextTestRunner()
+_runner.run(_testsuite())

--- a/libstarlark/src/main/java/net/starlark/java/eval/StarlarkList.java
+++ b/libstarlark/src/main/java/net/starlark/java/eval/StarlarkList.java
@@ -455,17 +455,6 @@ public final class StarlarkList<E> extends AbstractList<E>
     addElement((E) item); // unchecked
   }
 
-  @StarlarkMethod(name = "reverse", doc = "Reverses the order of the list items.")
-  public void reverse() throws EvalException {
-    Object[] revElems = new Object[size];
-    int j = size;
-    for (int i = 0 ; i < size; i++) {
-      revElems[j-1] = elems[i];
-      j = j - 1;
-    }
-    elems = revElems;
-  }
-
   @StarlarkMethod(name = "clear", doc = "Removes all the elements of the list.")
   public void clearElements() throws EvalException {
     Starlark.checkMutable(this);

--- a/libstarlark/src/main/java/net/starlark/java/eval/StarlarkList.java
+++ b/libstarlark/src/main/java/net/starlark/java/eval/StarlarkList.java
@@ -455,6 +455,17 @@ public final class StarlarkList<E> extends AbstractList<E>
     addElement((E) item); // unchecked
   }
 
+  @StarlarkMethod(name = "reverse", doc = "Reverses the order of the list items.")
+  public void reverse() throws EvalException {
+    Object[] revElems = new Object[size];
+    int j = size;
+    for (int i = 0 ; i < size; i++) {
+      revElems[j-1] = elems[i];
+      j = j - 1;
+    }
+    elems = revElems;
+  }
+
   @StarlarkMethod(name = "clear", doc = "Removes all the elements of the list.")
   public void clearElements() throws EvalException {
     Starlark.checkMutable(this);


### PR DESCRIPTION
## Fixes [Jira Story or GH Issue if applicable](link)

## Description of changes in release / Impact of release:
* Exposes AES-CTR for use 
* ~Add builtin `list.reverse()` function that was missing~

## Documentation
https://pycryptodome.readthedocs.io/en/latest/src/cipher/classic.html#ctr-mode

## Risks of this release

### Is this a breaking change?
- [ ] Yes
- [X] No

### If you answered Yes then describe why is it so
(insert text here if applicable)

### Is there a way to disable the change?
- [ ] Use previous release
- [ ] Use a feature flag
- [ ] No

#### Additional details go here
(insert text here if applicable)
