### PR TITLE
[PAYMTS-1960] Consider all other push account receipts helper method

### DIFF
--- a/larky/src/main/resources/vgs/nts.star
+++ b/larky/src/main/resources/vgs/nts.star
@@ -25,6 +25,30 @@ CRYPTOGRAM_SUPPORTING_PSP_TYPES = {
 }
 PUSH_ACCOUNT_RECEIPT_PAYLOAD_KEY = "push_account_receipt"
 PUSH_ACCOUNT_DATA_PAYLOAD_KEY = "push_account_data"
+# This is for matching Token Connect PushAccountReceipt value from Mastercard.
+# An example push account receipt looks like this:
+#
+#   MCC-STL-3BD6C1C3-9E36-41F1-AB2F-67911E5BF197
+#
+# According to Mastercard, the current possible prefix could be:
+#
+#  - MCC: Mastercard Credit
+#  - DMC: Mastercard Debit
+#  - MSI: Maestro
+#  - PVL: Privote Label
+#
+# And the second part after first dash could be
+#
+#  - STL (St. Louis)
+#  - KSC (Kansas City)
+#
+# Some examples of possible combination could be found in `test_default_nts.star`
+# testing file.
+#
+# Please note that Mastercard told us not to rely on these formats because it's
+# subject to change in the future. But because we don't have much time to find
+# a better way distinguish alias for between PAN and push account receipt for now,
+# this is still a reliable solution for now before it changes.
 MASTERCARD_PUSH_ACCOUNT_RECEIPT_REGEX = re.compile(r'^(.+)-[A-Z]{3}-(.+)$')
 
 def render(

--- a/larky/src/main/resources/vgs/nts.star
+++ b/larky/src/main/resources/vgs/nts.star
@@ -25,7 +25,7 @@ CRYPTOGRAM_SUPPORTING_PSP_TYPES = {
 }
 PUSH_ACCOUNT_RECEIPT_PAYLOAD_KEY = "push_account_receipt"
 PUSH_ACCOUNT_DATA_PAYLOAD_KEY = "push_account_data"
-MASTERCARD_PUSH_ACCOUNT_RECEIPT_PREFIX = "MCC-STL-"
+MASTERCARD_PUSH_ACCOUNT_RECEIPT_REGEX = re.compile(r'^(.+)-[A-Z]{3}-(.+)$')
 
 def render(
     input,
@@ -216,7 +216,7 @@ def is_mastercard_push_account_receipt(pan_alias):
     :param pan_alias: pan_alias value to check
     :return: True if the pan_alias revealed value looks like a Mastercard Token Connect PushAccountReceipt value
     """
-    return vault.reveal(pan_alias).startswith(MASTERCARD_PUSH_ACCOUNT_RECEIPT_PREFIX)
+    return MASTERCARD_PUSH_ACCOUNT_RECEIPT_REGEX.match(vault.reveal(pan_alias)) != None
 
 
 nts = larky.struct(

--- a/larky/src/test/resources/vgs_tests/nts/test_default_nts.star
+++ b/larky/src/test/resources/vgs_tests/nts/test_default_nts.star
@@ -429,6 +429,13 @@ def _test_is_mastercard_push_account_receipt():
         ("5555555555554444", False),
         ("Other", False),
         ("MCC-STL-471E0AD8-E233-492D-8FFE-06283CBD5018", True),
+        ("MDC-STL-471E0AD8-E233-492D-8FFE-06283CBD5018", True),
+        ("MSI-STL-471E0AD8-E233-492D-8FFE-06283CBD5018", True),
+        ("PVL-STL-471E0AD8-E233-492D-8FFE-06283CBD5018", True),
+        ("MCC-KSC-471E0AD8-E233-492D-8FFE-06283CBD5018", True),
+        ("MDC-KSC-471E0AD8-E233-492D-8FFE-06283CBD5018", True),
+        ("MSI-KSC-471E0AD8-E233-492D-8FFE-06283CBD5018", True),
+        ("PVL-KSC-471E0AD8-E233-492D-8FFE-06283CBD5018", True),
     ]:
         pan_alias = vault.redact(pan)
         asserts.assert_that(


### PR DESCRIPTION
## Fixes [PAYMTS-1960](https://verygoodsecurity.atlassian.net/browse/PAYMTS-1960)

## Description of changes in release / Impact of release:
Consider all other push account receipts helper method

## Documentation
Consider all other push account receipts helper method

## Risks of this release

### Is this a breaking change?
- [ ] Yes
- [x] No

### If you answered Yes then describe why is it so
(insert text here if applicable)

### Is there a way to disable the change?
- [ ] Use previous release
- [ ] Use a feature flag
- [ ] No

#### Additional details go here
(insert text here if applicable)


[PAYMTS-1960]: https://verygoodsecurity.atlassian.net/browse/PAYMTS-1960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ