### PR TITLE
[PAYMTS-1960] Add is_mastercard_push_account_receipt helper

### DIFF
--- a/larky/src/main/resources/vgs/nts.star
+++ b/larky/src/main/resources/vgs/nts.star
@@ -25,7 +25,7 @@ CRYPTOGRAM_SUPPORTING_PSP_TYPES = {
 }
 PUSH_ACCOUNT_RECEIPT_PAYLOAD_KEY = "push_account_receipt"
 PUSH_ACCOUNT_DATA_PAYLOAD_KEY = "push_account_data"
-
+MASTERCARD_PUSH_ACCOUNT_RECEIPT_PREFIX = "MCC-STL-"
 
 def render(
     input,
@@ -209,6 +209,16 @@ def extract_push_account_receipt(body):
     return push_account_receipts[index]
 
 
+def is_mastercard_push_account_receipt(pan_alias):
+    """Helper for determining whether is the given pan_alias is actually a Mastercard Token Connect
+    PushAccountReceipt.
+
+    :param pan_alias: pan_alias value to check
+    :return: True if the pan_alias revealed value looks like a Mastercard Token Connect PushAccountReceipt value
+    """
+    return vault.reveal(pan_alias).startswith(MASTERCARD_PUSH_ACCOUNT_RECEIPT_PREFIX)
+
+
 nts = larky.struct(
     PSPType=PSPType,
     get_network_token=_nts.get_network_token,
@@ -219,4 +229,5 @@ nts = larky.struct(
     use_network_token=use_network_token,
     is_token_connect_enrollment=is_token_connect_enrollment,
     extract_push_account_receipt=extract_push_account_receipt,
+    is_mastercard_push_account_receipt=is_mastercard_push_account_receipt,
 )

--- a/larky/src/test/resources/vgs_tests/nts/test_default_nts.star
+++ b/larky/src/test/resources/vgs_tests/nts/test_default_nts.star
@@ -422,6 +422,20 @@ def _test_extract_push_account_receipt():
         })
     ).is_none()
 
+
+def _test_is_mastercard_push_account_receipt():
+    for pan, result in [
+        ("4111111111111111", False),
+        ("5555555555554444", False),
+        ("Other", False),
+        ("MCC-STL-471E0AD8-E233-492D-8FFE-06283CBD5018", True),
+    ]:
+        pan_alias = vault.redact(pan)
+        asserts.assert_that(
+            nts.is_mastercard_push_account_receipt(pan_alias)
+        ).is_equal_to(result)
+
+
 def _suite():
     _suite = unittest.TestSuite()
 
@@ -456,6 +470,8 @@ def _suite():
     # Token connect helper tests
     _suite.addTest(unittest.FunctionTestCase(_test_is_token_connect_enrollment))
     _suite.addTest(unittest.FunctionTestCase(_test_extract_push_account_receipt))
+    # is_mastercard_push_account_receipt tests
+    _suite.addTest(unittest.FunctionTestCase(_test_is_mastercard_push_account_receipt))
     return _suite
 
 


### PR DESCRIPTION
## Fixes [PAYMTS-1960](https://verygoodsecurity.atlassian.net/browse/PAYMTS-1960)

## Description of changes in release / Impact of release:
Add is_mastercard_push_account_receipt helper

## Documentation
Add is_mastercard_push_account_receipt helper

## Risks of this release

### Is this a breaking change?
- [ ] Yes
- [x] No

### If you answered Yes then describe why is it so
(insert text here if applicable)

### Is there a way to disable the change?
- [ ] Use previous release
- [ ] Use a feature flag
- [ ] No

#### Additional details go here
(insert text here if applicable)
