### PR TITLE
[CSL3-1552] allow to skip additional unescape

### DIFF
--- a/larky/src/main/java/com/verygood/security/larky/modules/CodecsModule.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/CodecsModule.java
@@ -65,7 +65,7 @@ public class CodecsModule implements StarlarkValue {
               allowedTypes = {
                   @ParamType(type = Boolean.class),
               },
-              defaultValue = "True",
+              defaultValue = "False",
               named = true
           )
       },

--- a/larky/src/main/java/com/verygood/security/larky/modules/CodecsModule.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/CodecsModule.java
@@ -65,7 +65,7 @@ public class CodecsModule implements StarlarkValue {
               allowedTypes = {
                   @ParamType(type = Boolean.class),
               },
-              defaultValue = "False",
+              defaultValue = "True",
               named = true
           )
       },

--- a/larky/src/test/resources/stdlib_tests/test_bytes.star
+++ b/larky/src/test/resources/stdlib_tests/test_bytes.star
@@ -250,8 +250,8 @@ def _test_bytes_join():
 def _test_skip_unescape_encode():
     bytes = b"{\"field\": \"\\n  function(a):\\n    a=dosomething()\\n    return a\\n\\n\",\"simple_field\":{\"input\":\"123344444\"}}"
     text = codecs.decode(bytes,'ISO-8859-1')
-    asserts.assert_that(codecs.encode(text,'ISO-8859-1','error', True)).is_not_equal_to(bytes)
-    asserts.assert_that(codecs.encode(text,'ISO-8859-1','error')).is_equal_to(bytes)
+    asserts.assert_that(codecs.encode(text,'ISO-8859-1','error')).is_not_equal_to(bytes)
+    asserts.assert_that(codecs.encode(text,'ISO-8859-1','error', False)).is_equal_to(bytes)
 
 
 # TODO(adonovan): the specification is not finalized in many areas:

--- a/larky/src/test/resources/stdlib_tests/test_bytes.star
+++ b/larky/src/test/resources/stdlib_tests/test_bytes.star
@@ -247,6 +247,12 @@ def _test_bytes_join():
     sut = bytearray([0x2e]).join([bytes([0x61,0x62]), bytes([0x70,0x71]), bytes([0x72,0x73])])
     asserts.assert_that(sut).is_equal_to(expected)
 
+def _test_skip_unescape_encode():
+    bytes = b"{\"field\": \"\\n  function(a):\\n    a=dosomething()\\n    return a\\n\\n\",\"simple_field\":{\"input\":\"123344444\"}}"
+    text = str(bytes)
+    asserts.assert_that(codecs.encode(text,'ISO-8859-1','error')).is_not_equal_to(bytes)
+    asserts.assert_that(codecs.encode(text,'ISO-8859-1','error', False)).is_equal_to(bytes)
+
 
 # TODO(adonovan): the specification is not finalized in many areas:
 # - chr, ord functions
@@ -299,6 +305,7 @@ def _testsuite():
     _suite.addTest(unittest.FunctionTestCase(_test_slicing))
     _suite.addTest(unittest.FunctionTestCase(_test_bytes_are_immutable))
     _suite.addTest(unittest.FunctionTestCase(_test_bytes_join))
+    _suite.addTest(unittest.FunctionTestCase(_test_skip_unescape_encode))
 
     return _suite
 

--- a/larky/src/test/resources/stdlib_tests/test_bytes.star
+++ b/larky/src/test/resources/stdlib_tests/test_bytes.star
@@ -249,9 +249,9 @@ def _test_bytes_join():
 
 def _test_skip_unescape_encode():
     bytes = b"{\"field\": \"\\n  function(a):\\n    a=dosomething()\\n    return a\\n\\n\",\"simple_field\":{\"input\":\"123344444\"}}"
-    text = str(bytes)
-    asserts.assert_that(codecs.encode(text,'ISO-8859-1','error')).is_not_equal_to(bytes)
-    asserts.assert_that(codecs.encode(text,'ISO-8859-1','error', False)).is_equal_to(bytes)
+    text = codecs.decode(bytes,'ISO-8859-1')
+    asserts.assert_that(codecs.encode(text,'ISO-8859-1','error', True)).is_not_equal_to(bytes)
+    asserts.assert_that(codecs.encode(text,'ISO-8859-1','error')).is_equal_to(bytes)
 
 
 # TODO(adonovan): the specification is not finalized in many areas:


### PR DESCRIPTION
## Fixes [Jira Story or GH Issue if applicable](https://verygoodsecurity.atlassian.net/browse/CSL3-1552)

## Description of changes in release / Impact of release:
allow to skip additional unescape when `unescape=False`.  default `unescape=True`

## Documentation
(insert text here)

## Risks of this release

### Is this a breaking change?
- [ ] Yes
- [x] No

### If you answered Yes then describe why is it so
(insert text here if applicable)

### Is there a way to disable the change?
- [x] Use previous release
- [ ] Use a feature flag
- [ ] No

#### Additional details go here
(insert text here if applicable)
