### PR TITLE
initial config addition for Semgrep SAST and Dependency scans

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -278,6 +278,57 @@ jobs:
           name: Upload packages
           command: twine upload -u __token__ -p ${PYPI_TOKEN} ${DIST_PATH}/*.whl
 
+  scan-sast-pr:
+    <<: *job-defaults
+    <<: *machine-linux
+    parameters:
+      default_branch:
+        type: string
+        default: master
+    environment: 
+      SEMGREP_REPO_URL: << pipeline.project.git_url >>
+      SEMGREP_BRANCH: << pipeline.git.branch >>
+      SEMGREP_BASELINE_REF: << parameters.default_branch >>
+      SEMGREP_PR_ID: $CIRCLE_PR_NUMBER
+    steps:
+      - checkout
+      - <<: *install-java
+      - <<: *install_python
+      - <<: *restore-maven-cache
+      - <<: *setup-maven-distributions
+      - <<: *restore-maven-cache
+      - run:
+          name: "Semgrep diff scan"
+          command: |
+            export SEMGREP_REPO_NAME="$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME"
+            mvn dependency:tree -DoutputFile=maven_dep_tree.txt
+            python3 -m pip install semgrep
+            python3 -m semgrep ci
+
+  scan-sast-full:
+    <<: *job-defaults
+    <<: *machine-linux
+    parameters:
+      default_branch:
+        type: string
+        default: master
+    environment: 
+      SEMGREP_REPO_URL: << pipeline.project.git_url >>
+      SEMGREP_BRANCH: << pipeline.git.branch >>
+    steps:
+      - checkout
+      - <<: *install-java
+      - <<: *install_python
+      - <<: *restore-maven-cache
+      - <<: *setup-maven-distributions
+      - <<: *restore-maven-cache
+      - run:
+          name: "Semgrep full scan"
+          command: |
+            mvn dependency:tree -DoutputFile=maven_dep_tree.txt
+            python3 -m pip install semgrep
+            python3 -m semgrep ci
+
 workflows:
   version: 2
   build_and_tests:
@@ -286,6 +337,12 @@ workflows:
       - build-dist-linux:
           requires:
             - build-and-test
+      - scan-sast-pr:
+          requires:
+            - build-and-test
+          context:
+            - security-tools
+            - circleci
 
   release:
     jobs:
@@ -322,4 +379,25 @@ workflows:
               ignore: /.*/
           requires:
             - build-dist-linux
+      - scan-sast-full:
+          requires:
+            - build-dist-maven
+          context:
+            - security-tools
+            - circleci
+
+# Workflow for scheduled security scans
+  scheduled-security-scan:
+    triggers:
+      - schedule:
+          cron: "0 0 * * 1"
+          filters:
+            branches:
+              only:
+                - master       
+    jobs: 
+      - scan-sast-full:
+          context:
+            - security-tools
+            - circleci
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -288,7 +288,7 @@ jobs:
     environment: 
       SEMGREP_REPO_URL: << pipeline.project.git_url >>
       SEMGREP_BRANCH: << pipeline.git.branch >>
-      SEMGREP_BASELINE_REF: << parameters.default_branch >>
+      SEMGREP_BASELINE_REF: master
       SEMGREP_PR_ID: $CIRCLE_PR_NUMBER
     steps:
       - checkout

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,22 @@
+
+# Common large paths
+node_modules/
+build/
+dist/
+vendor/
+.env/
+.venv/
+.tox/
+*.min.js
+.npm/
+
+# Common test paths
+test/
+tests/
+*_test.go
+
+# Semgrep rules folder
+.semgrep
+
+# Semgrep-action log folder
+.semgrep_logs/


### PR DESCRIPTION
## Fixes [SECENG-222](https://verygoodsecurity.atlassian.net/jira/software/c/projects/SECENG/issues/SECENG-222?jql=project%20%3D%20%22SECENG%22%20AND%20text%20~%20%22sast%22%20ORDER%20BY%20created%20DESC)

## Description of changes in release / Impact of release:
Adding configuration for Semgrep Code (SAST) and SCA (dependency vulnerability scanning). The jobs provided perform scans of PRs and and also a scheduled scan. Required for PCI DSS 6

## Documentation
(insert text here)

## Risks of this release

### Is this a breaking change?
- [ ] Yes
- [X] No

### If you answered Yes then describe why is it so
(insert text here if applicable)

### Is there a way to disable the change?
- [ ] Use previous release
- [ ] Use a feature flag
- [X] No

#### Additional details go here
(insert text here if applicable)


[SECENG-222]: https://verygoodsecurity.atlassian.net/browse/SECENG-222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ