### PR TITLE
[SECENG-329] Fixes issue for installing semgrep via pip

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -24,7 +24,7 @@ services:
       apt-get update &&
       apt-get -y install python3 &&
       apt-get -y install python3-pip &&
-      python3 -m pip install semgrep &&
+      python3 -m pip install semgrep --break-system-packages &&
       git config --global --add safe.directory $$(pwd) &&
       semgrep ci --no-suppress-errors"
     working_dir: /app


### PR DESCRIPTION
## Fixes[ [SECENG-329]](https://verygoodsecurity.atlassian.net/browse/SECENG-329)

<!-- section -->
## Description of changes in release / Impact of release:
For java code bases Semgrep is installed as a python module onto a Maven docker image. Pip has updated behavior to be in line with PEP-668 which blocks the installation of python packages and modules system wide. As this is an ephemeral docker image the risk of such an install is low and therefore this behavior will be overwritten via the --break-system-packages flag.

<!-- section -->
## Value being added to the product or risk being removed by this release
re-establishes PCI required SAST scanning

<!-- section --> 
## Who is accountable for this change except yourself?
Stu Cianos

<!-- section -->
## Risks of this release

<!-- section -->
### Is this a breaking change?
  - [ ] Yes
  - [X] No

<!-- section -->
### If you answered Yes then describe why is it so
(insert text here)

<!-- section -->
#### Additional details go here
(insert text here)

<!-- section -->
### If you answered No then please explain why it is acceptable?
(insert text here)


[SECENG-329]: https://verygoodsecurity.atlassian.net/browse/SECENG-329?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ