### PR TITLE
Add ECDH

### DIFF
--- a/larky/src/main/java/com/verygood/security/larky/ModuleSupplier.java
+++ b/larky/src/main/java/com/verygood/security/larky/ModuleSupplier.java
@@ -27,6 +27,7 @@ import com.verygood.security.larky.modules.ChaseModule;
 import com.verygood.security.larky.modules.CodecsModule;
 import com.verygood.security.larky.modules.CollectionsModule;
 import com.verygood.security.larky.modules.CryptoModule;
+import com.verygood.security.larky.modules.ECDHModule;
 import com.verygood.security.larky.modules.JsonModule;
 import com.verygood.security.larky.modules.OpenSSLModule;
 import com.verygood.security.larky.modules.ProtoBufModule;
@@ -79,6 +80,7 @@ public class ModuleSupplier {
       CodecsModule.INSTANCE,
       CollectionsModule.INSTANCE,
       CryptoModule.INSTANCE,
+      ECDHModule.INSTANCE,
       JsonModule.INSTANCE,
       OpenSSLModule.INSTANCE,
       ProtoBufModule.INSTANCE,

--- a/larky/src/main/java/com/verygood/security/larky/modules/ECDHModule.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/ECDHModule.java
@@ -30,13 +30,6 @@ public class ECDHModule implements StarlarkValue {
 
     public static final ECDHModule INSTANCE = new ECDHModule();
 
-    @StarlarkMethod(name="test", structField = false)
-    public static String test() {
-        String str = "Hello, world!";
-        System.out.println(str);
-        return str;
-    }
-
     @StarlarkMethod(name="key_exchange",
     doc = "Load Keys and Exchange values",
         parameters = {

--- a/larky/src/main/java/com/verygood/security/larky/modules/ECDHModule.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/ECDHModule.java
@@ -1,0 +1,151 @@
+package com.verygood.security.larky.modules;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringReader;
+import java.security.*;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.security.spec.X509EncodedKeySpec;
+import java.util.Enumeration;
+import net.starlark.java.annot.Param;
+import net.starlark.java.annot.ParamType;
+import net.starlark.java.annot.StarlarkBuiltin;
+import net.starlark.java.annot.StarlarkMethod;
+import net.starlark.java.eval.*;
+import org.bouncycastle.openssl.PEMKeyPair;
+import org.bouncycastle.openssl.PEMParser;
+import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
+
+import javax.crypto.KeyAgreement;
+
+@StarlarkBuiltin(
+        name = "ECDH",
+        category = "BUILTIN",
+        doc = "A backend for ECDH operations."
+)
+public class ECDHModule implements StarlarkValue {
+
+    private static final String ECC_ALGORITHM = "EC";
+
+    public static final ECDHModule INSTANCE = new ECDHModule();
+
+    @StarlarkMethod(name="test", structField = false)
+    public static String test() {
+        String str = "Hello, world!";
+        System.out.println(str);
+        return str;
+    }
+
+    @StarlarkMethod(name="key_exchange",
+    doc = "Load Keys and Exchange values",
+        parameters = {
+            @Param(name="privKey", allowedTypes = {
+                    @ParamType(type = StarlarkBytes.class),
+                    @ParamType(type = String.class)
+            }),
+            @Param(name="privKeyType", allowedTypes = {
+                    @ParamType(type = String.class),
+                    @ParamType(type = StarlarkBytes.class)
+            }),
+            @Param(name="pubKey", allowedTypes = {
+                    @ParamType(type = StarlarkBytes.class)
+            }),
+            @Param(name = "pubKeyType", allowedTypes = {
+                    @ParamType(type = String.class),
+                    @ParamType(type = StarlarkBytes.class)
+            }),
+            @Param(name = "privPass", allowedTypes = {
+                    @ParamType(type = String.class),
+            })
+        }, useStarlarkThread = true)
+    public static StarlarkBytes key_exchange(Object privKey,
+                                Object privKeyType,
+                                StarlarkBytes pubKey,
+                                Object pubKeyType,
+                                String privPass,
+                                StarlarkThread thread) throws Exception {
+        String privType = privKeyType.toString();
+        String pubType = pubKeyType.toString();
+        StarlarkBytes prkBytes = null;
+        String prkStr = null;
+        if (privKey instanceof StarlarkBytes){
+            prkBytes = (StarlarkBytes) privKey;
+        } else if (privKey instanceof String){
+            prkStr = (String) privKey;
+        }
+        PrivateKey privateKey = null;
+        PublicKey publicKey = null;
+
+        switch (privType){
+            case "PKCS8":
+                privateKey = loadPrivateKeyPKCS8(prkBytes);
+                break;
+            case "PEM":
+                privateKey = loadPrivateKeySEC1(prkStr);
+                break;
+            case "PKCS12":
+                privateKey = loadPrivateKeyPKCS12(prkBytes, privPass.toCharArray());
+                break;
+        }
+
+        switch (pubType){
+            case "X509":
+                publicKey = loadPublicKeyX509(pubKey);
+        }
+
+        byte[] bytes = ellipticCurveDHExchange(privateKey, publicKey);
+        return StarlarkBytes.of(thread.mutability(), bytes);
+    }
+
+    private static byte[] ellipticCurveDHExchange(PrivateKey privateKey, PublicKey publicKey)
+            throws NoSuchAlgorithmException, InvalidKeyException {
+        KeyAgreement ka = KeyAgreement.getInstance("ECDH");
+        ka.init(privateKey);
+        ka.doPhase(publicKey, true);
+        return ka.generateSecret();
+    }
+
+
+    private static PrivateKey loadPrivateKeyPKCS8(StarlarkBytes privKey) throws Exception {
+        PKCS8EncodedKeySpec spec = new PKCS8EncodedKeySpec(privKey.toByteArray());
+        KeyFactory kf = KeyFactory.getInstance("EC");
+        return kf.generatePrivate(spec);
+    }
+
+    private static PrivateKey loadPrivateKeySEC1(String pem) throws Exception {
+        final PEMParser pemParser = new PEMParser(new StringReader(pem));
+        final Object parsedPem = pemParser.readObject();
+        if (!(parsedPem instanceof PEMKeyPair)) {
+            throw new IOException("Attempted to parse PEM string as a keypair, but it's actually a " + parsedPem.getClass());
+        }
+        final JcaPEMKeyConverter converter = new JcaPEMKeyConverter();
+
+        return converter.getKeyPair((PEMKeyPair) parsedPem).getPrivate();
+    }
+
+    private static PrivateKey loadPrivateKeyPKCS12(StarlarkBytes privKey, char[] password) throws Exception {
+        KeyStore keyStore = KeyStore.getInstance("PKCS12");
+        InputStream inputStream = new ByteArrayInputStream(privKey.toByteArray());
+        keyStore.load(inputStream, password);
+        Enumeration<String> aliases = keyStore.aliases();
+        PrivateKey privateKey = null;
+        while (aliases.hasMoreElements()) {
+            String alias = aliases.nextElement();
+            // try:
+            try {
+                privateKey = (PrivateKey) keyStore.getKey(alias, password);
+                return privateKey;
+            } catch(Exception e){
+                continue;
+            }
+        }
+        return privateKey;
+    }
+
+    private static PublicKey loadPublicKeyX509(StarlarkBytes pubKey) throws Exception {
+        X509EncodedKeySpec keySpec = new X509EncodedKeySpec(pubKey.toByteArray());
+        KeyFactory kf = KeyFactory.getInstance("EC");
+        return kf.generatePublic(keySpec);
+    }
+}

--- a/larky/src/main/resources/vendor/larky_ecdh.star
+++ b/larky/src/main/resources/vendor/larky_ecdh.star
@@ -15,7 +15,7 @@ def LarkyECDH():
         self.public_key_type = "X509"
         self.private_pass = ""
         self.private_types = ["PEM", "PKCS8", "PKCS12"]
-        self.public_types = ["X509"]
+        self.public_types = ["X509"] # To do: Expand so it takes the raw bytes
     self.__init__ = __init__
     self.__init__()
 

--- a/larky/src/main/resources/vendor/larky_ecdh.star
+++ b/larky/src/main/resources/vendor/larky_ecdh.star
@@ -1,0 +1,42 @@
+load("@stdlib//larky", "larky")
+load("@stdlib//base64", "base64")
+load("@stdlib//builtins", "builtins")
+load("@stdlib//re", "re")
+
+load("@stdlib//ECDH", ECDH="ECDH")
+
+
+def _strip(string):
+    string = string.decode("utf-8")
+    headers = re.findall("(-----.*-----)", string)
+    for header in headers:
+        string = string.replace(header,"")
+    string.replace("\n","")
+    return base64.b64decode(string)
+
+def exchange(private, privType, public, pubType, private_pass=None):
+    if privType != "PEM":
+        """
+        Strip the newlines and header/footer, then base64 decode
+        if it is PKCS8 or PKCS12. 
+        """
+        private = _strip(private)
+    else:
+        """
+        The whole PEM string has to be passed as-is if it's PEM/SEC1. 
+        """
+        private = private.decode('utf-8')
+    public = _strip(public)
+
+    if private_pass == None:
+        private_pass = ""
+
+    return ECDH.key_exchange(private,
+                             privType,
+                             public,
+                             pubType,
+                             private_pass)
+
+ecdh = larky.struct(
+    exchange=exchange,
+)

--- a/larky/src/main/resources/vendor/larky_ecdh.star
+++ b/larky/src/main/resources/vendor/larky_ecdh.star
@@ -6,37 +6,60 @@ load("@stdlib//re", "re")
 load("@stdlib//ECDH", ECDH="ECDH")
 
 
-def _strip(string):
-    string = string.decode("utf-8")
-    headers = re.findall("(-----.*-----)", string)
-    for header in headers:
-        string = string.replace(header,"")
-    string.replace("\n","")
-    return base64.b64decode(string)
+def LarkyECDH():
+    self = larky.mutablestruct(__name__='LarkyECDH', __class__=LarkyECDH)
+    def __init__():
+        self.private_key = None
+        self.public_key = None
+        self.private_key_type = "PEM"
+        self.public_key_type = "X509"
+        self.private_pass = ""
+        self.private_types = ["PEM", "PKCS8", "PKCS12"]
+        self.public_types = ["X509"]
+    self.__init__ = __init__
+    self.__init__()
 
-def exchange(private, privType, public, pubType, private_pass=None):
-    if privType != "PEM":
-        """
-        Strip the newlines and header/footer, then base64 decode
-        if it is PKCS8 or PKCS12. 
-        """
-        private = _strip(private)
-    else:
-        """
-        The whole PEM string has to be passed as-is if it's PEM/SEC1. 
-        """
-        private = private.decode('utf-8')
-    public = _strip(public)
+    def set_private_key(private_key, type="PEM", passwd=""):
+        if type == "PKCS12" and passwd == "":
+            fail("Error: PKCS12 Keystores require a password. Keystores without a password are not supported.")
+        if type == "PKCS12" or type == "PKCS8":
+            private_key = self._strip(private_key)
+        elif type == "PEM":
+            private_key = private_key.decode("utf-8")
+        elif type not in self.private_types:
+            fail("Unsupported private key type: %s. Available types: %s" % (type, str([x for x in self.private_types])))
+        self.private_key = private_key
+        self.private_key_type = type
+        self.private_pass = passwd
+    self.set_private_key = set_private_key
 
-    if private_pass == None:
-        private_pass = ""
+    def set_public_key(public_key, type="X509"):
+        if type == "X509":
+            self.public_key = self._strip(public_key)
+        elif type not in self.public_types:
+            fail("Unsupported public key type: %s. Available types: %s" % (type, str([x for x in self.public_types])))
+    self.set_public_key = set_public_key
 
-    return ECDH.key_exchange(private,
-                             privType,
-                             public,
-                             pubType,
-                             private_pass)
+    def _strip(string):
+        string = string.decode("utf-8")
+        headers = re.findall("(-----.*-----)", string)
+        for header in headers:
+            string = string.replace(header,"")
+        string.replace("\n","")
+        return base64.b64decode(string)
+    self._strip = _strip
 
-ecdh = larky.struct(
-    exchange=exchange,
-)
+    def exchange():
+        if self.private_key == None:
+            fail("Error: No private key set. Use LarkyECDH.set_private_key() to set it.")
+        elif self.public_key == None:
+            fail("Error: No public key set. Use LarkyECDH.set_public_key() to set it.")
+
+        return ECDH.key_exchange(self.private_key,
+                                 self.private_key_type,
+                                 self.public_key,
+                                 self.public_key_type,
+                                 self.private_pass)
+    self.exchange = exchange
+
+    return self

--- a/larky/src/test/resources/quick_tests/test_customer_usecase.star
+++ b/larky/src/test/resources/quick_tests/test_customer_usecase.star
@@ -36,7 +36,6 @@ def test_customer_case():
     
     body = json.loads(larky_output._data.decode("utf-8"))
     headers = larky_output.headers
-    print(body)
     # Test that the code has executed properly on your request
     asserts.assert_that(body['BIN']).is_equal_to("411111")
     asserts.assert_that(headers['X-Custom-Header']).is_equal_to("I am a changed header")

--- a/larky/src/test/resources/quick_tests/test_customer_usecase.star
+++ b/larky/src/test/resources/quick_tests/test_customer_usecase.star
@@ -7,12 +7,14 @@ load("@stdlib//builtins", builtins="builtins")
 load("@vendor//asserts","asserts")
 
 load("@vgs//http/request", "VGSHttpRequest")
+load("@vgs//vault", "vault")
 
 def process(input_http, ctx):
   # Extract card BIN and add it to the body
   body = json.loads(input_http.body.decode("utf-8"))
   BIN = body['cardNumber'][:6]
   body['BIN'] = BIN
+  body['cardNumber'] = vault.redact(body['cardNumber'], "persistent")
 
   # Add the BIN to the headers and change the X-Custom-Header 
   headers = input_http.headers
@@ -34,7 +36,7 @@ def test_customer_case():
     
     body = json.loads(larky_output._data.decode("utf-8"))
     headers = larky_output.headers
-
+    print(body)
     # Test that the code has executed properly on your request
     asserts.assert_that(body['BIN']).is_equal_to("411111")
     asserts.assert_that(headers['X-Custom-Header']).is_equal_to("I am a changed header")

--- a/larky/src/test/resources/vendor_tests/ECDH/test_ecdh.star
+++ b/larky/src/test/resources/vendor_tests/ECDH/test_ecdh.star
@@ -18,19 +18,18 @@ UTNRkR3gNi2lU68AJ6RoaDtBE6mBdjbuFQ==
 -----END EC PRIVATE KEY-----"""
 
 public_key_x509 = b"""-----BEGIN PUBLIC KEY-----
-MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAERac12qEdVcn6gMlIB44sCqW6zFZi
-Gcgl8g9+8E4S7xjTarje7g9QDcb7F5zDYkqoVFG8pWfzGHCtNCK5zv0uUA==
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEgJOZmQJwFpa4reM893yNFSxXV5/f
+aPBDWKsJNnEgfrH8hhKqPrR5f3dhxhkGLJgOB/PAk1XuUfUbZ7hz1rSX8A==
 -----END PUBLIC KEY-----"""
 
 public_key_ephemeral = b"""MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEMwliotf2ICjiMwREdqyHSilqZzuV2fZey86nBIDlTY8sNMJv9CPpL5/DKg4bIEMe6qaj67mz4LWdr7Er0Ld5qA=="""
-
 
 def test_generated_keypair():
     ecdh = LarkyECDH()
     ecdh.set_private_key(private_key_pkcs8, type="PKCS8")
     ecdh.set_public_key(public_key_x509, "X509")
     shared_secret = ecdh.exchange()
-    expected = b"yIk6UBFxABvvo1fao/V4DyZ1DX7TE66T58f05zEM0LA="
+    expected = b"9/mnqq+gMfEbBiKX+pvzat+aCFLvn415Ez4NGbzLUHM="
     asserts.assert_that(base64.b64encode(shared_secret)).is_equal_to(expected)
 
 
@@ -54,7 +53,8 @@ def test_pkcs12_keypair():
     ecdh.set_private_key(pkcs12_keystore, type="PKCS12", passwd="vgs")
     ecdh.set_public_key(public_key_x509, "X509")
     shared_secret = ecdh.exchange()
-    expected = b"FOc7tXpSy1xM/4hw7lVyjf8QqYfg0agsnbIdgdCn+Tk="
+    print(base64.b64encode(shared_secret))
+    expected = b"QbflyOdxe/N3bl44eMZplnVen0RAZweSUUyG+wEpwOk="
     asserts.assert_that(base64.b64encode(shared_secret)).is_equal_to(expected)
 
 

--- a/larky/src/test/resources/vendor_tests/ECDH/test_ecdh.star
+++ b/larky/src/test/resources/vendor_tests/ECDH/test_ecdh.star
@@ -1,0 +1,68 @@
+load("@stdlib//base64", base64="base64")
+load("@stdlib//unittest","unittest")
+load("@vendor//asserts","asserts")
+load("@vendor//larky_ecdh", "ecdh")
+
+private_key_pkcs8 = b"""-----BEGIN PRIVATE KEY-----
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgmz1M0Qw9vHLQlIR2
+6LK2CEUyHFARQ7KrrBSWJjqVOlmhRANCAARFpzXaoR1VyfqAyUgHjiwKpbrMVmIZ
+yCXyD37wThLvGNNquN7uD1ANxvsXnMNiSqhUUbylZ/MYcK00IrnO/S5Q
+-----END PRIVATE KEY-----"""
+
+pkcs12_keystore = b"""MIIBmwIBAzCCAWIGCSqGSIb3DQEHAaCCAVMEggFPMIIBSzCCAUcGCSqGSIb3DQEHAaCCATgEggE0MIIBMDCCASwGCyqGSIb3DQEMCgECoIG8MIG5MBwGCiqGSIb3DQEMAQMwDgQIBUdleOxVSwkCAggABIGYuv4nS1kIU2SgJhyMh9A1oew/yGmKfm60mDnRqcnAd2hoISSOhg+ieCoWQWRjSL/4i0hph1ArhRLWaPYYPuQCHXBIE681QEMe9a4GeVrF2DFIzsOczn19RQAYb3LaXMgcdKiiCGxC58duPgIt91yes/vsfk84iHcRY86q/iV7yh87WqeqqhDe+VUFn9DoUGcQcr8p6TQ+rh0xXjA3BgkqhkiG9w0BCRQxKh4oAFYAZQByAHkARwBvAG8AZABTAGUAYwB1AHIAaQB0AHkAIABEAGUAdjAjBgkqhkiG9w0BCRUxFgQUr3uI24KVinVD+7ITCMI/HigMdWwwMDAhMAkGBSsOAwIaBQAEFEky3g45rWcjiU5+WmIZMNQ5P8kmBAjBn2X9CBPm9AIBAQ=="""
+
+private_key_PEM = b"""-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIDqrpF0KEFW4Ncb76vyBi3StFLiT222sFC0wC3LsP1M9oAoGCCqGSM49
+AwEHoUQDQgAED44gNZExKHUk9sMuXeZEBazNA+agV/VJK8vFug/rwuzqmzKE5v7q
+UTNRkR3gNi2lU68AJ6RoaDtBE6mBdjbuFQ==
+-----END EC PRIVATE KEY-----"""
+
+public_key_x509 = b"""-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAERac12qEdVcn6gMlIB44sCqW6zFZi
+Gcgl8g9+8E4S7xjTarje7g9QDcb7F5zDYkqoVFG8pWfzGHCtNCK5zv0uUA==
+-----END PUBLIC KEY-----"""
+
+public_key_ephemeral = b"""MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEMwliotf2ICjiMwREdqyHSilqZzuV2fZey86nBIDlTY8sNMJv9CPpL5/DKg4bIEMe6qaj67mz4LWdr7Er0Ld5qA=="""
+
+
+def test_generated_keypair():
+    shared_secret = ecdh.exchange(
+        private_key_pkcs8, "PKCS8",
+        public_key_x509, "X509")
+    expected = b"yIk6UBFxABvvo1fao/V4DyZ1DX7TE66T58f05zEM0LA="
+    asserts.assert_that(base64.b64encode(shared_secret)).is_equal_to(expected)
+
+
+def test_halturin_keypair():
+    """
+    Test the inputs from Halturin's Apple Pay library
+    """
+    shared_secret = ecdh.exchange(
+        private_key_PEM, "PEM",
+        public_key_ephemeral, "X509")
+    expected = b"a2pPfemSdA560FnzLSv8zfdlWdGJTonApOLq1zfgx8w="
+    asserts.assert_that(base64.b64encode(shared_secret)).is_equal_to(expected)
+
+
+def test_pkcs12_keypair():
+    """
+    PKCS12 Keystores require a password to be compatible.
+    """
+    shared_secret = ecdh.exchange(
+        pkcs12_keystore, "PKCS12",
+        public_key_x509, "X509",
+        private_pass="vgs"
+    )
+    expected = b"FOc7tXpSy1xM/4hw7lVyjf8QqYfg0agsnbIdgdCn+Tk="
+    asserts.assert_that(base64.b64encode(shared_secret)).is_equal_to(expected)
+
+
+def _testsuite():
+    _suite = unittest.TestSuite()
+    _suite.addTest(unittest.FunctionTestCase(test_generated_keypair))
+    _suite.addTest(unittest.FunctionTestCase(test_halturin_keypair))
+    _suite.addTest(unittest.FunctionTestCase(test_pkcs12_keypair))
+    return _suite
+
+_runner = unittest.TextTestRunner()
+_runner.run(_testsuite())


### PR DESCRIPTION
## Description of changes in release / Impact of release:
Pycryptodome has been the backbone of Starlarky's encryption capabilities. However, Pycryptodome is missing ECDH capabilities (despite having ECDSA). The other cryptographic modules that would have ECDH use pycryptodome as the backend, and are thus missing this capability as well. This ports it in a standalone way, so that if pycryptodome adds it in the future, there is no need to worry about documenting additional differences between our libraries. 

## Documentation
See `test_ecdh.star` for usage- will write wiki page soon. 

## Risks of this release

### Is this a breaking change?
- [ ] Yes
- [X] No

### Is there a way to disable the change?
- [X] Use previous release
- [ ] Use a feature flag
- [ ] No

#### Additional details go here
* This was implemented in this standalone way rather than using the pycryptodome EC Libraries due to difficulties in getting the point-jacobi multiplication to work in Larky without recursion or mutating frozen dicts. 
* This actually allows us to do the decryption only on Apple Pay tokens completely within Larky right now- there is still additional work to be done to extract information from the certificate they supply and to perform all of the validations, but this lets us do the decryption itself. 
* This is a prerequisite to porting [applepay](https://github.com/halturin/applepay). EC Keys from this library's test case were included in our test files to ensure sufficient EC Key capabilities were ported. 