### PR TITLE
VAULT-2281 Add Delete API to LarkyVault

### DIFF
--- a/larky/src/main/java/com/verygood/security/larky/modules/VaultModule.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/VaultModule.java
@@ -158,7 +158,7 @@ public class VaultModule implements LarkyVault {
 
     @StarlarkMethod(
         name = "delete",
-        doc = "deletes aliased value, returns revealed value",
+        doc = "deletes aliased value",
         parameters = {
             @Param(
                 name = "value",
@@ -178,10 +178,9 @@ public class VaultModule implements LarkyVault {
                 })
         })
     @Override
-    public Object delete(Object value, Object storage) throws EvalException {
+    public void delete(Object value, Object storage) throws EvalException {
         validateStorage(storage);
-
-        return vault.delete(value, storage);
+        vault.delete(value, storage);
     }
 
     private void validateStorage(Object storage) throws EvalException {

--- a/larky/src/main/java/com/verygood/security/larky/modules/VaultModule.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/VaultModule.java
@@ -156,6 +156,34 @@ public class VaultModule implements LarkyVault {
         return vault.reveal(value, storage);
     }
 
+    @StarlarkMethod(
+        name = "delete",
+        doc = "deletes aliased value, returns revealed value",
+        parameters = {
+            @Param(
+                name = "value",
+                doc = "alias to delete",
+                allowedTypes = {
+                    @ParamType(type = String.class),
+                    @ParamType(type = List.class, generic1 = String.class)
+                }),
+            @Param(
+                name = "storage",
+                doc = "storage type ('persistent' or 'volatile')",
+                named = true,
+                defaultValue = "None",
+                allowedTypes = {
+                    @ParamType(type = NoneType.class),
+                    @ParamType(type = String.class),
+                })
+        })
+    @Override
+    public Object delete(Object value, Object storage) throws EvalException {
+        validateStorage(storage);
+
+        return vault.delete(value, storage);
+    }
+
     private void validateStorage(Object storage) throws EvalException {
         if (!(storage instanceof NoneType) && !(storage instanceof String)) {
             throw Starlark.errorf(String.format(

--- a/larky/src/main/java/com/verygood/security/larky/modules/vgs/vault/NoopVault.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/vgs/vault/NoopVault.java
@@ -17,7 +17,7 @@ public class NoopVault implements LarkyVault {
     }
 
     @Override
-    public Object delete(Object value, Object storage) throws EvalException {
+    public void delete(Object value, Object storage) throws EvalException {
         throw Starlark.errorf("vault.delete operation must be overridden");
     }
 }

--- a/larky/src/main/java/com/verygood/security/larky/modules/vgs/vault/NoopVault.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/vgs/vault/NoopVault.java
@@ -1,11 +1,9 @@
 package com.verygood.security.larky.modules.vgs.vault;
 
 import com.verygood.security.larky.modules.vgs.vault.spi.LarkyVault;
-import java.util.Map;
+import java.util.List;
 import net.starlark.java.eval.EvalException;
 import net.starlark.java.eval.Starlark;
-
-import java.util.List;
 
 public class NoopVault implements LarkyVault {
     @Override
@@ -16,5 +14,10 @@ public class NoopVault implements LarkyVault {
     @Override
     public Object reveal(Object value, Object storage) throws EvalException {
         throw Starlark.errorf("vault.reveal operation must be overridden");
+    }
+
+    @Override
+    public Object delete(Object value, Object storage) throws EvalException {
+        throw Starlark.errorf("vault.delete operation must be overridden");
     }
 }

--- a/larky/src/main/java/com/verygood/security/larky/modules/vgs/vault/defaults/DefaultVault.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/vgs/vault/defaults/DefaultVault.java
@@ -73,6 +73,13 @@ public class DefaultVault implements LarkyVault {
         return secret == null ? sValue : secret; // return value of alias if secret not found
     }
 
+    @Override
+    public Object delete(Object value, Object storage) throws EvalException {
+        String sValue = getValue(value);
+        Object secret = getStorage(storage).remove(sValue);
+        return secret == null ? sValue : secret; // return value of alias if secret not found
+    }
+
     private String getValue(Object value) throws EvalException {
         if (!(value instanceof String)) {
             throw Starlark.errorf(String.format(

--- a/larky/src/main/java/com/verygood/security/larky/modules/vgs/vault/defaults/DefaultVault.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/vgs/vault/defaults/DefaultVault.java
@@ -74,10 +74,9 @@ public class DefaultVault implements LarkyVault {
     }
 
     @Override
-    public Object delete(Object value, Object storage) throws EvalException {
+    public void delete(Object value, Object storage) throws EvalException {
         String sValue = getValue(value);
-        Object secret = getStorage(storage).remove(sValue);
-        return secret == null ? sValue : secret; // return value of alias if secret not found
+        getStorage(storage).remove(sValue);
     }
 
     private String getValue(Object value) throws EvalException {

--- a/larky/src/main/java/com/verygood/security/larky/modules/vgs/vault/spi/LarkyVault.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/vgs/vault/spi/LarkyVault.java
@@ -11,12 +11,11 @@ public interface LarkyVault extends StarlarkValue {
     Object reveal(Object value, Object storage) throws EvalException;
 
     /**
-     * Returns the current raw value (acts like a reveal and delete).
+     * Delete the token, errors if not found.
      * @param value Alias or Alias List
      * @param storage Persistent or Volatile (null defaults to Persistent)
-     * @return Value of alias(es) or throws if not found
      * @throws EvalException if any alias not found or bad input
      */
-    Object delete(Object value, Object storage) throws EvalException;
+    void delete(Object value, Object storage) throws EvalException;
 
 }

--- a/larky/src/main/java/com/verygood/security/larky/modules/vgs/vault/spi/LarkyVault.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/vgs/vault/spi/LarkyVault.java
@@ -1,14 +1,22 @@
 package com.verygood.security.larky.modules.vgs.vault.spi;
 
+import java.util.List;
 import net.starlark.java.eval.EvalException;
 import net.starlark.java.eval.StarlarkValue;
-
-import java.util.List;
 
 public interface LarkyVault extends StarlarkValue {
 
     Object redact(Object value, Object storage, Object format, List<Object> tags, Object decoratorConfig) throws EvalException;
 
     Object reveal(Object value, Object storage) throws EvalException;
+
+    /**
+     * Returns the current raw value (acts like a reveal and delete).
+     * @param value Alias or Alias List
+     * @param storage Persistent or Volatile (null defaults to Persistent)
+     * @return Value of alias(es) or throws if not found
+     * @throws EvalException if any alias not found or bad input
+     */
+    Object delete(Object value, Object storage) throws EvalException;
 
 }

--- a/larky/src/test/java/com/verygood/security/larky/modules/vgs/vault/VaultModuleSPITest.java
+++ b/larky/src/test/java/com/verygood/security/larky/modules/vgs/vault/VaultModuleSPITest.java
@@ -1,7 +1,6 @@
 package com.verygood.security.larky.modules.vgs.vault;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -86,7 +85,7 @@ public class VaultModuleSPITest {
         // Assert OK
         assertTrue(alias.contains("tok_"));
         assertEquals(secret, result);
-        assertNull(resultAfterDel);
+        assertEquals(alias, resultAfterDel);
     }
 
     @Test
@@ -106,7 +105,7 @@ public class VaultModuleSPITest {
         // Assert OK
         assertTrue(alias.contains("tok_"));
         assertEquals(secret, result);
-        assertNull(resultAfterDel);
+        assertEquals(alias, resultAfterDel);
     }
 
     @Test

--- a/larky/src/test/java/com/verygood/security/larky/modules/vgs/vault/VaultModuleSPITest.java
+++ b/larky/src/test/java/com/verygood/security/larky/modules/vgs/vault/VaultModuleSPITest.java
@@ -1,17 +1,19 @@
 package com.verygood.security.larky.modules.vgs.vault;
 
-import com.verygood.security.larky.modules.VaultModule;
-import net.starlark.java.eval.EvalException;
-import net.starlark.java.eval.Starlark;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.verygood.security.larky.modules.VaultModule;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import net.starlark.java.eval.EvalException;
+import net.starlark.java.eval.Starlark;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 // Tests that VaultModule SPI functionality works as expected
 public class VaultModuleSPITest {
@@ -44,17 +46,24 @@ public class VaultModuleSPITest {
         vault = new VaultModule();
 
         // Assert Exceptions
-        Assertions.assertThrows(EvalException.class,
+        assertThrows(EvalException.class,
                 () -> {
                     vault.redact("fail", Starlark.NONE, Starlark.NONE, null, null);
                 },
                 "vault.redact operation must be overridden"
         );
-        Assertions.assertThrows(EvalException.class,
+        assertThrows(EvalException.class,
                 () -> {
                     vault.reveal("fail", Starlark.NONE);
                 },
                 "vault.reveal operation must be overridden"
+        );
+
+        assertThrows(EvalException.class,
+            () -> {
+                vault.delete("fail", Starlark.NONE);
+            },
+            "vault.delete operation must be overridden"
         );
     }
 
@@ -70,10 +79,12 @@ public class VaultModuleSPITest {
         String secret = "4111111111111111";
         String alias = (String) vault.redact(secret, Starlark.NONE, Starlark.NONE, null, null);
         String result = (String) vault.reveal(alias, Starlark.NONE);
+        String del = (String) vault.delete(alias, Starlark.NONE);
 
         // Assert OK
-        Assertions.assertTrue(alias.contains("tok_"));
-        Assertions.assertEquals(secret, result);
+        assertTrue(alias.contains("tok_"));
+        assertEquals(secret, result);
+        assertEquals(secret, del);
     }
 
     @Test
@@ -87,10 +98,12 @@ public class VaultModuleSPITest {
         String secret = "4111111111111111";
         String alias = (String) vault.redact(secret, Starlark.NONE, Starlark.NONE, null, null);
         String result = (String) vault.reveal(alias, Starlark.NONE);
+        String del = (String) vault.delete(alias, Starlark.NONE);
 
         // Assert OK
-        Assertions.assertTrue(alias.contains("tok_"));
-        Assertions.assertEquals(secret, result);
+        assertTrue(alias.contains("tok_"));
+        assertEquals(secret, result);
+        assertEquals(secret, del);
     }
 
     @Test
@@ -102,7 +115,7 @@ public class VaultModuleSPITest {
         System.setProperty(VaultModule.ENABLE_INMEMORY_PROPERTY, "false");
 
         // Assert Exception
-        Assertions.assertThrows(IllegalArgumentException.class,
+        assertThrows(IllegalArgumentException.class,
                 () -> {
                     vault = new VaultModule();
                 },

--- a/larky/src/test/java/com/verygood/security/larky/modules/vgs/vault/VaultModuleSPITest.java
+++ b/larky/src/test/java/com/verygood/security/larky/modules/vgs/vault/VaultModuleSPITest.java
@@ -1,6 +1,7 @@
 package com.verygood.security.larky.modules.vgs.vault;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -79,12 +80,13 @@ public class VaultModuleSPITest {
         String secret = "4111111111111111";
         String alias = (String) vault.redact(secret, Starlark.NONE, Starlark.NONE, null, null);
         String result = (String) vault.reveal(alias, Starlark.NONE);
-        String del = (String) vault.delete(alias, Starlark.NONE);
+        vault.delete(alias, Starlark.NONE);
+        String resultAfterDel = (String) vault.reveal(alias, Starlark.NONE);
 
         // Assert OK
         assertTrue(alias.contains("tok_"));
         assertEquals(secret, result);
-        assertEquals(secret, del);
+        assertNull(resultAfterDel);
     }
 
     @Test
@@ -98,12 +100,13 @@ public class VaultModuleSPITest {
         String secret = "4111111111111111";
         String alias = (String) vault.redact(secret, Starlark.NONE, Starlark.NONE, null, null);
         String result = (String) vault.reveal(alias, Starlark.NONE);
-        String del = (String) vault.delete(alias, Starlark.NONE);
+        vault.delete(alias, Starlark.NONE);
+        String resultAfterDel = (String) vault.reveal(alias, Starlark.NONE);
 
         // Assert OK
         assertTrue(alias.contains("tok_"));
         assertEquals(secret, result);
-        assertEquals(secret, del);
+        assertNull(resultAfterDel);
     }
 
     @Test

--- a/larky/src/test/resources/vgs_tests/vault/test_default_vault.star
+++ b/larky/src/test/resources/vgs_tests/vault/test_default_vault.star
@@ -35,6 +35,24 @@ def _test_default_reveal():
 
     asserts.assert_that(revealed_card_number).is_equal_to(card_number)
 
+def _test_default_delete():
+    card_number = "4111111111111113"
+    redacted_card_number = vault.redact(card_number)
+    deleted = vault.delete(redacted_card_number)
+    asserts.assert_that(deleted).is_equal_to(card_number)
+    revealed_card_number = vault.reveal(redacted_card_number)
+
+    asserts.assert_that(revealed_card_number).is_equal_to(redacted_card_number)
+
+def _test_default_delete_volatile():
+    card_number = "4111111111111113"
+    redacted_card_number = vault.redact(card_number, storage='volatile')
+    deleted = vault.delete(redacted_card_number, storage='volatile')
+    asserts.assert_that(deleted).is_equal_to(card_number)
+    revealed_card_number = vault.reveal(redacted_card_number, storage='volatile')
+
+    asserts.assert_that(revealed_card_number).is_equal_to(redacted_card_number)
+
 def _test_empty_reveal():
     alias = "tok_123"
     revealed = vault.reveal(alias)
@@ -248,6 +266,10 @@ def _suite():
     _suite.addTest(unittest.FunctionTestCase(_test_default_reveal))
     _suite.addTest(unittest.FunctionTestCase(_test_empty_reveal))
     _suite.addTest(unittest.FunctionTestCase(_test_invalid_list_reveal))
+
+    # Delete Tests
+    _suite.addTest(unittest.FunctionTestCase(_test_default_delete))
+    _suite.addTest(unittest.FunctionTestCase(_test_default_delete_volatile))
 
     # Storage Tests
     _suite.addTest(unittest.FunctionTestCase(_test_persistent_storage))

--- a/larky/src/test/resources/vgs_tests/vault/test_default_vault.star
+++ b/larky/src/test/resources/vgs_tests/vault/test_default_vault.star
@@ -38,8 +38,7 @@ def _test_default_reveal():
 def _test_default_delete():
     card_number = "4111111111111113"
     redacted_card_number = vault.redact(card_number)
-    deleted = vault.delete(redacted_card_number)
-    asserts.assert_that(deleted).is_equal_to(card_number)
+    vault.delete(redacted_card_number)
     revealed_card_number = vault.reveal(redacted_card_number)
 
     asserts.assert_that(revealed_card_number).is_equal_to(redacted_card_number)
@@ -47,8 +46,7 @@ def _test_default_delete():
 def _test_default_delete_volatile():
     card_number = "4111111111111113"
     redacted_card_number = vault.redact(card_number, storage='volatile')
-    deleted = vault.delete(redacted_card_number, storage='volatile')
-    asserts.assert_that(deleted).is_equal_to(card_number)
+    vault.delete(redacted_card_number, storage='volatile')
     revealed_card_number = vault.reveal(redacted_card_number, storage='volatile')
 
     asserts.assert_that(revealed_card_number).is_equal_to(redacted_card_number)


### PR DESCRIPTION
## Fixes [VAULT-2281](link)

## Description of changes in release / Impact of release:
- Adds an API to VaultLarky to enable delete of aliases via Larky

## Documentation
(insert text here)

## Risks of this release

### Is this a breaking change?
- [ ] Yes
- [ ] No

### If you answered Yes then describe why is it so
(insert text here if applicable)

### Is there a way to disable the change?
- [ ] Use previous release
- [ ] Use a feature flag
- [ ] No

#### Additional details go here
(insert text here if applicable)


[VAULT-2281]: https://verygoodsecurity.atlassian.net/browse/VAULT-2281?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ