### PR TITLE
Upgrade to Truth 1.4.2.

### DIFF
--- a/larky/pom.xml
+++ b/larky/pom.xml
@@ -42,7 +42,7 @@
         <google.guava.version>31.1-jre</google.guava.version>
         <google.jimfs.version>1.3.0</google.jimfs.version>
         <google.re2j.version>1.7</google.re2j.version>
-        <google.truth.version>1.4.1</google.truth.version>
+        <google.truth.version>1.4.2</google.truth.version>
         <javax.xml.bind.jaxb-api.version>2.3.1</javax.xml.bind.jaxb-api.version>
         <org.bouncycastle.version>1.77</org.bouncycastle.version>
         <org.conscrypt.version>2.5.2</org.conscrypt.version>
@@ -171,12 +171,6 @@
         <dependency>
             <groupId>com.google.truth</groupId>
             <artifactId>truth</artifactId>
-            <version>${google.truth.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.google.truth.extensions</groupId>
-            <artifactId>truth-java8-extension</artifactId>
             <version>${google.truth.version}</version>
             <scope>test</scope>
         </dependency>

--- a/libstarlark/pom.xml
+++ b/libstarlark/pom.xml
@@ -29,7 +29,7 @@
         <google.flogger.version>0.8</google.flogger.version>
         <google.guava.version>33.0.0-jre</google.guava.version>
         <google.jimfs.version>1.3.0</google.jimfs.version>
-        <google.truth.version>1.4.1</google.truth.version>
+        <google.truth.version>1.4.2</google.truth.version>
         <org.jetbrains.annotations.version>24.1.0</org.jetbrains.annotations.version>
         <org.junit.version>4.13.2</org.junit.version>
         <org.projectlombok.version>1.18.30</org.projectlombok.version>
@@ -98,12 +98,6 @@
         <dependency>
             <groupId>com.google.truth</groupId>
             <artifactId>truth</artifactId>
-            <version>${google.truth.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>com.google.truth.extensions</groupId>
-            <artifactId>truth-java8-extension</artifactId>
             <version>${google.truth.version}</version>
             <scope>test</scope>
         </dependency>

--- a/libstarlark/src/test/java/net/starlark/java/eval/StarlarkEvaluationTest.java
+++ b/libstarlark/src/test/java/net/starlark/java/eval/StarlarkEvaluationTest.java
@@ -14,7 +14,6 @@
 package net.starlark.java.eval;
 
 import static com.google.common.truth.Truth.assertThat;
-import static com.google.common.truth.Truth8.assertThat;
 import static java.util.Arrays.stream;
 import static java.util.stream.Collectors.joining;
 import static org.junit.Assert.assertThrows;


### PR DESCRIPTION
This requires one code change to address [a newly ambiguous
call](https://github.com/google/truth/releases/tag/v1.4.2).

It's also a good opportunity to remove the dep on
`truth-java8-extension`, which has been unnecessary since
[1.3.0](https://github.com/google/truth/releases/tag/v1.3.0) moves its
classes into the main Truth artifact.
