### PR TITLE
Get NT for a merchant 

### DIFF
--- a/larky/src/main/java/com/verygood/security/larky/modules/NetworkTokenModule.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/NetworkTokenModule.java
@@ -86,6 +86,12 @@ public class NetworkTokenModule implements LarkyNetworkToken {
             doc = "Type of cryptogram to get for the network token",
             defaultValue = "'TAVV'",
             allowedTypes = {@ParamType(type = String.class)}),
+        @Param(
+            name = "merchant_id",
+            named = true,
+            doc = "Merchant id to get a network token for",
+            defaultValue = "''",
+            allowedTypes = {@ParamType(type = String.class)}),
       })
   @Override
   public Dict<String, Object> getNetworkToken(
@@ -94,6 +100,7 @@ public class NetworkTokenModule implements LarkyNetworkToken {
       String amount,
       String currencyCode,
       String cryptogramType,
+      String merchantId,
       StarlarkThread thread)
       throws EvalException {
     if (pan.trim().isEmpty()) {
@@ -102,7 +109,7 @@ public class NetworkTokenModule implements LarkyNetworkToken {
     final Optional<NetworkTokenService.NetworkToken> networkTokenOptional;
     try {
       networkTokenOptional =
-          networkTokenService.getNetworkToken(pan, cvv, amount, currencyCode, cryptogramType);
+          networkTokenService.getNetworkToken(pan, cvv, amount, currencyCode, cryptogramType, merchantId);
     } catch (UnsupportedOperationException exception) {
       throw Starlark.errorf("nts.get_network_token operation must be overridden");
     }

--- a/larky/src/main/java/com/verygood/security/larky/modules/vgs/nts/LarkyNetworkToken.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/vgs/nts/LarkyNetworkToken.java
@@ -23,6 +23,7 @@ public interface LarkyNetworkToken extends StarlarkValue {
       String amount,
       String currencyCode,
       String cryptogramType,
+      String merchantId,
       StarlarkThread thread)
       throws EvalException;
 }

--- a/larky/src/main/java/com/verygood/security/larky/modules/vgs/nts/MockNetworkTokenService.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/vgs/nts/MockNetworkTokenService.java
@@ -1,24 +1,58 @@
 package com.verygood.security.larky.modules.vgs.nts;
 
+import com.google.common.collect.ImmutableMap;
 import com.verygood.security.larky.modules.vgs.nts.spi.NetworkTokenService;
+import java.util.Map;
 import java.util.Optional;
+import org.apache.commons.lang3.StringUtils;
 
 public class MockNetworkTokenService implements NetworkTokenService {
+  
+  private static final String DEFAULT_MERCHANT_ID = "MC8SWErAVLuooPFYz9WTx5W1";
+
+  private static final Map<String, NetworkToken.NetworkTokenBuilder> NETWORK_TOKENS = ImmutableMap.of(
+      "MCdAhTydCJMZEzxgqhvVdkgo", NetworkToken.builder()
+          .token("4111111111111111")
+          .expireMonth(10)
+          .expireYear(27)
+          .cryptogramEci("MOCK_CRYPTOGRAM_ECI"),
+      DEFAULT_MERCHANT_ID, NetworkToken.builder()
+          .token("4242424242424242")
+          .expireMonth(12)
+          .expireYear(27)
+          .cryptogramEci("MOCK_CRYPTOGRAM_ECI")
+  );
+
   @Override
   public Optional<NetworkToken> getNetworkToken(
-      String panAlias, String cvv, String amount, String currencyCode, String cryptogramType) {
+      String panAlias, String cvv, String amount, String currencyCode, String cryptogramType,
+      String merchantId) {
     if (panAlias.equals("NOT_FOUND")) {
       return Optional.empty();
     }
-    return Optional.of(
-        NetworkToken.builder()
-            .token("4242424242424242")
-            .expireMonth(12)
-            .expireYear(27)
+    if (StringUtils.isBlank(merchantId)) {
+      return Optional.of(
+          getForDefaultMerchant(cryptogramType)
+      ); 
+    }
+    if (!NETWORK_TOKENS.containsKey(merchantId)) {
+      return Optional.empty(); 
+    }
+    final NetworkToken networkToken =
+        NETWORK_TOKENS.get(merchantId)
             .cryptogramValue(
                 cryptogramType.equals("DTVV") ? "MOCK_DYNAMIC_CVV" : "MOCK_CRYPTOGRAM_VALUE")
-            .cryptogramEci("MOCK_CRYPTOGRAM_ECI")
             .cryptogramType(cryptogramType)
-            .build());
+            .build();
+
+    return Optional.of(networkToken);
   }
+  
+  private NetworkToken getForDefaultMerchant(String cryptogramType) {
+    return NETWORK_TOKENS.get(DEFAULT_MERCHANT_ID)
+        .cryptogramValue(
+            cryptogramType.equals("DTVV") ? "MOCK_DYNAMIC_CVV" : "MOCK_CRYPTOGRAM_VALUE")
+        .cryptogramType(cryptogramType)
+        .build();
+  } 
 }

--- a/larky/src/main/java/com/verygood/security/larky/modules/vgs/nts/NoopNetworkTokenService.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/vgs/nts/NoopNetworkTokenService.java
@@ -6,7 +6,7 @@ import java.util.Optional;
 public class NoopNetworkTokenService implements NetworkTokenService {
   @Override
   public Optional<NetworkToken> getNetworkToken(
-      String panAlias, String cvv, String amount, String currencyCode, String cryptogramType) {
+      String panAlias, String cvv, String amount, String currencyCode, String cryptogramType, String merchantId) {
     throw new UnsupportedOperationException("Not implemented");
   }
 }

--- a/larky/src/main/java/com/verygood/security/larky/modules/vgs/nts/spi/NetworkTokenService.java
+++ b/larky/src/main/java/com/verygood/security/larky/modules/vgs/nts/spi/NetworkTokenService.java
@@ -16,7 +16,7 @@ public interface NetworkTokenService {
    * @return the network token value
    */
   Optional<NetworkToken> getNetworkToken(
-      String panAlias, String cvv, String amount, String currencyCode, String cryptogramType);
+      String panAlias, String cvv, String amount, String currencyCode, String cryptogramType, String merchantId);
 
   @Data
   @Builder

--- a/larky/src/main/resources/vgs/nts.star
+++ b/larky/src/main/resources/vgs/nts.star
@@ -34,6 +34,7 @@ def render(
     exp_year=None,
     cryptogram_value=None,
     cryptogram_eci=None,
+    merchant_id=None,
 ):
     """Retrieves a network token for the given PAN alias, renders the cryptogram, and injects the network token values
     into the payload.
@@ -72,11 +73,20 @@ def render(
     :param cryptogram_value: JSONPath to insert the cryptogram value of the network token within the input
            payload
     :param cryptogram_eci: JSONPath to insert the cryptogram ECI of the network token within the input payload
+    :param merchant_id: Merchant id to get a network token for
     :return: JSON payload injected with network token values
     """
     pan_value = jsonpath_ng.parse(pan).find(input).value
     amount_value = str(jsonpath_ng.parse(amount).find(input).value)
     currency_code_value = jsonpath_ng.parse(currency_code).find(input).value
+    
+    merchant_id_value = ""
+    merchant_id_result = None
+    if merchant_id != None:
+        merchant_id_result = jsonpath_ng.parse(merchant_id).find(input, error_safe=True)
+    if merchant_id_result != None and merchant_id_result.is_ok:
+        merchant_id_value = merchant_id_result.unwrap()
+      
     cvv_result = None
     if cvv != None and dcvv == None:
         cvv_result = jsonpath_ng.parse(cvv).find(input, error_safe=True)
@@ -94,6 +104,7 @@ def render(
         amount=amount_value,
         currency_code=currency_code_value,
         cryptogram_type="TAVV" if dcvv == None else "DTVV",
+        merchant_id=merchant_id_value,
     )
     placements = [
         (pan, network_token["token"]),

--- a/larky/src/main/resources/vgs/nts.star
+++ b/larky/src/main/resources/vgs/nts.star
@@ -82,7 +82,6 @@ def render(
     
     merchant_id_value = ""
     merchant_id_result = None
-
     if merchant_id != None:
         merchant_id_result = jsonpath_ng.parse(merchant_id).find(input, error_safe=True)
     if merchant_id_result != None and merchant_id_result.is_ok:

--- a/larky/src/main/resources/vgs/nts.star
+++ b/larky/src/main/resources/vgs/nts.star
@@ -82,6 +82,7 @@ def render(
     
     merchant_id_value = ""
     merchant_id_result = None
+
     if merchant_id != None:
         merchant_id_result = jsonpath_ng.parse(merchant_id).find(input, error_safe=True)
     if merchant_id_result != None and merchant_id_result.is_ok:

--- a/larky/src/main/resources/vgs/nts.star
+++ b/larky/src/main/resources/vgs/nts.star
@@ -80,6 +80,7 @@ def render(
     amount_value = str(jsonpath_ng.parse(amount).find(input).value)
     currency_code_value = jsonpath_ng.parse(currency_code).find(input).value 
     cvv_result = None
+    
     if cvv != None and dcvv == None:
         cvv_result = jsonpath_ng.parse(cvv).find(input, error_safe=True)
     elif dcvv != None and cvv == None:

--- a/larky/src/main/resources/vgs/nts.star
+++ b/larky/src/main/resources/vgs/nts.star
@@ -78,8 +78,7 @@ def render(
     """
     pan_value = jsonpath_ng.parse(pan).find(input).value
     amount_value = str(jsonpath_ng.parse(amount).find(input).value)
-    currency_code_value = jsonpath_ng.parse(currency_code).find(input).value
-      
+    currency_code_value = jsonpath_ng.parse(currency_code).find(input).value 
     cvv_result = None
     if cvv != None and dcvv == None:
         cvv_result = jsonpath_ng.parse(cvv).find(input, error_safe=True)

--- a/larky/src/main/resources/vgs/nts.star
+++ b/larky/src/main/resources/vgs/nts.star
@@ -78,9 +78,8 @@ def render(
     """
     pan_value = jsonpath_ng.parse(pan).find(input).value
     amount_value = str(jsonpath_ng.parse(amount).find(input).value)
-    currency_code_value = jsonpath_ng.parse(currency_code).find(input).value 
+    currency_code_value = jsonpath_ng.parse(currency_code).find(input).value
     cvv_result = None
-    
     if cvv != None and dcvv == None:
         cvv_result = jsonpath_ng.parse(cvv).find(input, error_safe=True)
     elif dcvv != None and cvv == None:

--- a/larky/src/main/resources/vgs/nts.star
+++ b/larky/src/main/resources/vgs/nts.star
@@ -34,7 +34,7 @@ def render(
     exp_year=None,
     cryptogram_value=None,
     cryptogram_eci=None,
-    merchant_id=None,
+    merchant_id='',
 ):
     """Retrieves a network token for the given PAN alias, renders the cryptogram, and injects the network token values
     into the payload.
@@ -79,13 +79,6 @@ def render(
     pan_value = jsonpath_ng.parse(pan).find(input).value
     amount_value = str(jsonpath_ng.parse(amount).find(input).value)
     currency_code_value = jsonpath_ng.parse(currency_code).find(input).value
-    
-    merchant_id_value = ""
-    merchant_id_result = None
-    if merchant_id != None:
-        merchant_id_result = jsonpath_ng.parse(merchant_id).find(input, error_safe=True)
-    if merchant_id_result != None and merchant_id_result.is_ok:
-        merchant_id_value = merchant_id_result.unwrap()
       
     cvv_result = None
     if cvv != None and dcvv == None:
@@ -104,7 +97,7 @@ def render(
         amount=amount_value,
         currency_code=currency_code_value,
         cryptogram_type="TAVV" if dcvv == None else "DTVV",
-        merchant_id=merchant_id_value,
+        merchant_id=merchant_id,
     )
     placements = [
         (pan, network_token["token"]),

--- a/larky/src/test/resources/vgs_tests/nts/test_default_nts.star
+++ b/larky/src/test/resources/vgs_tests/nts/test_default_nts.star
@@ -32,8 +32,7 @@ def _make_fixture():
         "mpiData": {
             "cavv": "TO_BE_REPLACED",
             "eci": "TO_BE_REPLACED",
-        },
-        "merchant_id": "MCdAhTydCJMZEzxgqhvVdkgo"
+        }
     }
 
 
@@ -134,7 +133,7 @@ def _test_render_for_merchant():
         exp_year="$.paymentMethod.expiryYear",
         cryptogram_value="$.mpiData.cavv",
         cryptogram_eci="$.mpiData.eci",
-        merchant_id="$.merchant_id",
+        merchant_id="MCdAhTydCJMZEzxgqhvVdkgo",
     )
     asserts.assert_that(output["paymentMethod"]["number"]).is_equal_to("4111111111111111")
     asserts.assert_that(output["paymentMethod"]["expiryMonth"]).is_equal_to(10)
@@ -144,23 +143,21 @@ def _test_render_for_merchant():
 
 
 def _test_render_for_merchant_not_found():
-    output = nts.render(
-        _make_fixture(),
-        pan="$.paymentMethod.number",
-        cvv="$.paymentMethod.cvv",
-        amount="$.amount.value",
-        currency_code="$.amount.currency",
-        exp_month="$.paymentMethod.expiryMonth",
-        exp_year="$.paymentMethod.expiryYear",
-        cryptogram_value="$.mpiData.cavv",
-        cryptogram_eci="$.mpiData.eci",
-        merchant_id="$.merchant_id_not_found",
+    asserts.assert_fails(
+        lambda: nts.render(
+            _make_fixture(),
+            pan="$.paymentMethod.number",
+            cvv="$.paymentMethod.cvv",
+            amount="$.amount.value",
+            currency_code="$.amount.currency",
+            exp_month="$.paymentMethod.expiryMonth",
+            exp_year="$.paymentMethod.expiryYear",
+            cryptogram_value="$.mpiData.cavv",
+            cryptogram_eci="$.mpiData.eci",
+            merchant_id="merchant_id_not_found",
+        ),
+        "network token is not found",
     )
-    asserts.assert_that(output["paymentMethod"]["number"]).is_equal_to("4242424242424242")
-    asserts.assert_that(output["paymentMethod"]["expiryMonth"]).is_equal_to(12)
-    asserts.assert_that(output["paymentMethod"]["expiryYear"]).is_equal_to(27)
-    asserts.assert_that(output["mpiData"]["cavv"]).is_equal_to("MOCK_CRYPTOGRAM_VALUE")
-    asserts.assert_that(output["mpiData"]["eci"]).is_equal_to("MOCK_CRYPTOGRAM_ECI")
 
 
 def _test_render_with_nested_safe():

--- a/larky/src/test/resources/vgs_tests/nts/test_default_nts.star
+++ b/larky/src/test/resources/vgs_tests/nts/test_default_nts.star
@@ -32,7 +32,8 @@ def _make_fixture():
         "mpiData": {
             "cavv": "TO_BE_REPLACED",
             "eci": "TO_BE_REPLACED",
-        }
+        },
+        "merchant_id": "MCdAhTydCJMZEzxgqhvVdkgo"
     }
 
 
@@ -46,6 +47,24 @@ def _test_get_network_token():
     asserts.assert_that(output).is_equal_to({
         "token": "4242424242424242",
         "exp_month": 12,
+        "exp_year": 27,
+        "cryptogram_value": "MOCK_CRYPTOGRAM_VALUE",
+        "cryptogram_eci": "MOCK_CRYPTOGRAM_ECI",
+        "cryptogram_type": "TAVV"
+    })
+
+
+def _test_get_network_token_for_merchant():
+    output = nts.get_network_token(
+        pan="MOCK_PAN_ALIAS",
+        cvv="MOCK_CVV",
+        amount="123.45",
+        currency_code="USD",
+        merchant_id="MCdAhTydCJMZEzxgqhvVdkgo",
+    )
+    asserts.assert_that(output).is_equal_to({
+        "token": "4111111111111111",
+        "exp_month": 10,
         "exp_year": 27,
         "cryptogram_value": "MOCK_CRYPTOGRAM_VALUE",
         "cryptogram_eci": "MOCK_CRYPTOGRAM_ECI",
@@ -96,6 +115,46 @@ def _test_render():
         exp_year="$.paymentMethod.expiryYear",
         cryptogram_value="$.mpiData.cavv",
         cryptogram_eci="$.mpiData.eci",
+    )
+    asserts.assert_that(output["paymentMethod"]["number"]).is_equal_to("4242424242424242")
+    asserts.assert_that(output["paymentMethod"]["expiryMonth"]).is_equal_to(12)
+    asserts.assert_that(output["paymentMethod"]["expiryYear"]).is_equal_to(27)
+    asserts.assert_that(output["mpiData"]["cavv"]).is_equal_to("MOCK_CRYPTOGRAM_VALUE")
+    asserts.assert_that(output["mpiData"]["eci"]).is_equal_to("MOCK_CRYPTOGRAM_ECI")
+
+
+def _test_render_for_merchant():
+    output = nts.render(
+        _make_fixture(),
+        pan="$.paymentMethod.number",
+        cvv="$.paymentMethod.cvv",
+        amount="$.amount.value",
+        currency_code="$.amount.currency",
+        exp_month="$.paymentMethod.expiryMonth",
+        exp_year="$.paymentMethod.expiryYear",
+        cryptogram_value="$.mpiData.cavv",
+        cryptogram_eci="$.mpiData.eci",
+        merchant_id="$.merchant_id",
+    )
+    asserts.assert_that(output["paymentMethod"]["number"]).is_equal_to("4111111111111111")
+    asserts.assert_that(output["paymentMethod"]["expiryMonth"]).is_equal_to(10)
+    asserts.assert_that(output["paymentMethod"]["expiryYear"]).is_equal_to(27)
+    asserts.assert_that(output["mpiData"]["cavv"]).is_equal_to("MOCK_CRYPTOGRAM_VALUE")
+    asserts.assert_that(output["mpiData"]["eci"]).is_equal_to("MOCK_CRYPTOGRAM_ECI")
+
+
+def _test_render_for_merchant_not_found():
+    output = nts.render(
+        _make_fixture(),
+        pan="$.paymentMethod.number",
+        cvv="$.paymentMethod.cvv",
+        amount="$.amount.value",
+        currency_code="$.amount.currency",
+        exp_month="$.paymentMethod.expiryMonth",
+        exp_year="$.paymentMethod.expiryYear",
+        cryptogram_value="$.mpiData.cavv",
+        cryptogram_eci="$.mpiData.eci",
+        merchant_id="$.merchant_id_not_found",
     )
     asserts.assert_that(output["paymentMethod"]["number"]).is_equal_to("4242424242424242")
     asserts.assert_that(output["paymentMethod"]["expiryMonth"]).is_equal_to(12)
@@ -270,11 +329,14 @@ def _suite():
 
     # Get network token tests
     _suite.addTest(unittest.FunctionTestCase(_test_get_network_token))
+    _suite.addTest(unittest.FunctionTestCase(_test_get_network_token_for_merchant))
     _suite.addTest(unittest.FunctionTestCase(_test_get_network_token_with_dtvv_type))
     _suite.addTest(unittest.FunctionTestCase(_test_get_network_token_pan_empty_value))
     _suite.addTest(unittest.FunctionTestCase(_test_get_network_token_not_found))
     # Render tests
     _suite.addTest(unittest.FunctionTestCase(_test_render))
+    _suite.addTest(unittest.FunctionTestCase(_test_render_for_merchant))
+    _suite.addTest(unittest.FunctionTestCase(_test_render_for_merchant_not_found))
     _suite.addTest(unittest.FunctionTestCase(_test_render_with_nested_safe))
     _suite.addTest(unittest.FunctionTestCase(_test_render_without_cvv_value))
     _suite.addTest(unittest.FunctionTestCase(_test_render_with_dcvv))


### PR DESCRIPTION
## Fixes [PAYMTS-1790](https://verygoodsecurity.atlassian.net/browse/PAYMTS-1790)

## Description of changes in release / Impact of release:
We need a way to select a NT by a merchant id if there are multiple NTs for a simple card alias


## Risks of this release

### Is this a breaking change?
- [] Yes
- [X] No

### If you answered Yes then describe why is it so
(insert text here if applicable)

### Is there a way to disable the change?
- [ ] Use previous release
- [ ] Use a feature flag
- [ ] No

#### Additional details go here
(insert text here if applicable)


[PAYMTS-1790]: https://verygoodsecurity.atlassian.net/browse/PAYMTS-1790?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ