### PR TITLE
fix the docker build process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,25 +4,27 @@ WORKDIR /build/
 ENV PYENV_ROOT="/root/.pyenv"
 ENV PATH="/root/.poetry/bin:$PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH"
 
-# java
 RUN apt-get update -qq \
+    && JVM_ARCH=$([ `lscpu | grep -o "aarch64"` ] && echo "arm64" || echo "amd64") \
+    && GRAALVM_ARCH=$([ `lscpu | grep -o "aarch64"` ] && echo "aarch64" || echo "amd64") \
+    # java
     && apt-get install -y curl openjdk-11-jdk maven \
-    && update-alternatives --set java /usr/lib/jvm/java-11-openjdk-amd64/bin/java \
-    && update-alternatives --set javac /usr/lib/jvm/java-11-openjdk-amd64/bin/javac \
+    && update-alternatives --set java /usr/lib/jvm/java-11-openjdk-${JVM_ARCH}/bin/java \
+    && update-alternatives --set javac /usr/lib/jvm/java-11-openjdk-${JVM_ARCH}/bin/javac \
     # ghr
     && apt-get install golang git -y \
-    && go get -u github.com/tcnksm/ghr \
+    && go install github.com/tcnksm/ghr@latest \
     # graalvm
-    && curl https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-21.1.0/graalvm-ce-java11-linux-amd64-21.1.0.tar.gz -O -J -L \
-    && tar xfz graalvm-ce-java11-linux-amd64-21.1.0.tar.gz \
+    && curl https://github.com/graalvm/graalvm-ce-builds/releases/download/vm-21.1.0/graalvm-ce-java11-linux-${GRAALVM_ARCH}-21.1.0.tar.gz -O -J -L \
+    && tar xfz graalvm-ce-java11-linux-${GRAALVM_ARCH}-21.1.0.tar.gz \
     && mv graalvm-ce-java11-21.1.0 .graalvm \
-    && rm graalvm-ce-java11-linux-amd64-21.1.0.tar.gz \
+    && rm graalvm-ce-java11-linux-${GRAALVM_ARCH}-21.1.0.tar.gz \
     && /build/.graalvm/bin/gu install native-image \
     # python
     && git clone https://github.com/pyenv/pyenv.git ~/.pyenv \
     && apt-get install -y gcc libbz2-dev libsqlite3-dev libssl-dev make zlib1g-dev libffi-dev \
     && ~/.pyenv/bin/pyenv install 3.8.6 \
     && ~/.pyenv/bin/pyenv local 3.8.6 \
-    && curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -
+    && curl -sSL https://install.python-poetry.org | python3 -
 
 WORKDIR /src


### PR DESCRIPTION
## Description of changes in release / Impact of release:
- detect the cpu architecture in order to build on M1 macs
- use `go install` since `go get` has been deprecated
- update poetry install process since `get-poetry.py` has been deprecated

## Documentation
- [`go get` deprecation](https://go.dev/doc/go-get-install-deprecation)
- [`get-poetry.py` deprecation](https://python-poetry.org/blog/announcing-poetry-1.2.0/)

## Risks of this release
- potential incompatibility with updated software (unlikely)

### Is this a breaking change?
- [ ] Yes
- [x] No

### Is there a way to disable the change?
- [ ] Use previous release
- [ ] Use a feature flag
- [x] No
