### PR TITLE
CSL3-1858 Expand Loop Emulation to 16K to support large XML files

### DIFF
--- a/larky/src/main/resources/stdlib/larky.star
+++ b/larky/src/main/resources/stdlib/larky.star
@@ -23,8 +23,8 @@ def _to_dict(s):
     return {key: getattr(s, key) for key in attributes}
 
 
-# emulates while loop but will iterate *only* for 4096 steps.
-WHILE_LOOP_EMULATION_ITERATION = 4096
+# emulates while loop but will iterate *only* for 16384 steps.
+WHILE_LOOP_EMULATION_ITERATION = 16384
 
 _SENTINEL = _sentinel()
 

--- a/larky/src/main/resources/stdlib/re.star
+++ b/larky/src/main/resources/stdlib/re.star
@@ -34,7 +34,7 @@ load("@stdlib//enum", "enum")
 load("@stdlib//re2j", _re2j="re2j")
 
 
-_WHILE_LOOP_EMULATION_ITERATION = 1000
+_WHILE_LOOP_EMULATION_ITERATION = 16384
 
 __ = -1  # Alias for the invalid class
 RegexFlags = enum.enumify_iterable(iterable=[


### PR DESCRIPTION
## Fixes CSL3-1858

## Description of changes in release / Impact of release:
Expand Loop Emulation to 16K to support large XML files

This should be considered a temp fix until we figure out how to prevent endless loops vs loops over a large amount of data.


## Documentation
(insert text here)

## Risks of this release

### Is this a breaking change?
- [ ] Yes
- [ ] No

### If you answered Yes then describe why is it so
(insert text here if applicable)

### Is there a way to disable the change?
- [ ] Use previous release
- [ ] Use a feature flag
- [ ] No

#### Additional details go here
(insert text here if applicable)
