### PR TITLE
Fix Jose JWE with certificates

### DIFF
--- a/larky/src/main/resources/vendor/jose/backends/pycrypto_backend.star
+++ b/larky/src/main/resources/vendor/jose/backends/pycrypto_backend.star
@@ -183,10 +183,6 @@ def RSAKey(key, algorithm):
             key = codecs.encode(key, encoding='utf-8')
 
         if types.is_bytelike(key):
-            if key.startswith(b'-----BEGIN CERTIFICATE-----'):
-                safe(self._process_cert)(key).unwrap()
-                return self
-
             self.prepared_key = RSA.importKey(key)
             return self
 

--- a/larky/src/test/resources/quick_tests/test_customer_usecase.star
+++ b/larky/src/test/resources/quick_tests/test_customer_usecase.star
@@ -1,0 +1,51 @@
+load("@stdlib//larky", "larky")
+load("@stdlib//unittest","unittest")
+load("@stdlib//json","json")
+load("@stdlib//types", "types")
+load("@stdlib//builtins", builtins="builtins")
+
+load("@vendor//asserts","asserts")
+
+load("@vgs//http/request", "VGSHttpRequest")
+
+def process(input_http, ctx):
+  # Extract card BIN and add it to the body
+  body = json.loads(input_http.body.decode("utf-8"))
+  BIN = body['cardNumber'][:6]
+  body['BIN'] = BIN
+
+  # Add the BIN to the headers and change the X-Custom-Header 
+  headers = input_http.headers
+  headers['X-BIN-Header'] = BIN
+  headers['X-Custom-Header'] = "I am a changed header"
+
+  # Set the body as builtins.bytes of the updated body and update the headers
+  input_http.body = builtins.bytes(json.dumps(body))
+  input_http.headers = headers
+
+  return input_http
+
+def test_customer_case():
+    req_body = b'{"cardNumber": "4111111111111111"}'
+    headers = {"X-Custom-Header":"Header Value"}
+    request = VGSHttpRequest("http://example.com", data=req_body, headers=headers, method='POST')
+    context_variables = {} 
+    larky_output = process(request, context_variables)
+    
+    body = json.loads(larky_output._data.decode("utf-8"))
+    headers = larky_output.headers
+
+    # Test that the code has executed properly on your request
+    asserts.assert_that(body['BIN']).is_equal_to("411111")
+    asserts.assert_that(headers['X-Custom-Header']).is_equal_to("I am a changed header")
+    asserts.assert_that(headers['X-BIN-Header']).is_equal_to("411111")
+
+
+def _testsuite():
+    _suite = unittest.TestSuite()
+    _suite.addTest(unittest.FunctionTestCase(test_customer_case))
+    return _suite
+
+
+_runner = unittest.TextTestRunner()
+_runner.run(_testsuite())


### PR DESCRIPTION
## Fixes [Jira Story or GH Issue if applicable](link)
* Fixes bug in python-jose that prevented certificates from being used in place of public PEM keys
* Adds python-jose test to cover the use case
* Adds `test_customer_usecase.star` under `quickTests` to provide a template for debugging Larky using the same format and methods as `process(input, ctx)` within the YAML

## Description of changes in release / Impact of release:
There was a block of code in the `pycrypto_backend.star` that was expecting to have to parse a certificate differently than a normal PEM file, and did not have any corresponding method to load a certificate. Removing these lines allows jose to behave the way it does in python.

## Documentation
(insert text here)

## Risks of this release

### Is this a breaking change?
- [ ] Yes
- [X] No

### If you answered Yes then describe why is it so
(insert text here if applicable)

### Is there a way to disable the change?
- [ ] Use previous release
- [ ] Use a feature flag
- [ ] No

#### Additional details go here
(insert text here if applicable)
