### PR TITLE
[PAYOP-1489] Make cvv optional for network token render

### DIFF
--- a/larky/src/main/resources/vgs/nts.star
+++ b/larky/src/main/resources/vgs/nts.star
@@ -85,9 +85,9 @@ def render(
         cvv_result = safe(jsonpath_ng.parse(dcvv).find)(input)
     elif all([cvv, dcvv]):
         fail("ValueError: only either one of cvv or dvcc can be provided")
-    cvv_value = None
+    cvv_value = ""
     if cvv_result != None and cvv_result.is_ok:
-        cvv_value = cvv_result.unwrap()
+        cvv_value = cvv_result.unwrap().value
 
     network_token = _nts.get_network_token(
         pan=pan_value,

--- a/larky/src/test/resources/vgs_tests/nts/test_default_nts.star
+++ b/larky/src/test/resources/vgs_tests/nts/test_default_nts.star
@@ -129,6 +129,19 @@ def _test_render_without_cvv_value():
     asserts.assert_that("cvv" in output["paymentMethod"]).is_false()
 
 
+def _test_render_without_dcvv_value():
+    input = _make_fixture()
+    input["paymentMethod"].pop("cvv")
+    output = nts.render(
+        input,
+        pan="$.paymentMethod.number",
+        dcvv="$.paymentMethod.cvv",
+        amount="$.amount.value",
+        currency_code="$.amount.currency",
+    )
+    asserts.assert_that("cvv" in output["paymentMethod"]).is_false()
+
+
 def _test_render_pan_empty_value():
     asserts.assert_fails(
         lambda: nts.render(
@@ -166,18 +179,6 @@ def _test_render_with_both_cvv_and_dcvv():
             currency_code="$.amount.currency",
         ),
         "ValueError: only either one of cvv or dvcc can be provided",
-    )
-
-
-def _test_render_without_either_cvv_or_dcvv():
-    asserts.assert_fails(
-        lambda: nts.render(
-            _make_fixture(),
-            pan="$.paymentMethod.number",
-            amount="$.amount.value",
-            currency_code="$.amount.currency",
-        ),
-        "ValueError: either one of cvv or dvcc need to be provided",
     )
 
 
@@ -245,7 +246,6 @@ def _suite():
     _suite.addTest(unittest.FunctionTestCase(_test_render_pan_empty_value))
     _suite.addTest(unittest.FunctionTestCase(_test_render_not_found))
     _suite.addTest(unittest.FunctionTestCase(_test_render_with_both_cvv_and_dcvv))
-    _suite.addTest(unittest.FunctionTestCase(_test_render_without_either_cvv_or_dcvv))
     # Support DCVV tests
     _suite.addTest(unittest.FunctionTestCase(_test_supports_dcvv_returns_true))
     _suite.addTest(unittest.FunctionTestCase(_test_supports_dcvv_returns_false))

--- a/larky/src/test/resources/vgs_tests/nts/test_default_nts.star
+++ b/larky/src/test/resources/vgs_tests/nts/test_default_nts.star
@@ -116,6 +116,23 @@ def _test_render_with_dcvv():
     asserts.assert_that(output["paymentMethod"]["cvv"]).is_equal_to("MOCK_DYNAMIC_CVV")
 
 
+def _test_render_without_cvv_json_path():
+    output = nts.render(
+        _make_fixture(),
+        pan="$.paymentMethod.number",
+        amount="$.amount.value",
+        currency_code="$.amount.currency",
+        exp_month="$.paymentMethod.expiryMonth",
+        exp_year="$.paymentMethod.expiryYear",
+        cryptogram_value="$.mpiData.cavv",
+        cryptogram_eci="$.mpiData.eci",
+    )
+    asserts.assert_that(output["paymentMethod"]["number"]).is_equal_to("4242424242424242")
+    asserts.assert_that(output["paymentMethod"]["expiryMonth"]).is_equal_to(12)
+    asserts.assert_that(output["paymentMethod"]["expiryYear"]).is_equal_to(27)
+    asserts.assert_that(output["mpiData"]["eci"]).is_equal_to("MOCK_CRYPTOGRAM_ECI")
+
+
 def _test_render_without_cvv_value():
     input = _make_fixture()
     input["paymentMethod"].pop("cvv")
@@ -243,6 +260,7 @@ def _suite():
     _suite.addTest(unittest.FunctionTestCase(_test_render))
     _suite.addTest(unittest.FunctionTestCase(_test_render_without_cvv_value))
     _suite.addTest(unittest.FunctionTestCase(_test_render_with_dcvv))
+    _suite.addTest(unittest.FunctionTestCase(_test_render_without_cvv_json_path))
     _suite.addTest(unittest.FunctionTestCase(_test_render_pan_empty_value))
     _suite.addTest(unittest.FunctionTestCase(_test_render_not_found))
     _suite.addTest(unittest.FunctionTestCase(_test_render_with_both_cvv_and_dcvv))

--- a/larky/src/test/resources/vgs_tests/nts/test_default_nts.star
+++ b/larky/src/test/resources/vgs_tests/nts/test_default_nts.star
@@ -116,6 +116,19 @@ def _test_render_with_dcvv():
     asserts.assert_that(output["paymentMethod"]["cvv"]).is_equal_to("MOCK_DYNAMIC_CVV")
 
 
+def _test_render_without_cvv_value():
+    input = _make_fixture()
+    input["paymentMethod"].pop("cvv")
+    output = nts.render(
+        input,
+        pan="$.paymentMethod.number",
+        cvv="$.paymentMethod.cvv",
+        amount="$.amount.value",
+        currency_code="$.amount.currency",
+    )
+    asserts.assert_that("cvv" in output["paymentMethod"]).is_false()
+
+
 def _test_render_pan_empty_value():
     asserts.assert_fails(
         lambda: nts.render(
@@ -227,6 +240,7 @@ def _suite():
     _suite.addTest(unittest.FunctionTestCase(_test_get_network_token_not_found))
     # Render tests
     _suite.addTest(unittest.FunctionTestCase(_test_render))
+    _suite.addTest(unittest.FunctionTestCase(_test_render_without_cvv_value))
     _suite.addTest(unittest.FunctionTestCase(_test_render_with_dcvv))
     _suite.addTest(unittest.FunctionTestCase(_test_render_pan_empty_value))
     _suite.addTest(unittest.FunctionTestCase(_test_render_not_found))


### PR DESCRIPTION
## Fixes [PAYOP-1489](https://verygoodsecurity.atlassian.net/browse/PAYOP-1489)

## Description of changes in release / Impact of release:
Make cvv optional for network token render

## Documentation
(insert text here)

## Risks of this release

### Is this a breaking change?
- [ ] Yes
- [x] No

### If you answered Yes then describe why is it so
(insert text here if applicable)

### Is there a way to disable the change?
- [ ] Use previous release
- [ ] Use a feature flag
- [x] No

#### Additional details go here
(insert text here if applicable)


[PAYOP-1489]: https://verygoodsecurity.atlassian.net/browse/PAYOP-1489?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ