### PR TITLE
[PAYOP-1264] Add `use_network_token` method for nts module

### DIFF
--- a/larky/src/main/resources/vgs/nts.star
+++ b/larky/src/main/resources/vgs/nts.star
@@ -106,7 +106,7 @@ def supports_dcvv(input, pan):
     return vault.reveal(jsonpath_ng.parse(pan).find(input).value).startswith("4")
 
 
-def is_network_token_enabled(headers):
+def use_network_token(headers):
     """Check value in the headers and determine whether is network token should be used or not
 
     :param headers: HTTP request headers to be checked against
@@ -120,5 +120,5 @@ nts = larky.struct(
     get_network_token=_nts.get_network_token,
     render=render,
     supports_dcvv=supports_dcvv,
-    is_network_token_enabled=is_network_token_enabled,
+    use_network_token=use_network_token,
 )

--- a/larky/src/main/resources/vgs/nts.star
+++ b/larky/src/main/resources/vgs/nts.star
@@ -4,6 +4,9 @@ load("@stdlib//larky", larky="larky")
 load("@vendor//jsonpath_ng", jsonpath_ng="jsonpath_ng")
 
 
+VGS_NETWORK_TOKEN_HEADER = "vgs-network-token"
+
+
 def render(
     input,
     pan,
@@ -103,8 +106,19 @@ def supports_dcvv(input, pan):
     return vault.reveal(jsonpath_ng.parse(pan).find(input).value).startswith("4")
 
 
+def is_network_token_enabled(headers):
+    """Check value in the headers and determine whether is network token should be used or not
+
+    :param headers: HTTP request headers to be checked against
+    :return: True if the network token is enabled, otherwise False
+    """
+    lower_case_headers = {key.lower(): value for key, value in headers.items()}
+    return lower_case_headers.get(VGS_NETWORK_TOKEN_HEADER, "").lower() == "yes"
+
+
 nts = larky.struct(
     get_network_token=_nts.get_network_token,
     render=render,
-    supports_dcvv=supports_dcvv
+    supports_dcvv=supports_dcvv,
+    is_network_token_enabled=is_network_token_enabled,
 )

--- a/larky/src/test/resources/vgs_tests/nts/test_default_nts.star
+++ b/larky/src/test/resources/vgs_tests/nts/test_default_nts.star
@@ -185,6 +185,17 @@ def _test_supports_dcvv_returns_false():
     asserts.assert_that(nts.supports_dcvv(input, "$.payload.number")).is_false()
 
 
+def _test_is_network_token_enabled():
+    asserts.assert_that(nts.is_network_token_enabled({})).is_false()
+    asserts.assert_that(nts.is_network_token_enabled({"vgs-network-token": ""})).is_false()
+    asserts.assert_that(nts.is_network_token_enabled({"vgs-network-token": "no"})).is_false()
+    asserts.assert_that(nts.is_network_token_enabled({"vgs-network-token": "other"})).is_false()
+    asserts.assert_that(nts.is_network_token_enabled({"vgs-network-token": "yes"})).is_true()
+    asserts.assert_that(nts.is_network_token_enabled({"Vgs-Network-Token": "yes"})).is_true()
+    asserts.assert_that(nts.is_network_token_enabled({"Vgs-Network-Token": "Yes"})).is_true()
+    asserts.assert_that(nts.is_network_token_enabled({"VGS-NETWORK-TOKEN": "YES"})).is_true()
+
+
 def _suite():
     _suite = unittest.TestSuite()
 
@@ -200,8 +211,11 @@ def _suite():
     _suite.addTest(unittest.FunctionTestCase(_test_render_not_found))
     _suite.addTest(unittest.FunctionTestCase(_test_render_with_both_cvv_and_dcvv))
     _suite.addTest(unittest.FunctionTestCase(_test_render_without_either_cvv_or_dcvv))
+    # Support DCVV tests
     _suite.addTest(unittest.FunctionTestCase(_test_supports_dcvv_returns_true))
     _suite.addTest(unittest.FunctionTestCase(_test_supports_dcvv_returns_false))
+    # Is network token enabled tests
+    _suite.addTest(unittest.FunctionTestCase(_test_is_network_token_enabled))
     return _suite
 
 

--- a/larky/src/test/resources/vgs_tests/nts/test_default_nts.star
+++ b/larky/src/test/resources/vgs_tests/nts/test_default_nts.star
@@ -185,15 +185,15 @@ def _test_supports_dcvv_returns_false():
     asserts.assert_that(nts.supports_dcvv(input, "$.payload.number")).is_false()
 
 
-def _test_is_network_token_enabled():
-    asserts.assert_that(nts.is_network_token_enabled({})).is_false()
-    asserts.assert_that(nts.is_network_token_enabled({"vgs-network-token": ""})).is_false()
-    asserts.assert_that(nts.is_network_token_enabled({"vgs-network-token": "no"})).is_false()
-    asserts.assert_that(nts.is_network_token_enabled({"vgs-network-token": "other"})).is_false()
-    asserts.assert_that(nts.is_network_token_enabled({"vgs-network-token": "yes"})).is_true()
-    asserts.assert_that(nts.is_network_token_enabled({"Vgs-Network-Token": "yes"})).is_true()
-    asserts.assert_that(nts.is_network_token_enabled({"Vgs-Network-Token": "Yes"})).is_true()
-    asserts.assert_that(nts.is_network_token_enabled({"VGS-NETWORK-TOKEN": "YES"})).is_true()
+def _test_use_network_token():
+    asserts.assert_that(nts.use_network_token({})).is_false()
+    asserts.assert_that(nts.use_network_token({"vgs-network-token": ""})).is_false()
+    asserts.assert_that(nts.use_network_token({"vgs-network-token": "no"})).is_false()
+    asserts.assert_that(nts.use_network_token({"vgs-network-token": "other"})).is_false()
+    asserts.assert_that(nts.use_network_token({"vgs-network-token": "yes"})).is_true()
+    asserts.assert_that(nts.use_network_token({"Vgs-Network-Token": "yes"})).is_true()
+    asserts.assert_that(nts.use_network_token({"Vgs-Network-Token": "Yes"})).is_true()
+    asserts.assert_that(nts.use_network_token({"VGS-NETWORK-TOKEN": "YES"})).is_true()
 
 
 def _suite():
@@ -215,7 +215,7 @@ def _suite():
     _suite.addTest(unittest.FunctionTestCase(_test_supports_dcvv_returns_true))
     _suite.addTest(unittest.FunctionTestCase(_test_supports_dcvv_returns_false))
     # Is network token enabled tests
-    _suite.addTest(unittest.FunctionTestCase(_test_is_network_token_enabled))
+    _suite.addTest(unittest.FunctionTestCase(_test_use_network_token))
     return _suite
 
 


### PR DESCRIPTION
## Fixes [PAYOP-1264](https://verygoodsecurity.atlassian.net/browse/PAYOP-1264)

## Description of changes in release / Impact of release:
Add `use_network_token` method for nts module

## Documentation
Add `use_network_token` method for nts module

## Risks of this release

### Is this a breaking change?
- [ ] Yes
- [ ] No

### If you answered Yes then describe why is it so
(insert text here if applicable)

### Is there a way to disable the change?
- [ ] Use previous release
- [ ] Use a feature flag
- [ ] No

#### Additional details go here
(insert text here if applicable)


[PAYOP-1264]: https://verygoodsecurity.atlassian.net/browse/PAYOP-1264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ