### PR TITLE
add standard library files to the runlarky project

### DIFF
--- a/runlarky/pom.xml
+++ b/runlarky/pom.xml
@@ -111,6 +111,9 @@
             <resource>
                 <directory>src/test/resources</directory>
             </resource>
+            <resource>
+                <directory>../larky/src/main/resources</directory>
+            </resource>
         </resources>
         <pluginManagement>
             <plugins>
@@ -212,6 +215,7 @@
                                 <buildArg>
                                     -H:ResourceConfigurationFiles=../src/main/resources/META-INF/native-image/resource-config.json
                                 </buildArg>
+                                <buildArg>-H:IncludeResources=".*$"</buildArg>
                             </buildArgs>
                         </configuration>
                     </plugin>


### PR DESCRIPTION
## Description of changes in release / Impact of release:
- add the stdlib files to the local runner
- bundle java resources with the native-image builder

## Risks of this release

### Is this a breaking change?
- [ ] Yes
- [x] No

### Is there a way to disable the change?
- [ ] Use previous release
- [ ] Use a feature flag
- [x] No
