### PR TITLE
port over Python's _namespaces() function instead of using the overloaded one that mimicked the lxml library

### DIFF
--- a/larky/src/test/java/com/verygood/security/larky/modules/utils/NumOpsUtilsTest.java
+++ b/larky/src/test/java/com/verygood/security/larky/modules/utils/NumOpsUtilsTest.java
@@ -9,14 +9,13 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
 import com.google.common.flogger.FluentLogger;
-
-import org.junit.Test;
-
 import java.io.IOException;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.util.Random;
 import java.util.UUID;
+
+import org.junit.Test;
 
 public class NumOpsUtilsTest {
   private static final FluentLogger logger = FluentLogger.forEnclosingClass();
@@ -47,7 +46,7 @@ public class NumOpsUtilsTest {
         bigIntBytes = bigIntBytesPadded;
       }
       byte[] ourBytes = NumOpsUtils.int128ToByteArray(msb, lsb);
-      System.out.println("ourBytes = " + ByteArrayUtil.toHexString(ourBytes, 1, ""));
+      /*System.out.println("ourBytes = " + ByteArrayUtil.toHexString(ourBytes, 1, ""));*/
       assertArrayEquals(bigIntBytes, ourBytes);
     }
   }

--- a/larky/src/test/resources/stdlib_tests/xml/etree/test_elementtree.star
+++ b/larky/src/test/resources/stdlib_tests/xml/etree/test_elementtree.star
@@ -537,6 +537,78 @@ def T_test_indent_level():
         b" </html>"))
 
 
+# load("@stdlib//xml/etree/ElementTree", ET="ElementTree")
+# load("@vendor//elementtree/SimpleXMLTreeBuilder", SimpleXMLTreeBuilder="SimpleXMLTreeBuilder")
+# load("@stdlib//io/StringIO", "StringIO")
+# load("@stdlib//builtins", "builtins")
+
+def test_namespace_prefix():
+    nsmap = ET._namespace_map
+    ET.register_namespace('soap', 'http://www.w3.org/2003/05/soap-envelope')
+    ET.register_namespace('xsi', 'http://www.w3.org/2001/XMLSchema-instance')
+    ET.register_namespace('xsd', 'http://www.w3.org/2001/XMLSchema')
+    ET.register_namespace('', 'https://www.sc-solutions.com/SmartTrackSE/RequestGateway')
+
+    data = """<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <soap:Body>
+        <AuthenticateAndAuthorizeTransactionResponse xmlns="https://www.sc-solutions.com/SmartTrackSE/RequestGateway">
+            <AuthenticateAndAuthorizeTransactionResult>
+                <TransactionType>BalanceInquiry</TransactionType>
+                <AccountNumber>8700561000023</AccountNumber>
+                <TransactionAmount>100</TransactionAmount>
+                <PurseBalances>
+                    <decimal>50.0000</decimal>
+                    <decimal>0.0000</decimal>
+                    <decimal>0.0000</decimal>
+                    <decimal>0.0000</decimal>
+                    <decimal>0.0000</decimal>
+                    <decimal>0.0000</decimal>
+                </PurseBalances>
+                <ReferenceNumber>1302797</ReferenceNumber>
+                <ApprovalCode>Approved</ApprovalCode>
+                <HostMessage>TransactionApproved</HostMessage>
+                <ResponseCode>Succeeded</ResponseCode>
+                <ResponseMessage>Transaction processed successfully.</ResponseMessage>
+            </AuthenticateAndAuthorizeTransactionResult>
+        </AuthenticateAndAuthorizeTransactionResponse>
+    </soap:Body>
+</soap:Envelope>"""
+    root = ET.fromstring(data)
+    acctNumber = root.find(".//{https://www.sc-solutions.com/SmartTrackSE/RequestGateway}AccountNumber")
+    acctNumber.text = "DROPPED"
+
+    ET.indent(root)
+    expected = b"""<?xml version="1.0" encoding="UTF-8"?>
+<soap:Envelope xmlns="https://www.sc-solutions.com/SmartTrackSE/RequestGateway" xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <soap:Body>
+    <AuthenticateAndAuthorizeTransactionResponse>
+      <AuthenticateAndAuthorizeTransactionResult>
+        <TransactionType>BalanceInquiry</TransactionType>
+        <AccountNumber>DROPPED</AccountNumber>
+        <TransactionAmount>100</TransactionAmount>
+        <PurseBalances>
+          <decimal>50.0000</decimal>
+          <decimal>0.0000</decimal>
+          <decimal>0.0000</decimal>
+          <decimal>0.0000</decimal>
+          <decimal>0.0000</decimal>
+          <decimal>0.0000</decimal>
+        </PurseBalances>
+        <ReferenceNumber>1302797</ReferenceNumber>
+        <ApprovalCode>Approved</ApprovalCode>
+        <HostMessage>TransactionApproved</HostMessage>
+        <ResponseCode>Succeeded</ResponseCode>
+        <ResponseMessage>Transaction processed successfully.</ResponseMessage>
+      </AuthenticateAndAuthorizeTransactionResult>
+    </AuthenticateAndAuthorizeTransactionResponse>
+  </soap:Body>
+</soap:Envelope>"""
+    actual = ET.tostring(root, xml_declaration=True, encoding="UTF-8")
+    asserts.assert_that(expected).is_equal_to(actual)
+    ET._namespace_map.clear()
+    ET._namespace_map.update(nsmap)
+
 def _suite():
     _suite = unittest.TestSuite()
     _suite.addTest(unittest.FunctionTestCase(_test_elementtree))
@@ -549,6 +621,7 @@ def _suite():
     _suite.addTest(unittest.FunctionTestCase(T_test_indent_space))
     _suite.addTest(unittest.FunctionTestCase(T_test_indent_space_caching))
     _suite.addTest(unittest.FunctionTestCase(T_test_indent_level))
+    _suite.addTest(unittest.FunctionTestCase(test_namespace_prefix))
 
     return _suite
 

--- a/larky/src/test/resources/test_starlark_executes_example.star
+++ b/larky/src/test/resources/test_starlark_executes_example.star
@@ -20,18 +20,22 @@ def pop_ifexists(target, key):
         _value = target.pop(key)
     return target
 
+
 print(pop_ifexists(people, "Dave"))
+
 
 # Define a function
 def greet(name):
     """Return a greeting."""
     return "Hello {}!".format(name)
 
+
 greeting = greet(names)
 
 above30 = [name for name, age in people.items() if age >= 30]
 
 print("{} people are above 30.".format(len(above30)))
+
 
 def fizz_buzz(n):
     """Print Fizz Buzz numbers from 1 to n."""
@@ -42,5 +46,6 @@ def fizz_buzz(n):
         if i % 5 == 0:
             s += "Buzz"
         print(s if s else i)
+
 
 fizz_buzz(20)


### PR DESCRIPTION
## Description of changes in release / Impact of release:

port over Python's _namespaces() function instead of using the overloaded one that mimicked the lxml library

## Documentation

there is one minor difference between this function and the one from python: the larky function properly respects namespaces and will automatically append all referenced namespaces correctly as opposed to only emitting used namespaces. This should generally be OK as it's still user defined. If this continues to become an issue, we can revert the behavior as part of `ElementTree::tostring()` by adding a `python_compat=True` flag.

## Risks of this release

### Is this a breaking change?
- [ ] Yes
- [x] No

### Is there a way to disable the change?
- [x] Use previous release
- [ ] Use a feature flag
- [ ] No
