### PR TITLE
Alias decorator config moved out from modules root

### DIFF
--- a/larky/src/main/java/com/verygood/security/larky/modules/VaultModule.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/VaultModule.java
@@ -1,7 +1,8 @@
 package com.verygood.security.larky.modules;
 
 import com.google.common.collect.ImmutableList;
-import com.verygood.security.larky.modules.DecoratorConfig.InvalidDecoratorConfigException;
+import com.verygood.security.larky.modules.vgs.vault.DecoratorConfig;
+import com.verygood.security.larky.modules.vgs.vault.DecoratorConfig.InvalidDecoratorConfigException;
 import com.verygood.security.larky.modules.vgs.vault.NoopVault;
 import com.verygood.security.larky.modules.vgs.vault.defaults.DefaultVault;
 import com.verygood.security.larky.modules.vgs.vault.spi.LarkyVault;

--- a/larky/src/main/java/com/verygood/security/larky/modules/vgs/vault/DecoratorConfig.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/vgs/vault/DecoratorConfig.java
@@ -1,4 +1,4 @@
-package com.verygood.security.larky.modules;
+package com.verygood.security.larky.modules.vgs.vault;
 
 import com.google.common.collect.ImmutableList;
 import java.util.Collections;
@@ -6,11 +6,13 @@ import java.util.List;
 import java.util.Map;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
 @Builder
+@EqualsAndHashCode
 public class DecoratorConfig {
 
   public static class InvalidDecoratorConfigException extends RuntimeException {
@@ -23,6 +25,7 @@ public class DecoratorConfig {
   @Getter
   @AllArgsConstructor
   @Builder
+  @EqualsAndHashCode
   public static class NonLuhnValidTransformPattern {
 
     private final String search;
@@ -32,6 +35,7 @@ public class DecoratorConfig {
   @Getter
   @AllArgsConstructor
   @Builder
+  @EqualsAndHashCode
   public static class NonLuhnValidPattern {
 
     private final String validatePattern;

--- a/larky/src/main/java/com/verygood/security/larky/modules/vgs/vault/defaults/DefaultVault.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/vgs/vault/defaults/DefaultVault.java
@@ -1,7 +1,7 @@
 package com.verygood.security.larky.modules.vgs.vault.defaults;
 
 import com.google.common.collect.ImmutableMap;
-import com.verygood.security.larky.modules.DecoratorConfig;
+import com.verygood.security.larky.modules.vgs.vault.DecoratorConfig;
 import com.verygood.security.larky.modules.vgs.vault.spi.LarkyVault;
 import java.util.HashMap;
 import java.util.List;


### PR DESCRIPTION
## Fixes CORE-1464

## Description of changes in release / Impact of release:
Follow up to https://github.com/verygoodsecurity/starlarky/pull/304
Moved Alias decorator config out from modules root

## Documentation
(insert text here)

## Risks of this release

### Is this a breaking change?
- [ ] Yes
- [X] No

### If you answered Yes then describe why is it so
(insert text here if applicable)

### Is there a way to disable the change?
- [X] Use previous release
- [ ] Use a feature flag
- [ ] No

#### Additional details go here
(insert text here if applicable)
