### PR TITLE
Mastercard oauth

### DIFF
--- a/larky/src/main/resources/vendor/MasterCard/oauth1/__init__.star
+++ b/larky/src/main/resources/vendor/MasterCard/oauth1/__init__.star
@@ -1,0 +1,3 @@
+load("@vendor//MasterCard/oauth1/oauth", OAuth="OAuth", OAuthParameters="OAuthParameters")
+load("@vendor//MasterCard/oauth1/authenticationutils", authenticationutils="authenticationutils")
+load("@vendor//MasterCard/oauth1/coreutils", coreutils="coreutils")

--- a/larky/src/main/resources/vendor/MasterCard/oauth1/authenticationutils.star
+++ b/larky/src/main/resources/vendor/MasterCard/oauth1/authenticationutils.star
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019-2021 Mastercard
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification, are
+# permitted provided that the following conditions are met:
+#
+# Redistributions of source code must retain the above copyright notice, this list of
+# conditions and the following disclaimer.
+# Redistributions in binary form must reproduce the above copyright notice, this list of
+# conditions and the following disclaimer in the documentation and/or other materials
+# provided with the distribution.
+# Neither the name of the MasterCard International Incorporated nor the names of its
+# contributors may be used to endorse or promote products derived from this software
+# without specific prior written permission.
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+# SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+# TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+# OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+# IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+# SUCH DAMAGE.
+#
+#from OpenSSL import crypto
+load("@stdlib//larky", larky="larky")
+load("@vendor//Crypto/PublicKey/RSA", RSA="RSA")
+load("@vendor//OpenSSL/crypto", crypto="crypto")
+
+def load_signing_key(private_key):
+    private = RSA.import_key(private_key)
+    return private
+
+
+authenticationutils = larky.struct(
+    __name__="authenticationutils",
+    load_signing_key=load_signing_key)

--- a/larky/src/main/resources/vendor/MasterCard/oauth1/coreutils.star
+++ b/larky/src/main/resources/vendor/MasterCard/oauth1/coreutils.star
@@ -1,0 +1,151 @@
+
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019-2021 Mastercard
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification, are
+# permitted provided that the following conditions are met:
+#
+# Redistributions of source code must retain the above copyright notice, this list of
+# conditions and the following disclaimer.
+# Redistributions in binary form must reproduce the above copyright notice, this list of
+# conditions and the following disclaimer in the documentation and/or other materials
+# provided with the distribution.
+# Neither the name of the MasterCard International Incorporated nor the names of its
+# contributors may be used to endorse or promote products derived from this software
+# without specific prior written permission.
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+# SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+# TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+# OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+# IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+# SUCH DAMAGE.
+#
+# Ported from https://github.com/Mastercard/oauth1-signer-python/blob/main/oauth1/coreutils.py
+#
+
+"""
+Utility file having common functions
+"""
+
+load("@stdlib//base64", base64="base64")
+load("@stdlib//hashlib", hashlib="hashlib")
+load("@stdlib//builtins", builtins="builtins")
+load("@stdlib//larky", larky="larky")
+load("@stdlib//urllib/parse", parse="parse")
+load("@vendor//Crypto/Random", Random="Random")
+
+def normalize_params(url, params):
+    """
+    Combines the query parameters of url and extra params into a single queryString.
+    All the query string parameters are lexicographically sorted
+    """
+    # parse the url
+    p = parse.urlparse(url)
+
+    # Get the query list
+    qs_list = parse.parse_qsl(p.query, keep_blank_values=True)
+    must_encode = False if p.query == parse.unquote(p.query) else True
+    if params == None:
+        combined_list = qs_list
+    else:
+        # Needs to be encoded before sorting
+        combined_list = [encode_pair(must_encode, key, value) for (key, value) in list(qs_list)]
+        combined_list += params.items()
+
+    encoded_list = ["%s=%s" % (key, value) for (key, value) in combined_list]
+    sorted_list = sorted(encoded_list, key=lambda x: x)
+
+    return "&".join(sorted_list)
+
+
+def encode_pair(must_encode, key, value):
+    encoded_key = percent_encode(key) if must_encode else key.replace(' ', '+')
+    value = value if builtins.isinstance(value, bytes) else str(value)
+    encoded_value = percent_encode(value) if must_encode else value.replace(' ', '+')
+    return encoded_key, encoded_value
+
+
+def normalize_url(url):
+    """
+    Removes the query parameters from the URL
+    """
+    p = parse.urlparse(url)
+
+    # netloc should be lowercase
+    netloc = p.netloc.lower()
+    if p.scheme == "http":
+        if netloc.endswith(":80"):
+            netloc = netloc[:-3]
+
+    elif p.scheme == "https" and netloc.endswith(":443"):
+        netloc = netloc[:-4]
+
+    # add a '/' at the end of the netloc if there in no path
+    if not p.path:
+        netloc = netloc + "/"
+
+    return "{}://{}{}".format(p.scheme, netloc, p.path)
+
+
+def sha256_encode(text):
+    """
+    Returns the digest of SHA-256 of the text
+    """
+    _hash = hashlib.sha256
+    if type(text) == str:
+        return _hash(text.encode('utf8')).digest()
+    elif type(text) == bytes:
+        return _hash(text).digest()
+    elif not text:
+        # Generally for calls where the payload is empty. Eg: get calls
+        # Fix for AttributeError: 'NoneType' object has no attribute 'encode'
+        return _hash(bytes("",'utf8')).digest()
+    else:
+        return _hash(bytes(str(text), 'utf-8')).digest()
+
+
+def base64_encode(text):
+    """
+    Base64 encodes the given input
+    """
+    if not builtins.isinstance(text, (bytes, bytearray)):
+        text = bytes(text, 'utf-8')
+    encode = base64.b64encode(text)
+    return encode.decode('ascii')
+
+
+def percent_encode(text):
+    """
+    Percent encodes a string as per https://tools.ietf.org/html/rfc3986
+    """
+    if text == None:
+        return ''
+    text = bytes(text, 'utf-8') if builtins.isinstance(text, str) else text
+    text = parse.quote(text, safe=b'~')
+    return text.replace('+', '%20').replace('*', '%2A').replace('%7E', '~')
+
+
+def get_nonce(length=16):
+    """
+    Returns a random string of length=@length
+    """
+    characters = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
+    charlen = len(characters)
+    return "".join([characters[Random.random.randint(0, charlen - 1)] for _ in range(0, length)])
+    
+
+coreutils = larky.struct(
+    __name__="coreutils",
+    get_nonce =get_nonce,
+    percent_encode=percent_encode,
+    base64_encode=base64_encode,
+    sha256_encode=sha256_encode,
+    normalize_url=normalize_url,
+    encode_pair=encode_pair,
+    normalize_params=normalize_params)

--- a/larky/src/main/resources/vendor/MasterCard/oauth1/oauth.star
+++ b/larky/src/main/resources/vendor/MasterCard/oauth1/oauth.star
@@ -1,0 +1,198 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright 2019-2021 Mastercard
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification, are
+# permitted provided that the following conditions are met:
+#
+# Redistributions of source code must retain the above copyright notice, this list of
+# conditions and the following disclaimer.
+# Redistributions in binary form must reproduce the above copyright notice, this list of
+# conditions and the following disclaimer in the documentation and/or other materials
+# provided with the distribution.
+# Neither the name of the MasterCard International Incorporated nor the names of its
+# contributors may be used to endorse or promote products derived from this software
+# without specific prior written permission.
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+# SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+# TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+# OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+# IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+# SUCH DAMAGE.
+#
+# Ported from https://github.com/Mastercard/oauth1-signer-python/blob/main/oauth1/oauth.py
+#
+
+load("@stdlib//json", json="json")
+load("@stdlib//larky", larky="larky")
+load("@vendor//Crypto/Signature", pkcs1_15="pkcs1_15")
+load("@vendor//Crypto/Hash", SHA256="SHA256")
+load("@vendor//Crypto/PublicKey/RSA", RSA="RSA")
+load("@vendor//MasterCard/oauth1/coreutils", util='coreutils')
+
+def OAuth():
+    self = larky.mutablestruct(__class__='OAuth')
+    self.EMPTY_STRING = ""
+
+    def get_authorization_header(uri, method, payload, consumer_key, signing_key, timestamp):
+        oauth_parameters = self.get_oauth_parameters(uri, method, payload, consumer_key, signing_key, timestamp)
+
+        # Get the updated base parameters dict
+        oauth_base_parameters_dict = oauth_parameters.get_base_parameters_dict()
+
+        # Generate the header value for OAuth Header
+        oauth_key = oauth_parameters.OAUTH_KEY + " " + ",".join(
+            [str(key) + "=\"" + str(value) + "\"" for (key, value) in oauth_base_parameters_dict.items()])
+        return oauth_key
+    self.get_authorization_header = get_authorization_header
+
+    def get_oauth_parameters(uri, method, payload, consumer_key, signing_key, timestamp):
+        # Get all the base parameters such as nonce and timestamp
+        oauth_parameters = OAuthParameters()
+        oauth_parameters.set_oauth_consumer_key(consumer_key)
+        oauth_parameters.set_oauth_nonce(util.get_nonce())
+        #oauth_parameters.set_oauth_timestamp(util.get_timestamp())
+        oauth_parameters.set_oauth_timestamp(timestamp)
+        oauth_parameters.set_oauth_signature_method("RSA-SHA256")
+        oauth_parameters.set_oauth_version("1.0")
+
+        payload_str = json.dumps(payload) if type(payload) == dict or type(payload) == list else payload
+        if not payload_str:
+            # If the request does not have an entity body, the hash should be taken over the empty string
+            payload_str = OAuth().EMPTY_STRING
+
+        encoded_hash = util.base64_encode(util.sha256_encode(payload_str))
+        oauth_parameters.set_oauth_body_hash(encoded_hash)
+
+        # Get the base string
+        base_string = self.get_base_string(uri, method, oauth_parameters.get_base_parameters_dict())
+
+        # Sign the base string using the private key
+        signature = self.sign_message(base_string, signing_key)
+
+        # Set the signature in the Base parameters
+        oauth_parameters.set_oauth_signature(util.percent_encode(signature))
+
+        return oauth_parameters
+    self.get_oauth_parameters = get_oauth_parameters
+
+    def copy_dict(orig):
+        new_dict = {}
+        for key in orig.keys():
+            new_dict[key] = orig[key]
+        return new_dict
+
+    def get_base_string(url, method, oauth_parameters):
+        #merge_params = oauth_parameters.copy()
+        merge_params = copy_dict(oauth_parameters)
+        return "{}&{}&{}".format(method.upper(),
+                                 util.percent_encode(util.normalize_url(url)),
+                                 util.percent_encode(util.normalize_params(url, merge_params)))
+    self.get_base_string = get_base_string
+
+    def sign_message(message, signing_key):
+        #    Signs the message using the private signing key
+        #sign = crypto.sign(signing_key, message.encode("utf-8"), 'SHA256')
+        key = RSA.import_key(signing_key)
+        h = SHA256.new(bytes(message, 'utf-8'))
+        sign = pkcs1_15.new(key).sign(h)
+        return util.base64_encode(sign)
+    self.sign_message = sign_message
+
+    return self
+
+def OAuthParameters():
+    """
+    Stores the OAuth parameters required to generate the Base String and Headers constants
+    """
+    self = larky.mutablestruct(__class__='OAuthParameters')
+
+    self.OAUTH_BODY_HASH_KEY = "oauth_body_hash"
+    self.OAUTH_CONSUMER_KEY = "oauth_consumer_key"
+    self.OAUTH_NONCE_KEY = "oauth_nonce"
+    self.OAUTH_KEY = "OAuth"
+    self.AUTHORIZATION = "Authorization"
+    self.OAUTH_SIGNATURE_KEY = "oauth_signature"
+    self.OAUTH_SIGNATURE_METHOD_KEY = "oauth_signature_method"
+    self.OAUTH_TIMESTAMP_KEY = "oauth_timestamp"
+    self.OAUTH_VERSION = "oauth_version"
+
+    def __init__():
+        self.base_parameters = {}
+    self.__init__ = __init__
+    __init__()
+
+    def put(key, value):
+        self.base_parameters[key] = value
+    self.put = put
+
+    def get(key):
+        return self.base_parameters[key]
+    self.get = get
+
+    def set_oauth_consumer_key(consumer_key):
+        self.put(self.OAUTH_CONSUMER_KEY, consumer_key)
+    self.set_oauth_consumer_key = set_oauth_consumer_key
+
+    def get_oauth_consumer_key():
+        return self.get(self.OAUTH_CONSUMER_KEY)
+    self.get_oauth_consumer_key = get_oauth_consumer_key
+
+    def set_oauth_nonce(oauth_nonce):
+        self.put(self.OAUTH_NONCE_KEY, oauth_nonce)
+    self.set_oauth_nonce = set_oauth_nonce
+
+    def get_oauth_nonce():
+        return self.get(OAuthParameters.OAUTH_NONCE_KEY)
+    self.get_oauth_nonce = get_oauth_nonce
+
+    def set_oauth_timestamp(timestamp):
+        self.put(self.OAUTH_TIMESTAMP_KEY, timestamp)
+    self.set_oauth_timestamp = set_oauth_timestamp
+
+    def get_oauth_timestamp():
+        return self.get(self.OAUTH_TIMESTAMP_KEY)
+    self.get_oauth_timestamp = get_oauth_timestamp
+
+    def set_oauth_signature_method(signature_method):
+        self.put(self.OAUTH_SIGNATURE_METHOD_KEY, signature_method)
+    self.set_oauth_signature_method = set_oauth_signature_method
+
+    def get_oauth_signature_method():
+        return self.get(self.OAUTH_SIGNATURE_METHOD_KEY)
+    self.get_oauth_signature_method = get_oauth_signature_method
+
+    def set_oauth_signature(signature):
+        self.put(self.OAUTH_SIGNATURE_KEY, signature)
+    self.set_oauth_signature = set_oauth_signature
+
+    def get_oauth_signature():
+        return self.get(self.OAUTH_SIGNATURE_KEY)
+    self.get_oauth_signature = get_oauth_signature
+
+    def set_oauth_body_hash(body_hash):
+        self.put(self.OAUTH_BODY_HASH_KEY, body_hash)
+    self.set_oauth_body_hash = set_oauth_body_hash
+
+    def get_oauth_body_hash():
+        return self.get(self.OAUTH_BODY_HASH_KEY)
+    self.get_oauth_body_hash = get_oauth_body_hash
+
+    def set_oauth_version(version):
+        self.put(self.OAUTH_VERSION, version)
+    self.set_oauth_version = set_oauth_version
+
+    def get_oauth_version():
+        return self.get(self.OAUTH_VERSION)
+    self.get_oauth_version = get_oauth_version
+
+    def get_base_parameters_dict():
+        return self.base_parameters
+    self.get_base_parameters_dict = get_base_parameters_dict
+
+    return self

--- a/larky/src/test/resources/vendor_tests/MasterCard/test_mcoauth.star
+++ b/larky/src/test/resources/vendor_tests/MasterCard/test_mcoauth.star
@@ -65,7 +65,8 @@ _signing_key = """-----BEGIN PRIVATE KEY-----
     22dZWKvD3xJ7HRUx/Hyk+VEkH11lsLZ/8AhcwZAr76cE/HLz1XtkKKBCnnlOLPZN
     03j+WKU3p1fzeWqfW4nyCALQ
     -----END PRIVATE KEY-----"""
-_b64_signing_key = ''.join(_signing_key.split('\n')[1:-1]).replace(' ','')
+_b64_signing_key = bytes(''.join(_signing_key.split('\n')[1:-1]).replace(' ',''), 'utf-8')
+_b64_ck = base64.b64encode(b'dummy')
 uri = 'https://www.example.com'
 
 def test_get_authorization_header_nominal():
@@ -110,11 +111,10 @@ def test_signature_base_string2():
 
     asserts.assert_that(base_string).is_equal_to(expected)
 
-
 def test_legacy_wrapper_direct_key():
     req = VGSHttpRequest(uri + "sample_path", builtins.bytes('{}'), {"timestamp":"1111111111"}, 'POST')
     signature = OAuth().vgs_legacy_signature(
-            consumerKey='dummy',
+            consumerKey=_b64_ck,
             signingKey=_b64_signing_key,
             request=req,
             ctx={"timestamp":"1111111111"}
@@ -124,7 +124,7 @@ def test_legacy_wrapper_direct_key():
 def test_legacy_wrapper_key_header():
     req = VGSHttpRequest(uri + "/sample_path", builtins.bytes('{}'), {"x-secret-key":_b64_signing_key}, 'POST')
     signature = OAuth().vgs_legacy_signature(
-            consumerKey='dummy',
+            consumerKey=_b64_ck,
             keyHeader='x-secret-key',
             request=req,
             ctx={"timestamp":"1111111111"}
@@ -135,7 +135,7 @@ def test_legacy_wrapper_key_header():
 def test_legacy_missing_signing_key():
     req = VGSHttpRequest(uri + "sample_path", builtins.bytes('{}'), {"x-secret-key":_b64_signing_key}, 'POST')
     asserts.assert_fails(lambda: OAuth().vgs_legacy_signature(
-            consumerKey='dummy',
+            consumerKey=_b64_ck,
             request=req,
             ctx={"timestamp":"1111111111"}
         ), "Either `signingKey` or `keyHeader` are required parameters.")
@@ -143,7 +143,7 @@ def test_legacy_missing_signing_key():
 def test_legacy_too_many_keys():
     req = VGSHttpRequest(uri + "sample_path", builtins.bytes('{}'), {"x-secret-key":_b64_signing_key}, 'POST')
     asserts.assert_fails(lambda: OAuth().vgs_legacy_signature(
-            consumerKey='dummy',
+            consumerKey=_b64_ck,
             signingKey=_b64_signing_key,
             keyHeader='x-secret-key',
             request=req,
@@ -163,7 +163,7 @@ def test_legacy_no_consumer_key():
 def test_legacy_no_request():
     req = VGSHttpRequest(uri + "sample_path", builtins.bytes('{}'), {"x-secret-key":_b64_signing_key}, 'POST')
     asserts.assert_fails(lambda: OAuth().vgs_legacy_signature(
-            consumerKey='dummy',
+            consumerKey=_b64_ck,
             signingKey=_b64_signing_key,
             ctx={"timestamp":"1111111111"},
         ), "The HTTP Request Object is required in the `request` parameter.")
@@ -172,7 +172,7 @@ def test_legacy_no_request():
 def test_legacy_no_ctx():
     req = VGSHttpRequest(uri + "sample_path", builtins.bytes('{}'), {"x-secret-key":_b64_signing_key}, 'POST')
     asserts.assert_fails(lambda: OAuth().vgs_legacy_signature(
-            consumerKey='dummy',
+            consumerKey=_b64_ck,
             signingKey=_b64_signing_key,
             request=req,
         ), "The ctx Object is required in the `ctx` parameter.")

--- a/larky/src/test/resources/vendor_tests/MasterCard/test_mcoauth.star
+++ b/larky/src/test/resources/vendor_tests/MasterCard/test_mcoauth.star
@@ -1,0 +1,122 @@
+# -*- coding: utf-8 -*-#
+#
+#
+# Copyright 2019-2021 Mastercard
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification, are
+# permitted provided that the following conditions are met:
+#
+# Redistributions of source code must retain the above copyright notice, this list of
+# conditions and the following disclaimer.
+# Redistributions in binary form must reproduce the above copyright notice, this list of
+# conditions and the following disclaimer in the documentation and/or other materials
+# provided with the distribution.
+# Neither the name of the MasterCard International Incorporated nor the names of its
+# contributors may be used to endorse or promote products derived from this software
+# without specific prior written permission.
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+# SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+# TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+# OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+# IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+# IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+# SUCH DAMAGE.
+#
+# Copied from https://github.com/Mastercard/oauth1-signer-python/blob/main/tests/test_oauth.py
+
+
+load("@stdlib//unittest","unittest")
+load("@stdlib//json", "json")
+load("@stdlib//base64", "base64")
+load("@vendor//asserts","asserts")
+load("@vgs//MasterCard/oauth1", OAuth="OAuth", OAuthParameters="OAuthParameters",
+    authenticationutils="authenticationutils", util="coreutils")
+
+_signing_key = """-----BEGIN PRIVATE KEY-----
+    MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCYoc5Ue4MKxHIQ
+    eSESKQiIv341EFDtfAlAsXP74modJuwnSLOfSkFNgKH4y6vSKiUK7BxU2KFy7FkR
+    J9/vceJmP9MD6bWPgT2Wg4iSQxgPtAHEVps9MYvkhW0lt0hyhAcGLUR3kb4YjSkG
+    fa8EzG/G2g+/VKdL0mnSgWhCnSBnR0xRwWccgdRTLm20/jzXkmHD92DBR7kDgiBU
+    rPWTfLHDnsVoIUut6BAPI83TIjHjVG1Jn8K0prbGeQU9ALwaL36qvppYpmCqaAGH
+    OM2fXsEPFNhEZxQpbyW2M4PtXHnjSqlNOKN2tmdF3jWwm9hKZ9xeaWJkBmBnLe3t
+    Nz0OdO0pAgMBAAECggEBAJHQGn5JFJJnw5SLM5XWz4lcb2SgNr/5/BjqriQXVEqP
+    UZHh+X+Wf7ZbyeEWKgp4KrU5hYNlBS/2LMyf7GYixSfrl1qoncP/suektwcLw+PU
+    ks+P8XRPbhadhP1AEJ0eFlvHSR51hEaOLIA/98C80ZgF4H9njv93f5MT/5eL5lXi
+    pFX1dcxUB55q9QOtQ7uCg++NyG5F6u4FxbNtOtsjyNzWZSjYsjSyGHDip9ScDOPN
+    sGQfznxo/oifdXvc25BgWvRflIIYEP08eeUSuGW2nUnx+Joc0oZTkC0wfU+aqKla
+    Zp8zfOEIm0gUDgWtgnq5I5JHJMuW6BtA4K3E+nyP0lECgYEAzIbNx/lVxmFPbPp+
+    AG9LD3JLycjdmTzwpHK44MsaUBOZ9PkLZs0NpR5z0/qcFb8YGGz3qN6E/TTydmfX
+    CpZ3bxP3+x81gL9SVG/y2GP/ky/REA0jFycwVlONeVnd09xPNNLZLUgZhWyAQIA2
+    pmVMh8W+pX6ojxGgOe+KIGutJCUCgYEAvwuNciTzkjBz9nFCjLONvP05WMdIAXo1
+    uxd17iQ0lhRtmHbphojFAPcHYocm2oUXJo5nLvy+u8xnxbyXaZHmRqm98AzmBTtp
+    phFtgfTtv/cSvOsBpdyyaJaN12IUs2XYACGBRa2DUkgxxvHtbmjFGFIU+5VgjOG8
+    g0LfoPhLM7UCgYAmdRaOioihY7zOjg9RP5wKjIBJsfZREQ9irJus0SPieL0TPhzx
+    uI7fRGmdK1tcD3GVbi/nVegFwIXy07WwrPhKL6QKWSTzT4ZIkEBGhg8RewVBkmbN
+    vLWvFcjdT5ORebR/B0KE7DC4UN2Qw0sDYLrSMNGXRsilFjhdjHgZfoWw7QKBgAZr
+    QvNk3nI5AoxzPcMwfUCuWXDsMTUrgAarQSEhQksQoKYQyMPmcIgZxLvAwsNw2VhI
+    TJs9jsMMmSgBsCyx5ETXizQ3mrruRhx4VW+aZSqgCJckZkfGZJAzDsz/1KY6c8l9
+    VrSaoeDv4AxJMKsXBhhNGbtiR340T3sxkgX8kbpJAoGBAII2aFeQ4oE8DhSZZo2b
+    pJxO072xy1P9PRlyasYBJ2sNiF0TTguXJB1Ncu0TM0+FLZXIFddalPgv1hY98vNX
+    22dZWKvD3xJ7HRUx/Hyk+VEkH11lsLZ/8AhcwZAr76cE/HLz1XtkKKBCnnlOLPZN
+    03j+WKU3p1fzeWqfW4nyCALQ
+    -----END PRIVATE KEY-----"""
+uri = 'https://www.example.com'
+
+def test_get_authorization_header_nominal():
+    header = OAuth().get_authorization_header(uri, 'POST', 'payload', 'dummy', _signing_key, "1111111111")
+    asserts.assert_true("OAuth" in header)
+    asserts.assert_that("dummy" in header)
+
+def test_get_authorization_header_should_compute_body_hash():
+    header = OAuth().get_authorization_header(uri, 'POST', '{}', 'dummy', _signing_key, '1111111111')
+    asserts.assert_that('RBNvo1WzZ4oRRq0W9+hknpT7T8If536DEMBg9hyq/4o=' in header).is_equal_to(True)
+
+def test_get_authorization_header_should_return_empty_string_body_hash():
+    header = OAuth().get_authorization_header(uri, 'GET', None, 'dummy', _signing_key, '1111111111')
+    asserts.assert_that('47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=' in header).is_equal_to(True)
+
+def test_sign_message():
+    base_string = 'POST&https%3A%2F%2Fsandbox.api.mastercard.com%2Ffraud%2Fmerchant%2Fv1%2Ftermination-inquiry&Format%3DXML%26PageLength%3D10%26PageOffset%3D0%26oauth_body_hash%3DWhqqH%252BTU95VgZMItpdq78BWb4cE%253D%26oauth_consumer_key%3Dxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx%26oauth_nonce%3D1111111111111111111%26oauth_signature_method%3DRSA-SHA1%26oauth_timestamp%3D1111111111%26oauth_version%3D1.0'
+    signature = OAuth().sign_message(base_string, _signing_key)
+    signature = util.percent_encode(signature)
+    asserts.assert_that(signature).is_equal_to("DvyS3R795sUb%2FcvBfiFYZzPDU%2BRVefW6X%2BAfyu%2B9fxjudQft%2BShXhpounzJxYCwOkkjZWXOR0ICTMn6MOuG04TTtmPMrOxj5feGwD3leMBsi%2B3XxcFLPi8BhZKqgapcAqlGfjEhq0COZ%2FF9aYDcjswLu0zgrTMSTp4cqXYMr9mbQVB4HL%2FjiHni5ejQu9f6JB9wWW%2BLXYhe8F6b4niETtzIe5o77%2B%2BkKK67v9wFIZ9pgREz7ug8K5DlxX0DuwdUKFhsenA5z%2FNNCZrJE%2BtLu0tSjuF5Gsjw5GRrvW33MSoZ0AYfeleh5V3nLGgHrhVjl5%2BiS40pnG2po%2F5hIAUT5ag%3D%3D")
+
+def test_get_nonce():
+    nonce = util.get_nonce()
+    asserts.assert_that(len(nonce)).is_equal_to(16)
+
+def test_signature_base_string2():
+    signing_key = authenticationutils.load_signing_key(_signing_key)
+    body = "<?xml version=\"1.0\" encoding=\"Windows-1252\"?><ns2:TerminationInquiryRequest xmlns:ns2=\"http://mastercard.com/termination\"><AcquirerId>1996</AcquirerId><TransactionReferenceNumber>1</TransactionReferenceNumber><Merchant><Name>TEST</Name><DoingBusinessAsName>TEST</DoingBusinessAsName><PhoneNumber>5555555555</PhoneNumber><NationalTaxId>1234567890</NationalTaxId><Address><Line1>5555 Test Lane</Line1><City>TEST</City><CountrySubdivision>XX</CountrySubdivision><PostalCode>12345</PostalCode><Country>USA</Country></Address><Principal><FirstName>John</FirstName><LastName>Smith</LastName><NationalId>1234567890</NationalId><PhoneNumber>5555555555</PhoneNumber><Address><Line1>5555 Test Lane</Line1><City>TEST</City><CountrySubdivision>XX</CountrySubdivision><PostalCode>12345</PostalCode><Country>USA</Country></Address><DriversLicense><Number>1234567890</Number><CountrySubdivision>XX</CountrySubdivision></DriversLicense></Principal></Merchant></ns2:TerminationInquiryRequest>"
+    url = "https://sandbox.api.mastercard.com/fraud/merchant/v1/termination-inquiry?Format=XML&PageOffset=0&PageLength=10"
+    method = "POST"
+    oauth_parameters = OAuthParameters()
+    oauth_parameters.set_oauth_consumer_key("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx")
+    oauth_parameters.set_oauth_nonce("1111111111111111111")
+    oauth_parameters.set_oauth_timestamp("1111111111")
+    oauth_parameters.set_oauth_version("1.0")
+    oauth_parameters.set_oauth_body_hash("body/hash")
+    encoded_hash = util.base64_encode(util.sha256_encode(body))
+    oauth_parameters.set_oauth_body_hash(encoded_hash)
+
+    base_string = OAuth().get_base_string(url, method, oauth_parameters.get_base_parameters_dict())
+    expected = "POST&https%3A%2F%2Fsandbox.api.mastercard.com%2Ffraud%2Fmerchant%2Fv1%2Ftermination-inquiry&Format%3DXML%26PageLength%3D10%26PageOffset%3D0%26oauth_body_hash%3Dh2Pd7zlzEZjZVIKB4j94UZn%2FxxoR3RoCjYQ9%2FJdadGQ%3D%26oauth_consumer_key%3Dxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx%26oauth_nonce%3D1111111111111111111%26oauth_timestamp%3D1111111111%26oauth_version%3D1.0"
+
+    asserts.assert_that(base_string).is_equal_to(expected)
+
+def _testsuite():
+    _suite = unittest.TestSuite()
+    _suite.addTest(unittest.FunctionTestCase(test_get_authorization_header_nominal))
+    _suite.addTest(unittest.FunctionTestCase(test_get_authorization_header_should_compute_body_hash))
+    _suite.addTest(unittest.FunctionTestCase(test_get_authorization_header_should_return_empty_string_body_hash))
+    _suite.addTest(unittest.FunctionTestCase(test_sign_message))
+    _suite.addTest(unittest.FunctionTestCase(test_get_nonce))
+    _suite.addTest(unittest.FunctionTestCase(test_signature_base_string2))
+    return _suite
+
+_runner = unittest.TextTestRunner()
+_runner.run(_testsuite())


### PR DESCRIPTION
## Fixes [Jira Story or GH Issue if applicable](link)

## Description of changes in release / Impact of release:
* Ports functionality from [Mastercard OAuth Signer](https://github.com/Mastercard/oauth1-signer-python)
* Provides a wrapper for a previous VGS FCO to allow maximum portability to Larky and ease of use

## Documentation
Documentation for the library functionality can be found at https://github.com/Mastercard/oauth1-signer-python. However, there is one caveat and key difference, and that is that the timestamp must be passed manually as an additional parameter to the `get_authorization_header()` and `get_oauth_parameters()` functions. 